### PR TITLE
311/feature/fix 4 step textfield new1

### DIFF
--- a/src/containers/tutor-home-page/become-a-tutor/BecomeATutor.js
+++ b/src/containers/tutor-home-page/become-a-tutor/BecomeATutor.js
@@ -50,6 +50,7 @@ const BecomeATutor = () => {
       errors={ errors }
       handleBlur={ handleBlur }
       handleChange={ handleChange }
+      handleErrors={ handleErrors }
       key='4'
       setStepErrors={ setStepErrors }
     />,

--- a/src/containers/tutor-home-page/experience-step/ExperienceStep.js
+++ b/src/containers/tutor-home-page/experience-step/ExperienceStep.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -12,8 +12,12 @@ import { styles } from '~/containers/tutor-home-page/experience-step/experience-
 const ExperienceStep = ({ data, handleChange, handleBlur, errors, btnsBox, setStepErrors, stepLabel }) => {
   const { t } = useTranslation()
 
+  const [counterColor, setCounterColor] = useState('#263238')
+  const [focused, setFocused] = useState(false)
+
   useEffect(() => {
     setStepErrors((prevState) => ({ ...prevState, [stepLabel]: Boolean(errors.experience) }))
+    errors.experience === undefined ? setCounterColor('#263238') : setCounterColor('red')
   }, [errors, setStepErrors, stepLabel])
 
   return (
@@ -29,18 +33,22 @@ const ExperienceStep = ({ data, handleChange, handleBlur, errors, btnsBox, setSt
           </Typography>
           <AppTextField
             autoFocus
-            errorMsg={ t(errors.experience) }
+            errorMsg={ focused ? t(errors.experience) : null }
             fullWidth
             label={ t('becomeTutor.experience.textFieldLabel') }
             maxRows='17'
             minRows='6'
             multiline
-            onBlur={ handleBlur('experience') }
+            onBlur={ () => {
+              handleBlur('experience')
+              setFocused(false)
+            } }
             onChange={ handleChange('experience') }
+            onFocus={ () => setFocused(true) }
             type='text'
             value={ data.experience }
           />
-          <Typography variant='body2'>
+          <Typography color={ counterColor } style={ { float: 'right', position: 'relative', top: -20 } } variant='caption'>
             { `${data.experience.length}/1000` }
           </Typography>
         </Box>

--- a/src/containers/tutor-home-page/experience-step/ExperienceStep.js
+++ b/src/containers/tutor-home-page/experience-step/ExperienceStep.js
@@ -9,11 +9,19 @@ import AppTextField from '~/components/app-text-field/AppTextField'
 import img from '~/assets/img/tutor-home-page/become-tutor/experience.png'
 import { styles } from '~/containers/tutor-home-page/experience-step/experience-step.styles'
 
-const ExperienceStep = ({ data, handleChange, handleBlur, errors, btnsBox, setStepErrors, stepLabel }) => {
+const ExperienceStep = ({
+  data,
+  handleChange,
+  handleBlur,
+  handleErrors,
+  errors,
+  btnsBox,
+  setStepErrors,
+  stepLabel
+}) => {
   const { t } = useTranslation()
 
   const [counterColor, setCounterColor] = useState('#263238')
-  const [focused, setFocused] = useState(false)
 
   useEffect(() => {
     setStepErrors((prevState) => ({ ...prevState, [stepLabel]: Boolean(errors.experience) }))
@@ -33,18 +41,15 @@ const ExperienceStep = ({ data, handleChange, handleBlur, errors, btnsBox, setSt
           </Typography>
           <AppTextField
             autoFocus
-            errorMsg={ focused ? t(errors.experience) : null }
+            errorMsg={ t(errors.experience) }
             fullWidth
             label={ t('becomeTutor.experience.textFieldLabel') }
             maxRows='17'
             minRows='6'
             multiline
-            onBlur={ () => {
-              handleBlur('experience')
-              setFocused(false)
-            } }
+            onBlur={ () => handleErrors('experience', undefined) }
             onChange={ handleChange('experience') }
-            onFocus={ () => setFocused(true) }
+            onFocus={ handleBlur('experience') }
             type='text'
             value={ data.experience }
           />

--- a/tests/unit/containers/mentor-home-page/become-a-tutor/experience-step/ExperienceStep.spec.js
+++ b/tests/unit/containers/mentor-home-page/become-a-tutor/experience-step/ExperienceStep.spec.js
@@ -18,7 +18,7 @@ describe('Experience page test', () => {
     fireEvent.change(textField, {
       target: { value: 'New value' }
     })
-    fireEvent.blur(textField)
+    fireEvent.focus(textField)
     const shortTextError = screen.getByText(/common.errorMessages.shortText/i)
 
     expect(shortTextError).toBeInTheDocument()
@@ -29,7 +29,7 @@ describe('Experience page test', () => {
     fireEvent.change(textField, {
       target: { value: 'Some experience.'.repeat(100) }
     })
-    fireEvent.blur(textField)
+    fireEvent.focus(textField)
     const longTextError = screen.getByText(/common.errorMessages.longText/i)
 
     expect(longTextError).toBeInTheDocument()


### PR DESCRIPTION
so, now functionality of error works only when focused
number of letters also red when error, it is moved to one row, and to right side

focused:
![focused](https://user-images.githubusercontent.com/41526202/193411684-49aa01ad-e5ec-4f8e-aaef-67477c65e37b.jpg)


not focused:
![not-focused](https://user-images.githubusercontent.com/41526202/193411694-0256004c-dcfd-4e92-8666-edb2b6722f71.jpg)


when no error:
![no error](https://user-images.githubusercontent.com/41526202/193411709-89919eef-c4c4-4c37-abce-3db26cdf6b3d.jpg)
