### PR TITLE
Implemented buttons for new page route

### DIFF
--- a/src/pages/create-course/CreateCourse.styles.ts
+++ b/src/pages/create-course/CreateCourse.styles.ts
@@ -1,0 +1,8 @@
+export const styles = {
+  buttons: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '24px',
+    mt: '32px'
+  }
+}

--- a/src/pages/create-course/CreateCourse.tsx
+++ b/src/pages/create-course/CreateCourse.tsx
@@ -1,13 +1,33 @@
-import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+import Box from '@mui/material/Box'
+
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
+import AppButton from '~/components/app-button/AppButton'
+
+import { authRoutes } from '~/router/constants/authRoutes'
+import { ButtonTypeEnum, ButtonVariantEnum } from '~/types'
+
+import { styles } from '~/pages/create-course/CreateCourse.styles'
 
 const CreateCourse = () => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
   return (
-    <div>
-      <PageWrapper>
-        <div>New course</div>
-      </PageWrapper>
-    </div>
+    <PageWrapper>
+      <Box sx={styles.buttons}>
+        <AppButton
+          onClick={() => navigate(authRoutes.myCourses.root.path)}
+          variant={ButtonVariantEnum.Tonal}
+        >
+          {t('common.cancel')}
+        </AppButton>
+        <AppButton disabled type={ButtonTypeEnum.Submit}>
+          {t('common.save')}
+        </AppButton>
+      </Box>
+    </PageWrapper>
   )
 }
 

--- a/tests/unit/pages/create-course/CreateCourse.spec.jsx
+++ b/tests/unit/pages/create-course/CreateCourse.spec.jsx
@@ -1,14 +1,33 @@
-import CreateCourse from '~/pages/create-course/CreateCourse'
 import { renderWithProviders } from '~tests/test-utils'
-import { screen } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
+
+import CreateCourse from '~/pages/create-course/CreateCourse'
+
+const mockedNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useNavigate: () => mockedNavigate
+}))
 
 describe('CreateCourse', () => {
   beforeEach(() => {
     renderWithProviders(<CreateCourse />)
   })
 
-  it('should render page and find "New course" title', () => {
-    const newCourseBreadcrumb = screen.getByText('New course')
-    expect(newCourseBreadcrumb).toBeInTheDocument()
+  it('should render cancel and save buttons', () => {
+    const cancelButton = screen.getByText('common.cancel')
+    expect(cancelButton).toBeInTheDocument()
+
+    const saveButton = screen.getByText('common.save')
+    expect(saveButton).toBeInTheDocument()
+  })
+
+  it('redirect by clicking cancel button', () => {
+    const cancelButton = screen.getByText('common.cancel')
+
+    fireEvent.click(cancelButton)
+
+    expect(mockedNavigate).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
**Implemented cancel and save buttons with logic:**

<img width="1279" alt="buttons-cancel-save" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/56305508/7a408105-2af2-4c4a-946a-0547e518dd63">

**Tests:**

<img width="851" alt="image" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/56305508/d28b5597-8ac1-436b-b90f-f3dd1cc1def9">

Closed issue: #1308 