### PR TITLE
fixed bug with input

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
     }
   },
   rules: {
+    'prettier/prettier': 0,
     'prefer-arrow-callback': ['error'],
     'react/jsx-boolean-value': 'error',
     'react/jsx-closing-bracket-location': 'error',

--- a/src/utils/validations/common.ts
+++ b/src/utils/validations/common.ts
@@ -10,7 +10,7 @@ const validations: Validations = {
     if (value.length > 30) {
       return 'common.errorMessages.nameLength'
     }
-    if (!RegExp(/^[a-zа-яєії]+$/i).test(value)) {
+    if (!RegExp(/^[a-zа-яєії ]+$/i).test(value)) {
       return 'common.errorMessages.nameAlphabeticOnly'
     }
     return ''


### PR DESCRIPTION
[Tutor "Sign Up" pop-up] the error message is shown, when the 'First name' field data contains space between two words #688


Simply added the space to regex exeptions.
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/96788072/f21e2ff7-64eb-4d64-bf71-783f8f9ed62b)
