### PR TITLE
Fixed crumbs for new course

### DIFF
--- a/src/router/routes/authRouter.tsx
+++ b/src/router/routes/authRouter.tsx
@@ -111,7 +111,7 @@ export const authRouter = (
     />
     <Route
       element={<CreateCourse />}
-      handle={{ crumb: newCourse }}
+      handle={{ crumb: [myCourses, newCourse] }}
       path={authRoutes.myCourses.newCourse.route}
     />
     <Route


### PR DESCRIPTION
Fixed correct breadcrumbs myCourses -> newCourse
path: /my-courses/new-course

<img width="519" alt="image" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/56305508/d9873b84-feb4-4730-906a-629718fc35cf">

Fixed issue: #1350 