### PR TITLE
Fixed overlapped email input field on the forgot password form

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.jsx
@@ -94,7 +94,7 @@ const ForgotPassword = () => {
           onChange={handleInputChange('email')}
           required
           size='large'
-          sx={{ mb: '5px' }}
+          sx={{ mb: '16px', mt: '32px' }}
           type='email'
           value={data.email}
         />

--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
@@ -25,8 +25,7 @@ export const styles = {
       mb: '16px'
     },
     description: {
-      typography: 'body2',
-      mb: '32px'
+      typography: 'body2'
     }
   }
 }


### PR DESCRIPTION
Before: 
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/121502737/ea143daa-edd7-44c7-9e19-28f1934f00e6)

After:
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/121502737/fe196ff5-65b7-4747-9280-29381a7ec59d)

Fixed issue: #1036