### PR TITLE
disable closing window outside popup

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -45,6 +45,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
       data-testid='popup'
       fullScreen={isMobile}
       maxWidth='xl'
+      onClick={(e) => e.stopPropagation()}
       onClose={handleClose}
       open
     >


### PR DESCRIPTION
We needed to prevent window closing when we click outside our modal window. Now it's fixed