### PR TITLE
Fixed unlimited renders in Edit Lesson page

### DIFF
--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.constants.tsx
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.constants.tsx
@@ -20,7 +20,9 @@ export const defaultResponse = {
   description: '',
   title: '',
   updatedAt: '',
-  _id: ''
+  _id: '',
+  content: '',
+  category: null
 }
 
 export const myResourcesPath = '/my-resources'

--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
@@ -64,10 +64,10 @@ const CreateOrEditLesson = () => {
     setAlert({
       severity: snackbarVariants.success,
       message: id
-        ? 'newLesson.successEditedLesson'
-        : 'newLesson.successAddedLesson'
+        ? t('lesson.successEditedLesson')
+        : t('lesson.successAddedLesson')
     })
-    navigate(authRoutes.myResources.root.route)
+    navigate(authRoutes.myResources.root.path)
   }
 
   const handleAddAttachments = (attachments: Attachment[]) => {
@@ -162,8 +162,11 @@ const CreateOrEditLesson = () => {
   })
 
   useEffect(() => {
-    if (id) void fetchDataLesson(id)
-  }, [id, fetchDataLesson])
+    if (id) {
+      void fetchDataLesson(id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id])
 
   if (getLessonLoading) {
     return <Loader pageLoad />


### PR DESCRIPTION
Fixed unlimited renders in Edit Lesson page.
Also, I fixed alert messages and routes after clicking on save or cancel.

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/104988390/4ec1d3ff-455d-41e3-be95-65be630546cc