### PR TITLE
fixed btn flashing

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -43,6 +43,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
     <Dialog
       PaperProps={paperProps}
       data-testid='popup'
+      disableRestoreFocus
       fullScreen={isMobile}
       maxWidth='xl'
       onClose={handleClose}


### PR DESCRIPTION
After we were closing pop up dialog with ESC, button was flashing, now it's not.

![ezgif-3-424e78ef816](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/89192246/576d9ec4-d645-4f0f-8cdc-17d2e3ef4b94)

