### PR TITLE
Refactored styles

### DIFF
--- a/src/components/step-wrapper/StepWrapper.jsx
+++ b/src/components/step-wrapper/StepWrapper.jsx
@@ -30,7 +30,7 @@ const StepWrapper = ({ children, steps }) => {
 
   const nextButton = isLastStep ? (
     <Button
-      onClick={ handleSubmit } size='small' sx={ styles.btn }
+      onClick={ handleSubmit } size='small' sx={ styles.finishBtn }
       variant='contained'
     >
       { t('common.finish') }

--- a/src/components/step-wrapper/StepWrapper.styles.js
+++ b/src/components/step-wrapper/StepWrapper.styles.js
@@ -52,6 +52,6 @@ export const styles = {
   btn: btnStyle,
   finishBtn:{
     ...btnStyle,
-    width:'96px'
+    minWidth:'96px'
   }
 }

--- a/src/components/step-wrapper/StepWrapper.styles.js
+++ b/src/components/step-wrapper/StepWrapper.styles.js
@@ -1,5 +1,11 @@
 import { fadeAnimation } from '~/styles/app-theme/custom-animations'
 
+const btnStyle =  {
+  padding:'10px 20px',
+  display:'flex',
+  columnGap:1
+}
+
 export const styles = {
   root: {
     display: { xs: 'flex' },
@@ -43,9 +49,9 @@ export const styles = {
     justifyContent: 'space-between',
     mt: '10px'
   },
-  btn: {
-    padding: '10px 20px',
-    display: 'flex',
-    columnGap: 1
+  btn: btnStyle,
+  finishBtn:{
+    ...btnStyle,
+    width:'96px'
   }
 }

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
@@ -44,7 +44,8 @@ export const style = {
     justifyContent: 'space-between',
     maxWidth: '432px',
     m: { md: 0, xs: '0 auto' },
-    pt: 0
+    pt: 0,
+    pb:{ xs:'30px', sm:'0' }
   },
   description: {
     mb: '20px'

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
@@ -6,6 +6,7 @@ export const style = {
     justifyContent: 'space-between',
     gap: '40px',
     height: { sm: '485px' },
+    paddingBottom:{ sm:'210px', md:'0px' },
     ...fadeAnimation
   },
   img: {

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles.js
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles.js
@@ -5,6 +5,7 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-around',
     height: { sm: '485px' },
+    paddingBottom:{ xs:'30px',sm:'0' },
     ...fadeAnimation
   },
   imgContainer: {

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -68,7 +68,7 @@ const SubjectsStep = ({ stepLabel, btnsBox }) => {
     <Box sx={ styles.container }>
       { isDesktop && imageBlock }
       <Box sx={ styles.rigthBox }>
-        <Box>
+        <Box sx={ styles.contentBox } >
           <Typography mb='20px'>
             { t('becomeTutor.categories.title') }
           </Typography>
@@ -103,7 +103,9 @@ const SubjectsStep = ({ stepLabel, btnsBox }) => {
           <FormHelperText data-testid='error-subject' error={ !!subjectError } sx={ { textAlign: 'center' } }>
             { subjectError || ' ' }
           </FormHelperText>
-          <AppChipList defaultQuantity={ 2 } handleChipDelete={ handleChipDelete } items={ listOfItems } />
+          <AppChipList
+            defaultQuantity={ 2 } handleChipDelete={ handleChipDelete } items={ listOfItems }
+          />
         </Box>
         { btnsBox }
       </Box>

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -6,6 +6,7 @@ export const styles = {
     justifyContent: 'space-between',
     gap: '40px',
     height: { sm: '485px' },
+    paddingBottom:{ xs:'30px', sm:'0px' },
     ...fadeAnimation
   },
   imgContainer: {

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.styles.js
@@ -27,5 +27,6 @@ export const styles = {
     justifyContent: 'space-between',
     m: { md: 0, xs: '0 auto' },
     pt: 0
-  }
+  },
+  contentBox: { mb:{ xs:'30px', sm:'0' } }
 }


### PR DESCRIPTION
Refactor style on Mentor's stepper:

 1. Change space after buttons on 1,2,4 steps [General, Subjects, Photo] on mobile version (Do as on [Language] step).
 2. Change space after buttons on 4 step [Photo] on tablet version.
 3. Change size of button 'finish' (as buttons 'next->').

|         Original          |         Updated          | 
| :-----------------------: | :----------------------: | 
|**![was-first-step](https://user-images.githubusercontent.com/90138904/224650157-6e08413f-c77b-4933-86e9-c58c4bb21e4c.png)**|**![updated-first](https://user-images.githubusercontent.com/90138904/225364117-1c10702d-5bd5-4e17-b314-63f5223d37ba.png)**| 
|**![1-second-step-before](https://user-images.githubusercontent.com/90138904/224650318-e9e58d84-963f-4c16-b3e1-e944a04001cc.png)**|**![updated-second](https://user-images.githubusercontent.com/90138904/225364474-ba022449-e1d1-4d95-8535-0c4111824e85.png)**| 
|**![1-forth-step-before](https://user-images.githubusercontent.com/90138904/224650437-dd5489ac-c4aa-496b-907f-ac833470733d.png)**|**![1-forth-step-after](https://user-images.githubusercontent.com/90138904/224650465-54240f21-8d86-4998-9f76-a523b3107907.png)**| 
|**![2-before-forth-step](https://user-images.githubusercontent.com/90138904/224650699-6cb84d9f-3fa4-4825-aabe-f0f09373e01e.png)**|**![2-after-forth-step](https://user-images.githubusercontent.com/90138904/224650726-3b203d5e-987e-4d0e-89ec-f69e0fce9bf2.png)**| 