### PR TITLE
Fixed resources order

### DIFF
--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -162,7 +162,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
   }, [getAllResourcesItems, updateResources, addNewResources, sectionData])
 
   useEffect(() => {
-    if (handleSectionResourcesOrder) {
+    if (handleSectionResourcesOrder && sectionData.order) {
       handleSectionResourcesOrder(sectionData.id, resources)
     }
   }, [resources, sectionData.id, handleSectionResourcesOrder])

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -165,7 +165,12 @@ const CourseSectionContainer: FC<SectionProps> = ({
     if (handleSectionResourcesOrder && sectionData.order) {
       handleSectionResourcesOrder(sectionData.id, resources)
     }
-  }, [resources, sectionData.id, handleSectionResourcesOrder])
+  }, [
+    resources,
+    sectionData.id,
+    handleSectionResourcesOrder,
+    sectionData.order
+  ])
 
   const deleteResource = (resource: CourseResources) => {
     if (resource.resourceType === ResourcesTypes.Lessons) {


### PR DESCRIPTION
After merging the course section resources did not save the order, fixed that

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/17857767/8564a339-66e7-482e-92ae-674f38f083b9




