### PR TITLE
Changed max upload file size

### DIFF
--- a/src/components/file-uploader/FileUploader.tsx
+++ b/src/components/file-uploader/FileUploader.tsx
@@ -90,7 +90,7 @@ const FileUploader: FC<FileUploaderProps> = ({
       {isImages && (
         <>
           <Typography sx={styles.fileSize}>
-            {`${t('errorMessages.fileSize', { size: '10' })} ${t(
+            {`${t('errorMessages.fileSize', { size: '5' })} ${t(
               'common.megabytes'
             )}`}
           </Typography>

--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -26,7 +26,7 @@
     "placeholder": "Photo Preview",
     "description": "Velit officia consequat duis enim velit mollit. Exercitation veniam consequat sunt nostrud amet.",
     "typeError": "Wrong file type. Only .png/.jpg/.jpeg files are allowed.",
-    "fileSizeError": "Size for one file cannot be more than 10MB."
+    "fileSizeError": "Size for one file cannot be more than 5 MB."
   },
   "successMessage": "Success! Your data were added."
 }

--- a/src/constants/translations/en/common.json
+++ b/src/constants/translations/en/common.json
@@ -38,7 +38,7 @@
   "uploadNewFile": "Upload new file",
   "typeError": "Wrong file type. Only .pdf/.jpg/.jpeg files are allowed.",
   "allFilesSizeError": "All files size error",
-  "fileSizeError": "Розмір одного файлу не може перевищувати 10 Мб.",
+  "fileSizeError": "Size for one file cannot be more than 5 MB.",
   "noItems": "No items found",
   "view": "View",
   "labels": {

--- a/src/constants/translations/ua/become-tutor.json
+++ b/src/constants/translations/ua/become-tutor.json
@@ -32,7 +32,7 @@
 	"placeholder":"Попередній перегляд фотографій",
 	"description":"Velit officia consequat duis enim velit mollit. Exercitation veniam consequat sunt nostrud amet.",
 	"typeError": "Неправильний тип файлу. Дозволяються лише файли .png/.jpg/.jpeg.",
-	"fileSizeError": "Розмір одного файлу не може перевищувати 10 Мб."
+	"fileSizeError": "Розмір одного файлу не може перевищувати 5 Мб."
   },
   "successMessage": "Успішно! Ваші дані додано."
 }

--- a/src/constants/translations/ua/common.json
+++ b/src/constants/translations/ua/common.json
@@ -35,7 +35,7 @@
   "uploadNewFile": "Завантажити новий файл",
   "typeError": "Неправильний тип файлу. Дозволяються лише файли .pdf/.jpg/.jpeg",
   "allFilesSizeError": "Помилка розміру всіх файлів",
-  "fileSizeError": "Size for one file cannot be more than 10 MB.",
+  "fileSizeError": "Розмір одного файлу не може перевищувати 5 Мб.",
   "noItems": "Елементів не знайдено",
   "view": "Переглянути",
   "labels": {

--- a/src/containers/add-documents/AddDocuments.constants.ts
+++ b/src/containers/add-documents/AddDocuments.constants.ts
@@ -1,8 +1,8 @@
 import { AddDocuments } from '~/types'
 
 export const validationData: AddDocuments = {
-  maxFileSize: 10_000_000,
-  maxAllFilesSize: 50_000_000,
+  maxFileSize: 5_000_000,
+  maxAllFilesSize: 20_000_000,
   filesTypes: ['application/pdf', 'image/jpeg', 'image/png'],
   fileSizeError: 'common.fileSizeError',
   allFilesSizeError: 'common.allFilesSizeError',

--- a/src/containers/tutor-home-page/add-photo-step/constants.js
+++ b/src/containers/tutor-home-page/add-photo-step/constants.js
@@ -1,7 +1,7 @@
 export const MB = 1_000_000
 
 export const validationData = {
-  maxFileSize: 10 * MB,
+  maxFileSize: 5 * MB,
   filesTypes: ['image/jpeg', 'image/png'],
   fileSizeError: 'becomeTutor.photo.fileSizeError',
   typeError: 'becomeTutor.photo.typeError',

--- a/tests/unit/components/file-uploader/FileUploader.spec.jsx
+++ b/tests/unit/components/file-uploader/FileUploader.spec.jsx
@@ -7,8 +7,8 @@ const emitter = vi.fn()
 const initialState = []
 const initialError = undefined
 const validationData = {
-  maxFileSize: 10_000_000,
-  maxAllFilesSize: 50_000_000,
+  maxFileSize: 5_000_000,
+  maxAllFilesSize: 20_000_000,
   filesTypes: ['application/pdf', 'image/jpeg', 'image/png'],
   fileSizeError: 'becomeTutor.documents.fileSizeError',
   allFilesSizeError: 'becomeTutor.documents.allFilesSizeError',

--- a/tests/unit/components/user-steps-wrapper/UserStepsWrapper.spec.jsx
+++ b/tests/unit/components/user-steps-wrapper/UserStepsWrapper.spec.jsx
@@ -75,7 +75,7 @@ describe('UserStepsWrapper test', () => {
     const fakeFile = new File(['certificate'], 'test-file.png', {
       type: 'image/png'
     })
-    Object.defineProperty(fakeFile, 'size', { value: 9_000_000 })
+    Object.defineProperty(fakeFile, 'size', { value: 4_000_000 })
 
     const photo = screen.getByText(/step.stepLabels.photo/i)
     fireEvent.click(photo)

--- a/tests/unit/hooks/use-upload.spec.js
+++ b/tests/unit/hooks/use-upload.spec.js
@@ -4,8 +4,8 @@ import { vi } from 'vitest'
 
 const files = []
 const validationData = {
-  maxFileSize: 10_000_000,
-  maxAllFilesSize: 50_000_000,
+  maxFileSize: 5_000_000,
+  maxAllFilesSize: 20_000_000,
   filesTypes: ['application/pdf'],
   fileSizeError: 'becomeTutor.documents.fileSizeError',
   allFilesSizeError: 'becomeTutor.documents.allFilesSizeError',


### PR DESCRIPTION
Changed maximum upload file size for profile photo and tutor's resources to 5mb

1) Stepper - Photo upload
<img width="391" alt="Знімок екрана 2024-02-20 о 12 24 36" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/17857767/22c306e8-0dbd-48e2-abc3-d3c62f5594b8">

2) Upload of tutor's resources

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/17857767/4acc9822-a568-4fe0-b15d-64f007f89897
