### PR TITLE
Changed description on home page welcoming block

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -1,6 +1,6 @@
 {
   "welcomeBlock": {
-    "description": "An educational platform that offers professional courses in It is a long established fact that a reader will be distracted by the readable content of",
+    "description": "An educational platform that offers professional courses, empowering students with essential skills for career success.",
     "getStarted": "Get started for free"
   },
   "accordion": {


### PR DESCRIPTION
Fixed description text on the home page welcoming block

**Before**:

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/108689551/6d8e1ec3-7a45-4cd3-b278-a3dd533a1518)

**After**:

<img width="1429" alt="image" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/108689551/d3af22ab-bbc1-4a2f-960f-51fb6357dc42">


Fixes #1177 