### PR TITLE
fixed bugs with input

### DIFF
--- a/src/utils/validations/common.ts
+++ b/src/utils/validations/common.ts
@@ -10,7 +10,7 @@ const validations: Validations = {
     if (value.length > 30) {
       return 'common.errorMessages.nameLength'
     }
-    if (!RegExp(/^[a-zа-яєії]+$/i).test(value)) {
+    if (!RegExp(/^[a-zа-яєії ]+$/i).test(value)) {
       return 'common.errorMessages.nameAlphabeticOnly'
     }
     return ''


### PR DESCRIPTION
simply added space to regex

[Tutor "Sign Up" pop-up] the error message is shown, when the 'First name' field data contains space between two words #688

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/96788072/5f4158bc-3f6a-4cfd-adad-9f095bcd6a28)

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/96788072/1e96330e-fea3-4383-8ce6-7fdd36ce397c)
