### PR TITLE
Fix the bug when cooperation details cannot be opened

### DIFF
--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -74,11 +74,12 @@ const CooperationDetails = () => {
 
   const cooperationContent = activeTab && tabsData[activeTab]?.content
 
-  const pageContent = isActivityCreated ? (
-    <CooperationActivities />
-  ) : (
-    cooperationContent
-  )
+  const pageContent =
+    isActivityCreated && activeTab === CooperationTabsEnum.Activities ? (
+      <CooperationActivities />
+    ) : (
+      cooperationContent
+    )
 
   const iconConditionals = isNotesOpen ? (
     <KeyboardDoubleArrowRightIcon />


### PR DESCRIPTION
Fix the bug when cooperation details cannot be opened after adding an activity.

The bug was fixed by changing the condition responsible for displaying the current tab content.

Actual result:

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/110097862/71800287-7d02-4700-b6d9-6620338b61e8
