### PR TITLE
Unit tests for AdminPortal container

### DIFF
--- a/tests/unit/containers/admin-portal/AdminPortal.spec.jsx
+++ b/tests/unit/containers/admin-portal/AdminPortal.spec.jsx
@@ -1,0 +1,54 @@
+import { configureStore } from '@reduxjs/toolkit'
+import reducer from '~/redux/reducer'
+import {
+  createMemoryRouter,
+  createRoutesFromElements,
+  RouterProvider
+} from 'react-router-dom'
+import { routerConfig } from '~/router/router'
+import { render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { ThemeProvider } from '@mui/material/styles'
+import { theme } from '~/styles/app-theme/custom-mui.styles'
+import { beforeEach, expect } from 'vitest'
+
+const renderWithRouter = (initialEntries, preloadedState) => {
+  const store = configureStore({
+    reducer: { appMain: reducer },
+    preloadedState
+  })
+  const router = createMemoryRouter(createRoutesFromElements(routerConfig), {
+    initialEntries: [initialEntries]
+  })
+
+  render(
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <RouterProvider router={router} />
+      </ThemeProvider>
+    </Provider>
+  )
+}
+
+describe('Admin Portal tests', () => {
+  beforeEach(() => {
+    const preloadState = { appMain: { userRole: 'admin' } }
+    const path = '/admin'
+    renderWithRouter(path, preloadState)
+  })
+
+  it('should render loader', () => {
+    const loader = screen.getByTestId('loader')
+    expect(loader).toBeInTheDocument()
+  })
+
+  it('should have admin nav bar', () => {
+    const adminNavBar = screen.getByTestId('AdminNavBar')
+    expect(adminNavBar).toBeInTheDocument()
+  })
+
+  it('should render admin home data as default', async () => {
+    const adminPagePlaceholder = await screen.findByText('Hello Admin!')
+    await waitFor(() => expect(adminPagePlaceholder).toBeInTheDocument())
+  })
+})

--- a/tests/unit/containers/admin-portal/AdminPortal.spec.jsx
+++ b/tests/unit/containers/admin-portal/AdminPortal.spec.jsx
@@ -6,13 +6,15 @@ import {
   RouterProvider
 } from 'react-router-dom'
 import { routerConfig } from '~/router/router'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import { ThemeProvider } from '@mui/material/styles'
 import { theme } from '~/styles/app-theme/custom-mui.styles'
 import { beforeEach, expect } from 'vitest'
 
-const renderWithRouter = (initialEntries, preloadedState) => {
+import AdminPortal from '~/containers/layout/admin-portal/AdminPortal'
+
+const renderAdminPortalRouter = (initialEntries, preloadedState) => {
   const store = configureStore({
     reducer: { appMain: reducer },
     preloadedState
@@ -24,7 +26,9 @@ const renderWithRouter = (initialEntries, preloadedState) => {
   render(
     <Provider store={store}>
       <ThemeProvider theme={theme}>
-        <RouterProvider router={router} />
+        <RouterProvider router={router}>
+          <AdminPortal />
+        </RouterProvider>
       </ThemeProvider>
     </Provider>
   )
@@ -32,9 +36,9 @@ const renderWithRouter = (initialEntries, preloadedState) => {
 
 describe('Admin Portal tests', () => {
   beforeEach(() => {
-    const preloadState = { appMain: { userRole: 'admin' } }
+    const preloadedState = { appMain: { userRole: 'admin' } }
     const path = '/admin'
-    renderWithRouter(path, preloadState)
+    renderAdminPortalRouter(path, preloadedState)
   })
 
   it('should render loader', () => {
@@ -45,10 +49,5 @@ describe('Admin Portal tests', () => {
   it('should have admin nav bar', () => {
     const adminNavBar = screen.getByTestId('AdminNavBar')
     expect(adminNavBar).toBeInTheDocument()
-  })
-
-  it('should render admin home data as default', async () => {
-    const adminPagePlaceholder = await screen.findByText('Hello Admin!')
-    await waitFor(() => expect(adminPagePlaceholder).toBeInTheDocument())
   })
 })


### PR DESCRIPTION
Created tests for AdminPortal container

1) Before 
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/17857767/4e377c67-2bd1-4d4b-a6bb-c5a852689ba4)

2) After
<img width="900" alt="Знімок екрана 2023-10-05 о 10 57 45" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/17857767/6817d0e9-a0a4-45ca-b1f4-f938c5eadb95">

<img width="787" alt="image" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/17857767/8f7e7406-9693-4526-84cd-13c6f3cd577c">


Closed #1190 