### PR TITLE
Fixed title text “Share your experience” is shown in two lines in the tutor registration block.

### DIFF
--- a/src/components/info-card/InfoCard.styles.js
+++ b/src/components/info-card/InfoCard.styles.js
@@ -28,6 +28,7 @@ export const styles = {
     },
     title: {
       typography: { md: 'h4', xs: 'h5' },
+      letterSpacing: '0',
       marginBottom: '16px'
     },
     description: {

--- a/src/components/info-card/InfoCard.styles.js
+++ b/src/components/info-card/InfoCard.styles.js
@@ -27,8 +27,7 @@ export const styles = {
       margin: '0 auto 32px'
     },
     title: {
-      typography: { md: 'h4', xs: 'h5' },
-      letterSpacing: '0',
+      typography: 'h5',
       marginBottom: '16px'
     },
     description: {


### PR DESCRIPTION
I'm not sure if i am even allowed to change any project styles, but i had 3 different options to resolve this problem:

1. Redusing title font-size
2. Redusing padding of InfoCards
3. Removing letter-spacing from title

So, i picked most neutral option and just removed letter-spacing from titles in InfoCards.

Before:
![зображення](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/45912519/834b210a-e11b-4ffc-9986-cc18abd95b79)

After:
![зображення](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/45912519/cf4c5977-c1da-4248-90a1-ea1b7bfbdf88)

