### PR TITLE
Changed behaviour for emoji picker

### DIFF
--- a/src/containers/chat/chat-text-area/ChatTextArea.tsx
+++ b/src/containers/chat/chat-text-area/ChatTextArea.tsx
@@ -4,7 +4,8 @@ import {
   useState,
   useRef,
   Dispatch,
-  SetStateAction
+  SetStateAction,
+  MouseEvent
 } from 'react'
 import Picker from '@emoji-mart/react'
 import data from '@emoji-mart/data'
@@ -70,12 +71,16 @@ const ChatTextArea: FC<ChatTextAreaProps> = ({
     }
   }
 
-  const onOpenPicker = () => setIsEmojiPickerOpen(true)
+  const onTogglePicker = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    setIsEmojiPickerOpen((prevState) => !prevState)
+  }
+
   const onClosePicker = () => setIsEmojiPickerOpen(false)
 
   const endAdornment = (
     <>
-      <IconButton onMouseEnter={onOpenPicker}>
+      <IconButton onClick={onTogglePicker}>
         <MoodIcon />
       </IconButton>
       <IconButton disabled>

--- a/tests/unit/pages/chat/chat-text-area/ChatTextArea.spec.jsx
+++ b/tests/unit/pages/chat/chat-text-area/ChatTextArea.spec.jsx
@@ -59,10 +59,10 @@ describe('ChatTextArea component test', () => {
     expect(emojiIcon).toBeInTheDocument()
   })
 
-  it('should open emoji picker', async () => {
+  it('should toggle emoji picker', async () => {
     const emojiIcon = screen.getByTestId('MoodIcon')
 
-    fireEvent.mouseEnter(emojiIcon)
+    fireEvent.click(emojiIcon)
 
     const picker = screen.getByTestId('emoji-picker')
 


### PR DESCRIPTION
Changed behaviour for emoji picker
Implemented with stopping the click event from propagating to the Picker component using e.stopPropagation()

**Before:**

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/56305508/5d36010d-4454-444f-b526-b58806a66f7c

**Actual result:**

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/56305508/20c2237e-50d5-415e-94e8-9fedf496bf34

Fixed issue: #1260 