### PR TITLE
The item descriptions are bold in the home page “How it works” block fixed

### DIFF
--- a/src/containers/guest-home-page/cards-with-button/CardsWithButton.styles.js
+++ b/src/containers/guest-home-page/cards-with-button/CardsWithButton.styles.js
@@ -48,7 +48,10 @@ export const styles = {
     },
     description: {
       textAlign: { sm: 'end', xs: 'start' },
-      typography: { xs: 'subtitle2' }
+      fontWeight: 400,
+      fontSize: '14px',
+      lineHeight: '20px',
+      letterSpacing: '0.1px'
     },
     slidesIn: slidesRightAnimation
   },
@@ -74,7 +77,10 @@ export const styles = {
     },
     description: {
       textAlign: 'start',
-      typography: { xs: 'subtitle2' }
+      fontWeight: 400,
+      fontSize: '14px',
+      lineHeight: '20px',
+      letterSpacing: '0.1px'
     },
     slidesIn: slidesLeftAnimation
   }

--- a/src/containers/guest-home-page/cards-with-button/CardsWithButton.styles.js
+++ b/src/containers/guest-home-page/cards-with-button/CardsWithButton.styles.js
@@ -48,10 +48,7 @@ export const styles = {
     },
     description: {
       textAlign: { sm: 'end', xs: 'start' },
-      fontWeight: 400,
-      fontSize: '14px',
-      lineHeight: '20px',
-      letterSpacing: '0.1px'
+      typography: 'body2'
     },
     slidesIn: slidesRightAnimation
   },
@@ -77,10 +74,7 @@ export const styles = {
     },
     description: {
       textAlign: 'start',
-      fontWeight: 400,
-      fontSize: '14px',
-      lineHeight: '20px',
-      letterSpacing: '0.1px'
+      typography: 'body2'
     },
     slidesIn: slidesLeftAnimation
   }


### PR DESCRIPTION
Issue with bold description resolved. I prefer to overwrite default styles of 'subtitle2' with changes in font-weight instead of just writing font-weight: '400 !important'.

Result:

![зображення](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/45912519/7f404859-83ab-4a2d-8a7b-e5a6a2ac67c5)
