### PR TITLE
472/Implemented offers view switcher

### DIFF
--- a/src/components/view-switcher/ViewSwitcher.jsx
+++ b/src/components/view-switcher/ViewSwitcher.jsx
@@ -5,7 +5,7 @@ import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 import GridViewIcon from '@mui/icons-material/GridView'
 
 import { cardsViews } from '~/constants'
-import { styles } from './ViewSwitcher.styles'
+import { styles } from '~/components/view-switcher/ViewSwitcher.styles'
 
 const ViewSwitcher = ({ setOffersView }) => {
   const [cardsView, setCardsView ] = useState(cardsViews.inline)
@@ -28,7 +28,8 @@ const ViewSwitcher = ({ setOffersView }) => {
       <ToggleButton
         aria-label='grid card view'
         onClick={ changeCardsView }
-        selected={ cardsView === cardsViews.grid } sx={ { ...styles.toggleButton } }
+        selected={ cardsView === cardsViews.grid }
+        sx={ styles.toggleButton }
         value={ cardsViews.grid }
       >
         <GridViewIcon sx={ styles.icon }  />

--- a/src/components/view-switcher/ViewSwitcher.jsx
+++ b/src/components/view-switcher/ViewSwitcher.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import ToggleButton from '@mui/material/ToggleButton'
 
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
@@ -7,32 +6,29 @@ import GridViewIcon from '@mui/icons-material/GridView'
 import { cardsViews } from '~/constants'
 import { styles } from '~/components/view-switcher/ViewSwitcher.styles'
 
-const ViewSwitcher = ({ setOffersView }) => {
-  const [cardsView, setCardsView ] = useState(cardsViews.inline)
+const ViewSwitcher = ({ setOffersView, offersView }) => {
 
-  const changeCardsView = (_event,view) => {
-    setOffersView(view)
-    setCardsView(view)
-  }
-
+  const changeOffersView = (_event, view) => setOffersView(view)
+  
   return (
     <>
       <ToggleButton
-        aria-label='inline card view' onClick={ changeCardsView }
-        selected={ cardsView === cardsViews.inline }
-        sx={ { ...styles.toggleButton, marginRight:'8px' } }
+        aria-label='inline card view'
+        onClick={ changeOffersView }
+        selected={ offersView === cardsViews.inline }
+        sx={ styles.inlineButton }
         value={ cardsViews.inline }
       >
         <FormatListBulletedIcon sx={ styles.icon } />
       </ToggleButton>
       <ToggleButton
         aria-label='grid card view'
-        onClick={ changeCardsView }
-        selected={ cardsView === cardsViews.grid }
-        sx={ styles.toggleButton }
+        onClick={ changeOffersView }
+        selected={ offersView === cardsViews.grid }
+        sx={ styles.gridButton }
         value={ cardsViews.grid }
       >
-        <GridViewIcon sx={ styles.icon }  />
+        <GridViewIcon sx={ styles.icon } />
       </ToggleButton>
     </>
   )

--- a/src/components/view-switcher/ViewSwitcher.jsx
+++ b/src/components/view-switcher/ViewSwitcher.jsx
@@ -1,4 +1,5 @@
 import ToggleButton from '@mui/material/ToggleButton'
+import Box from '@mui/material/Box'
 
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
 import GridViewIcon from '@mui/icons-material/GridView'
@@ -7,11 +8,10 @@ import { cardsViews } from '~/constants'
 import { styles } from '~/components/view-switcher/ViewSwitcher.styles'
 
 const ViewSwitcher = ({ setOffersView, offersView }) => {
-
   const changeOffersView = (_event, view) => setOffersView(view)
-  
+
   return (
-    <>
+    <Box>
       <ToggleButton
         aria-label='inline card view'
         onClick={ changeOffersView }
@@ -30,7 +30,7 @@ const ViewSwitcher = ({ setOffersView, offersView }) => {
       >
         <GridViewIcon sx={ styles.icon } />
       </ToggleButton>
-    </>
+    </Box>
   )
 }
 

--- a/src/components/view-switcher/ViewSwitcher.jsx
+++ b/src/components/view-switcher/ViewSwitcher.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import ToggleButton from '@mui/material/ToggleButton'
+
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
+import GridViewIcon from '@mui/icons-material/GridView'
+
+import { cardsViews } from '~/constants'
+import { styles } from './ViewSwitcher.styles'
+
+const ViewSwitcher = ({ setOffersView }) => {
+  const [cardsView, setCardsView ] = useState(cardsViews.inline)
+
+  const changeCardsView = (_event,view) => {
+    setOffersView(view)
+    setCardsView(view)
+  }
+
+  return (
+    <>
+      <ToggleButton
+        aria-label='inline card view' onClick={ changeCardsView }
+        selected={ cardsView === cardsViews.inline }
+        sx={ { ...styles.toggleButton, marginRight:'8px' } }
+        value={ cardsViews.inline }
+      >
+        <FormatListBulletedIcon sx={ styles.icon } />
+      </ToggleButton>
+      <ToggleButton
+        aria-label='grid card view'
+        onClick={ changeCardsView }
+        selected={ cardsView === cardsViews.grid } sx={ { ...styles.toggleButton } }
+        value={ cardsViews.grid }
+      >
+        <GridViewIcon sx={ styles.icon }  />
+      </ToggleButton>
+    </>
+  )
+}
+
+export default ViewSwitcher

--- a/src/components/view-switcher/ViewSwitcher.styles.js
+++ b/src/components/view-switcher/ViewSwitcher.styles.js
@@ -1,14 +1,16 @@
 export const styles = {
   icon: {
     fontSize: '24px',
-    color: 'primary.900',
+    color: 'primary.900'
   },
-  toggleButton:{
-    borderColor:'primary.200',
-    '&.Mui-selected':{
-      borderColor:'primary.900',
-      transition:'.16s ease',
-      backgroundColor:'transparent'
+  toggleButton: {
+    borderColor: 'primary.200',
+    '&.Mui-selected': {
+      borderColor: 'primary.900',
+      transition: '.16s ease',
+      backgroundColor: 'transparent'
     }
-  }
+  },
+  gridButton: this.toggleButton,
+  inlineButton: { ...this.toggleButton, marginRight: '8px' }
 }

--- a/src/components/view-switcher/ViewSwitcher.styles.js
+++ b/src/components/view-switcher/ViewSwitcher.styles.js
@@ -7,7 +7,8 @@ export const styles = {
     borderColor:'primary.200',
     '&.Mui-selected':{
       borderColor:'primary.900',
-      transition:'.16s ease'
+      transition:'.16s ease',
+      backgroundColor:'transparent'
     }
   }
 }

--- a/src/components/view-switcher/ViewSwitcher.styles.js
+++ b/src/components/view-switcher/ViewSwitcher.styles.js
@@ -1,16 +1,16 @@
+const toggleButtonStyle = {
+  borderColor: 'primary.200',
+  '&.Mui-selected': {
+    borderColor: 'primary.900',
+    transition: '.16s ease',
+    backgroundColor: 'transparent'
+  }
+}
 export const styles = {
   icon: {
     fontSize: '24px',
     color: 'primary.900'
   },
-  toggleButton: {
-    borderColor: 'primary.200',
-    '&.Mui-selected': {
-      borderColor: 'primary.900',
-      transition: '.16s ease',
-      backgroundColor: 'transparent'
-    }
-  },
-  gridButton: this.toggleButton,
-  inlineButton: { ...this.toggleButton, marginRight: '8px' }
+  gridButton: toggleButtonStyle,
+  inlineButton: { ...toggleButtonStyle, marginRight: '8px' }
 }

--- a/src/components/view-switcher/ViewSwitcher.styles.js
+++ b/src/components/view-switcher/ViewSwitcher.styles.js
@@ -1,0 +1,13 @@
+export const styles = {
+  icon: {
+    fontSize: '24px',
+    color: 'primary.900',
+  },
+  toggleButton:{
+    borderColor:'primary.200',
+    '&.Mui-selected':{
+      borderColor:'primary.900',
+      transition:'.16s ease'
+    }
+  }
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -16,4 +16,9 @@ export const snackbarVariants = {
   warning: 'warning'
 }
 
+export const cardsViews = {
+  inline:'inline',
+  grid:'grid'
+}
+
 export const myProfilePath = '/tutor/myProfile' || '/student/myProfile'

--- a/src/stories/ViewSwitcher.stories.jsx
+++ b/src/stories/ViewSwitcher.stories.jsx
@@ -1,0 +1,20 @@
+import ViewSwitcher from '~/components/view-switcher/ViewSwitcher'
+
+export default {
+  title: 'ViewSwitcher',
+  component: ViewSwitcher,
+  argTypes: {
+    setOffersView:{
+      type:'function',
+      description:'change offers card view'
+    }
+  }
+}
+
+const Template = (args) => <ViewSwitcher { ...args } />
+
+export const Default = Template.bind({})
+
+Default.args = {
+  setOffersView: (view) => console.log('Updated view: ',view)
+}

--- a/src/stories/ViewSwitcher.stories.jsx
+++ b/src/stories/ViewSwitcher.stories.jsx
@@ -21,5 +21,6 @@ const Template = (args) => <ViewSwitcher { ...args } />
 export const Default = Template.bind({})
 
 Default.args = {
-  setOffersView: (view) => console.log('Updated view: ',view)
+  setOffersView: (view) => console.log('Updated view: ',view),
+  offersView:'inline'
 }

--- a/src/stories/ViewSwitcher.stories.jsx
+++ b/src/stories/ViewSwitcher.stories.jsx
@@ -7,6 +7,11 @@ export default {
     setOffersView:{
       type:'function',
       description:'change offers card view'
+    },
+    offersView:{
+      options: ['inline', 'grid'],
+      control: { type: 'radio' },
+      description:'offers view state'
     }
   }
 }

--- a/tests/unit/components/view-switcher/ViewSwitcher.spec.jsx
+++ b/tests/unit/components/view-switcher/ViewSwitcher.spec.jsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import ViewSwitcher from '~/components/view-switcher/ViewSwitcher'
+import { cardsViews } from '~/constants'
+
+const mockedSetOffersView = vi.fn()
+
+describe('ViewSwitcher component', () => {
+  beforeEach(() => render(<ViewSwitcher setOffersView={ mockedSetOffersView } />))
+  it('should change view to inline on click', () => {
+    const mockedInlineViewButton = screen.getByLabelText('inline card view')
+    fireEvent.click(mockedInlineViewButton)
+    expect(mockedSetOffersView).toHaveBeenCalledWith(cardsViews.inline)
+  })
+  it('should change view to grid on click', () => {
+    const mockedInlineViewButton = screen.getByLabelText('grid card view')
+    fireEvent.click(mockedInlineViewButton)
+    expect(mockedSetOffersView).toHaveBeenCalledWith(cardsViews.grid)
+  })
+})

--- a/tests/unit/components/view-switcher/ViewSwitcher.spec.jsx
+++ b/tests/unit/components/view-switcher/ViewSwitcher.spec.jsx
@@ -7,13 +7,14 @@ import { cardsViews } from '~/constants'
 const mockedSetOffersView = vi.fn()
 
 describe('ViewSwitcher component', () => {
-  beforeEach(() => render(<ViewSwitcher setOffersView={ mockedSetOffersView } />))
   it('should change view to inline on click', () => {
+    render(<ViewSwitcher offersView={ cardsViews.inline } setOffersView={ mockedSetOffersView } />)
     const mockedInlineViewButton = screen.getByLabelText('inline card view')
     fireEvent.click(mockedInlineViewButton)
     expect(mockedSetOffersView).toHaveBeenCalledWith(cardsViews.inline)
   })
   it('should change view to grid on click', () => {
+    render(<ViewSwitcher offersView={ cardsViews.grid } setOffersView={ mockedSetOffersView } />)
     const mockedInlineViewButton = screen.getByLabelText('grid card view')
     fireEvent.click(mockedInlineViewButton)
     expect(mockedSetOffersView).toHaveBeenCalledWith(cardsViews.grid)


### PR DESCRIPTION
Implement a switcher that can change view of offers (horizontal and square versions):

[FIGMA](https://www.figma.com/file/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=3193%3A59961&t=RQ8FuzVvyCQM7MdM-1)
![image](https://user-images.githubusercontent.com/90138904/222640820-197f9329-00be-4e35-b679-191be10c0f62.png)
hovered
![Screenshot from 2023-03-03 07-42-56](https://user-images.githubusercontent.com/90138904/222640987-f664d6be-6a97-4717-9c7f-096b24f9613c.png)