### PR TITLE
Fixed alignment and style of error message in add photo step of the stepper

### DIFF
--- a/src/components/file-uploader/FileUploader.styles.ts
+++ b/src/components/file-uploader/FileUploader.styles.ts
@@ -29,10 +29,5 @@ export const styles = {
   fileSize: {
     mt: '10px',
     typography: TypographyVariantEnum.Body2
-  },
-  error: {
-    color: 'error',
-    ml: 1,
-    typography: TypographyVariantEnum.Caption
   }
 }

--- a/src/components/file-uploader/FileUploader.tsx
+++ b/src/components/file-uploader/FileUploader.tsx
@@ -8,7 +8,7 @@ import ListItem from '@mui/material/ListItem'
 import List from '@mui/material/List'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import CloseIcon from '@mui/icons-material/Close'
-import { SxProps } from '@mui/material'
+import { FormHelperText, SxProps } from '@mui/material'
 
 import useUpload from '~/hooks/use-upload'
 
@@ -32,6 +32,7 @@ interface FileUploaderProps {
   sx?: {
     root?: SxProps
     button?: SxProps
+    error?: SxProps
   }
   variant?: ButtonVariantEnum
   icon?: ReactElement
@@ -95,7 +96,9 @@ const FileUploader: FC<FileUploaderProps> = ({
             )}`}
           </Typography>
           {initialError && (
-            <Typography sx={styles.error}>{t(initialError)}</Typography>
+            <FormHelperText error sx={sx.error}>
+              {t(initialError)}
+            </FormHelperText>
           )}
         </>
       )}


### PR DESCRIPTION
Alignment of error message in the stepper was not properly aligned.  Also, colour of the error message was inconsistent with the error message in previous step (subject step). Fixed for both tutor and student.

Before fix:
<img width="716" alt="318134154-9ae9879c-af05-43d8-b514-9a8c293ba8eb" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/d76a7250-615c-4c7f-9ee4-4e6d77be8dd1">

After fix:
![erro-message-fix](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/1b3b98c1-fc3a-4efd-a658-308af8112539)
