### PR TITLE
[Home page] The slash separator between home page buttons is not corresponded to the mockup

### DIFF
--- a/src/containers/layout/navbar/NavBar.styles.js
+++ b/src/containers/layout/navbar/NavBar.styles.js
@@ -27,8 +27,7 @@ export const styles = {
     width: 'auto',
     '&::after': {
       content: '"/"',
-      lineHeight: '24px',
-      fontFamily: 'Poppins,-apple-system,Arial,sans-serif',
+      fontFamily: 'Poppins',
       padding: { md: '0 0 0 8px', lg: '0 0 0 20px' }
     },
     '&:last-child::after': {

--- a/src/containers/layout/navbar/NavBar.styles.js
+++ b/src/containers/layout/navbar/NavBar.styles.js
@@ -27,7 +27,8 @@ export const styles = {
     width: 'auto',
     '&::after': {
       content: '"/"',
-      fontFamily: 'Poppins',
+      fontWeight: 500,
+      fontFamily: 'Rubik',
       padding: { md: '0 0 0 8px', lg: '0 0 0 20px' }
     },
     '&:last-child::after': {

--- a/src/containers/layout/navbar/NavBar.styles.js
+++ b/src/containers/layout/navbar/NavBar.styles.js
@@ -24,7 +24,6 @@ export const styles = {
     },
     pl: '0',
     pr: { md: '8px', lg: '20px' },
-    position: 'relative',
     width: 'auto',
     '&::after': {
       content: '"/"',

--- a/src/containers/layout/navbar/NavBar.styles.js
+++ b/src/containers/layout/navbar/NavBar.styles.js
@@ -24,10 +24,13 @@ export const styles = {
     },
     pl: '0',
     pr: { md: '8px', lg: '20px' },
+    position: 'relative',
     width: 'auto',
     '&::after': {
       content: '"/"',
-      padding: { md: '0 0 3px 8px', lg: '0 0 3px 20px' }
+      lineHeight: '24px',
+      fontFamily: 'Poppins,-apple-system,Arial,sans-serif',
+      padding: { md: '0 0 0 8px', lg: '0 0 0 20px' }
     },
     '&:last-child::after': {
       content: '""'

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;800;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
 :root {
   --scrollbar-border-radius: 10px;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,4 @@
 @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@300;400;500;600;800;900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 
 :root {
   --scrollbar-border-radius: 10px;


### PR DESCRIPTION
From:
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/89192246/30b0b1eb-1e6a-47a4-9d35-fafaa00e676d)
To:
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/89192246/8c9b7507-2ac6-4c55-95f6-314a01215992)
