### PR TITLE
Bug fix/690/confirm password field

### DIFF
--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -13,6 +13,7 @@ import { guestRoutes } from '~/router/constants/guestRoutes'
 import AppButton from '~/components/app-button/AppButton'
 
 import { styles } from '~/containers/guest-home-page/signup-form/SignupForm.styles'
+import { confirmPassword } from "~/utils/validations/login";
 
 const SignupForm = ({
   handleSubmit,
@@ -127,7 +128,7 @@ const SignupForm = ({
 
       <AppTextField
         InputProps={confirmPasswordVisibility}
-        errorMsg={t(errors.confirmPassword)}
+        errorMsg={data.confirmPassword && t(errors.confirmPassword)}
         fullWidth
         label={t('common.labels.confirmPassword')}
         onBlur={handleBlur('confirmPassword')}

--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -128,7 +128,7 @@ const SignupForm = ({
 
       <AppTextField
         InputProps={confirmPasswordVisibility}
-        errorMsg={data.confirmPassword && t(errors.confirmPassword)}
+        errorMsg={t(errors.confirmPassword)}
         fullWidth
         label={t('common.labels.confirmPassword')}
         onBlur={handleBlur('confirmPassword')}

--- a/src/utils/validations/login.js
+++ b/src/utils/validations/login.js
@@ -19,6 +19,6 @@ export const lastName = (value) => {
 export const confirmPassword = (password, data) => {
   return emptyField(
     password,
-    password !== data.password ? 'common.errorMessages.passwordsDontMatch' : ''
+    password !== data.password ? 'common.errorMessages.emptyField' : ''
   )
 }


### PR DESCRIPTION
We needed to change error message of confirm password when it's empty
From:
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/89192246/aa2c9e28-71ff-4555-9fc7-8aee6685fba9)
To:
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/89192246/f7412874-8212-4d50-926b-c09f26ed4118)

Changes:
in src/utils/validations/login.js
From: 
   password !== data.password ? 'common.errorMessages.passwordsDontMatch' : ''
To:
   password !== data.password ? 'common.errorMessages.emptyField' : ''