### PR TITLE
Fixed getting wrong cities on stepper

### DIFF
--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
@@ -56,7 +56,15 @@ const GeneralInfoStep = ({
       handleNonInputValueChange('city', null)
       handleNonInputValueChange('country', value)
     }
-    if (value) await fetchCities(value)
+    if (value) {
+      const selectedCountry = countries.find(
+        (country) => country.name === value
+      )
+      if (selectedCountry) {
+        const countryCode = selectedCountry.iso2
+        await fetchCities(countryCode)
+      }
+    }
   }
 
   const onChangeCity = (_, value) => {
@@ -105,6 +113,8 @@ const GeneralInfoStep = ({
     fetchOnMount: false,
     defaultResponse: defaultResponses.array
   })
+
+  const countriesNames = countries.map((country) => country.name)
 
   const {
     loading: loadingCities,
@@ -179,7 +189,7 @@ const GeneralInfoStep = ({
               loading={loadingCountries}
               onChange={onChangeCountry}
               onFocus={onFocusCountry}
-              options={countries}
+              options={countriesNames}
               sx={{ mb: '30px' }}
               textFieldProps={{
                 label: t('common.labels.country')

--- a/tests/unit/containers/mentor-home-page/general-info-step/GeneralInfoStep.spec.jsx
+++ b/tests/unit/containers/mentor-home-page/general-info-step/GeneralInfoStep.spec.jsx
@@ -18,7 +18,7 @@ const userRole = 'tutor'
 const userDataMock = { _id: userId, firstName: 'test', lastName: 'test' }
 const countriesDataMock = [
   { name: 'Ukraine', iso2: 'UA' },
-  { name: 'Belgium', iso2: 'BE}' }
+  { name: 'Belgium', iso2: 'BE' }
 ]
 const citiesDataMock = ['Antwerp', 'Brussels']
 const countryCode = 'BE'

--- a/tests/unit/containers/mentor-home-page/general-info-step/GeneralInfoStep.spec.jsx
+++ b/tests/unit/containers/mentor-home-page/general-info-step/GeneralInfoStep.spec.jsx
@@ -16,9 +16,12 @@ const setIsUserFetched = vi.fn()
 const userId = '63f5d0ebb'
 const userRole = 'tutor'
 const userDataMock = { _id: userId, firstName: 'test', lastName: 'test' }
-const countriesDataMock = ['Ukraine', 'Belgium']
+const countriesDataMock = [
+  { name: 'Ukraine', iso2: 'UA' },
+  { name: 'Belgium', iso2: 'BE}' }
+]
 const citiesDataMock = ['Antwerp', 'Brussels']
-const country = 'Belgium'
+const countryCode = 'BE'
 
 const mockState = {
   appMain: { userId, loading: false }
@@ -41,7 +44,7 @@ describe('GeneralInfoStep test', () => {
         .onGet(URLs.location.getCountries)
         .reply(200, countriesDataMock)
       mockAxiosClient
-        .onGet(`${URLs.location.getCities}/${country}`)
+        .onGet(`${URLs.location.getCities}/${countryCode}`)
         .reply(200, citiesDataMock)
       renderWithProviders(
         <StepProvider


### PR DESCRIPTION
Fixed getting wrong cities on stepper. If there is no information about cities of certain country user will see in dropdown text 'No options'.

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/121502737/ffe99a37-78ef-4798-b283-c265b04a5567

