### PR TITLE
Fixed typescript error in App drawer component

### DIFF
--- a/src/components/app-drawer/AppDrawer.tsx
+++ b/src/components/app-drawer/AppDrawer.tsx
@@ -9,9 +9,16 @@ import useConfirm from '~/hooks/use-confirm'
 import { styles } from '~/components/app-drawer/AppDrawer.styles'
 import { PositionEnum } from '~/types'
 
-interface AppDrawerProps extends DrawerProps {
+type AnchorPositionsFromEnum =
+  | PositionEnum.Top
+  | PositionEnum.Bottom
+  | PositionEnum.Left
+  | PositionEnum.Right
+
+interface AppDrawerProps extends Omit<DrawerProps, 'anchor'> {
   children: ReactNode
   closeIcon?: boolean
+  anchor?: DrawerProps['anchor'] | AnchorPositionsFromEnum
   onClose: () => void
 }
 


### PR DESCRIPTION
Fixed typescript error by allowing developer to pass either correct enum values or fixed string values