### PR TITLE
The “What can you do” button is not highlighted after clicking it, fixed.

### DIFF
--- a/src/containers/layout/navbar/NavBar.styles.js
+++ b/src/containers/layout/navbar/NavBar.styles.js
@@ -17,8 +17,11 @@ export const styles = {
   navItemText: {
     color: 'primary.900',
     textDecoration: 'none',
-    '&:focus': {
+    '&:hover': {
       color: 'primary.500'
+    },
+    '&:focus': {
+      textDecoration: 'underline'
     }
   },
   navItem: {

--- a/src/containers/layout/navbar/NavBar.styles.js
+++ b/src/containers/layout/navbar/NavBar.styles.js
@@ -16,7 +16,10 @@ export const styles = {
   },
   navItemText: {
     color: 'primary.900',
-    textDecoration: 'none'
+    textDecoration: 'none',
+    '&:focus': {
+      color: 'primary.500'
+    }
   },
   navItem: {
     '&:last-child': {


### PR DESCRIPTION
I added a `:focus` pseudo-class to solve this problem. NavItem is highlighted on click now but if we click another item on the page then the highlight is removed from the item. I am not sure is this supposed element behavior.

Result:

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/45912519/c43c37fd-f103-4550-828b-7bd55cef0e5c

