### PR TITLE
Fixex amount of items for categories and subjects page. And added error handle for stepper.

### DIFF
--- a/src/hooks/use-load-more.tsx
+++ b/src/hooks/use-load-more.tsx
@@ -25,11 +25,16 @@ const useLoadMore = <Response, Params>({
 }: UseLoadMoreProps<Response, Params>): UseLoadMoreReturn<Response> => {
   const [skip, setSkip] = useState<number>(0)
   const [data, setData] = useState<Response[] | []>([])
-  const [previousLimit, setPreviousLimit] = useState<number>(0)
+  const [previousLimit, setPreviousLimit] = useState<number>(limit)
 
   const loadMore = useCallback(
     () => setSkip((prevState) => prevState + limit),
     [limit]
+  )
+
+  const handleResponse = useCallback(
+    (data: Response[]) => setData((prevState) => [...prevState, ...data]),
+    []
   )
 
   const resetData = useCallback(() => {
@@ -40,26 +45,22 @@ const useLoadMore = <Response, Params>({
   const { response, loading, fetchData } = useAxios<Response[], Params>({
     service,
     defaultResponse: defaultResponses.array,
-    fetchOnMount: false
+    fetchOnMount: false,
+    onResponse: handleResponse
   })
 
   useEffect(() => {
-    if (previousLimit !== limit) {
+    if (previousLimit === limit) {
+      void fetchData({ ...params, limit, skip } as Params)
+    } else {
       resetData()
       setPreviousLimit(limit)
-      return
     }
-
-    void fetchData({ ...params, limit, skip } as Params)
   }, [fetchData, limit, previousLimit, resetData, skip, params])
 
-  useEffect(() => {
-    response.length && setData((prevState) => [...prevState, ...response])
-  }, [response])
-
   const isExpandable = useMemo(
-    () => limit <= response.length,
-    [limit, response]
+    () => data.length > 0 && limit <= response.length,
+    [limit, data, response]
   )
 
   return {

--- a/src/hooks/use-load-more.tsx
+++ b/src/hooks/use-load-more.tsx
@@ -25,6 +25,7 @@ const useLoadMore = <Response, Params>({
 }: UseLoadMoreProps<Response, Params>): UseLoadMoreReturn<Response> => {
   const [skip, setSkip] = useState<number>(0)
   const [data, setData] = useState<Response[] | []>([])
+  const [previousLimit, setPreviousLimit] = useState<number>(0)
 
   const loadMore = useCallback(
     () => setSkip((prevState) => prevState + limit),
@@ -43,8 +44,14 @@ const useLoadMore = <Response, Params>({
   })
 
   useEffect(() => {
+    if (previousLimit !== limit) {
+      resetData()
+      setPreviousLimit(limit)
+      return
+    }
+
     void fetchData({ ...params, limit, skip } as Params)
-  }, [fetchData, limit, skip, params])
+  }, [fetchData, limit, previousLimit, resetData, skip, params])
 
   useEffect(() => {
     response.length && setData((prevState) => [...prevState, ...response])

--- a/src/hooks/use-steps.jsx
+++ b/src/hooks/use-steps.jsx
@@ -21,6 +21,13 @@ const useSteps = ({ steps }) => {
     [userId]
   )
 
+  const handleResponseError = (error) => {
+    setAlert({
+      severity: snackbarVariants.error,
+      message: error ? `errors.${error.code}` : ''
+    })
+  }
+
   const handleResponse = () => {
     setAlert({
       severity: snackbarVariants.success,
@@ -33,7 +40,8 @@ const useSteps = ({ steps }) => {
     service: updateUser,
     fetchOnMount: false,
     defaultResponse: null,
-    onResponse: handleResponse
+    onResponse: handleResponse,
+    onResponseError: handleResponseError
   })
 
   const stepErrors = Object.values(stepData).map(


### PR DESCRIPTION
When the width screen changes we receive additional cards.
Now it is fixed.
Attached screens as it was before.
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/83120263/50b6dc3d-3878-41f1-8603-5e80983b70da)
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/83120263/92234d7c-070c-4a7b-8f13-50dfd7edba0b)
