### PR TITLE
fixed - The user’s name is accepted when adding with whitespace to the profile on the “General” page

### DIFF
--- a/src/utils/validations/common.ts
+++ b/src/utils/validations/common.ts
@@ -10,7 +10,7 @@ const validations: Validations = {
     if (value.length > 30) {
       return 'common.errorMessages.nameLength'
     }
-    if (!RegExp(/^[a-zа-яєії ]+$/i).test(value)) {
+    if (!RegExp(/^(?! )[a-zа-яєії ]+(?<! )$/i).test(value)) {
       return 'common.errorMessages.nameAlphabeticOnly'
     }
     return ''


### PR DESCRIPTION

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/101183408/8f363269-f7a7-4812-b513-04f640785482

