### PR TITLE
Replaced mapped types with typescript Record utility type and splitte…

### DIFF
--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -45,26 +45,19 @@ import {
   CourseResources
 } from '~/types'
 import { styles } from '~/containers/course-section/CourseSectionContainer.styles'
+import CourseSectionsList from '../course-sections-list/CourseSectionsList'
 
-interface SectionProps {
+interface SectionProps
+  extends Pick<
+    Parameters<typeof CourseSectionsList>[0],
+    | 'handleSectionInputChange'
+    | 'handleSectionNonInputChange'
+    | 'handleSectionResourcesOrder'
+    | 'titleText'
+    | 'setSectionsItems'
+  > {
   sectionData: CourseSection
   sections: CourseSection[]
-  setSectionsItems: (value: CourseSection[]) => void
-  handleSectionInputChange: (
-    id: string,
-    field: keyof CourseSection,
-    value: string
-  ) => void
-  handleSectionNonInputChange: (
-    id: string,
-    field: keyof CourseSection,
-    value: CourseResources[]
-  ) => void
-  titleText: string
-  handleSectionResourcesOrder?: (
-    id: string,
-    resources: CourseResources[]
-  ) => void
 }
 
 type openModalFunc = () => void

--- a/src/containers/course-sections-list/CourseSectionsList.tsx
+++ b/src/containers/course-sections-list/CourseSectionsList.tsx
@@ -24,23 +24,18 @@ import useDroppable from '~/hooks/use-droppable'
 import useMenu from '~/hooks/use-menu'
 
 import { styles } from '~/containers/course-sections-list/CourseSectionsList.styles'
-import { CourseSection, CourseResources } from '~/types'
+import { CourseSection, CourseResources, FormInputValueChange } from '~/types'
 import { useModalContext } from '~/context/modal-context'
 import { useCooperationContext } from '~/context/cooperation-context'
 
 interface CourseSectionsListProps {
   items: CourseSection[]
   setSectionsItems: (value: CourseSection[]) => void
-  handleSectionInputChange: (
-    id: string,
-    field: keyof CourseSection,
-    value: string
-  ) => void
-  handleSectionNonInputChange: (
-    id: string,
-    field: keyof CourseSection,
-    value: CourseResources[]
-  ) => void
+  handleSectionInputChange: FormInputValueChange<string, CourseSection>
+  handleSectionNonInputChange: FormInputValueChange<
+    CourseResources[],
+    CourseSection
+  >
   handleSectionResourcesOrder?: (
     id: string,
     resources: CourseResources[]

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
@@ -26,24 +26,25 @@ import {
   TextFieldVariantEnum,
   ComponentEnum,
   UserResponse,
-  CourseExtendedAutocompleteOptions
+  CourseExtendedAutocompleteOptions,
+  FormNonInputValueChange,
+  UseFormEventHandler
 } from '~/types'
 import { styles } from '~/containers/my-courses/course-toolbar/CourseToolbar.style'
 
 interface CourseToolbarProps {
   data: CourseForm
   user: UserResponse | null
-  errors: { [key in keyof CourseForm]: string }
-  handleBlur: (
-    key: keyof CourseForm
-  ) => (event: FocusEvent<HTMLInputElement>) => void
-  handleInputChange: (
-    key: keyof CourseForm
-  ) => (event: ChangeEvent<HTMLInputElement>) => void
-  handleNonInputValueChange: (
-    key: keyof CourseForm,
-    value: string | ProficiencyLevelEnum[] | null
-  ) => void
+  errors: Record<keyof CourseForm, string>
+  handleBlur: UseFormEventHandler<CourseForm, FocusEvent<HTMLInputElement>>
+  handleInputChange: UseFormEventHandler<
+    CourseForm,
+    ChangeEvent<HTMLInputElement>
+  >
+  handleNonInputValueChange: FormNonInputValueChange<
+    string | ProficiencyLevelEnum[] | null,
+    CourseForm
+  >
 }
 
 const CourseToolbar = ({

--- a/src/hooks/use-form.tsx
+++ b/src/hooks/use-form.tsx
@@ -1,13 +1,17 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
+import {
+  FormNonInputValueChange,
+  UseFormErrors,
+  UseFormEventHandler,
+  UseFormValidations
+} from '~/types'
 import { getEmptyValues } from '~/utils/helper-functions'
 import { isEqual } from '~/utils/isEqual'
 
 interface UseFormProps<T> {
   initialValues: T
-  initialErrors?: { [K in keyof T]: string }
-  validations?: Partial<{
-    [K in keyof T]: (value: T[K] | string, data: T) => string | undefined
-  }>
+  initialErrors?: UseFormErrors<T>
+  validations?: Partial<UseFormValidations<T>>
   onSubmit?: (data?: T) => Promise<void>
   submitWithData?: boolean
 }
@@ -15,14 +19,10 @@ interface UseFormProps<T> {
 interface UseFormOutput<T> {
   data: T
   isDirty: boolean
-  errors: { [K in keyof T]: string }
-  handleInputChange: (
-    key: keyof T
-  ) => (event: React.ChangeEvent<HTMLInputElement>) => void
-  handleNonInputValueChange: (key: keyof T, value: T[keyof T]) => void
-  handleBlur: (
-    key: keyof T
-  ) => (event: React.FocusEvent<HTMLInputElement>) => void
+  errors: UseFormErrors<T>
+  handleInputChange: UseFormEventHandler<T, React.ChangeEvent<HTMLInputElement>>
+  handleNonInputValueChange: FormNonInputValueChange<T[keyof T], T>
+  handleBlur: UseFormEventHandler<T, React.FocusEvent<HTMLInputElement>>
   handleErrors: (key: keyof T, error: string) => void
   handleSubmit: (event: React.FormEvent<HTMLDivElement>) => void
   resetData: (keys?: (keyof T)[]) => void
@@ -38,9 +38,8 @@ export const useForm = <T extends object>({
 }: UseFormProps<T>): UseFormOutput<T> => {
   const [data, setData] = useState<T>(initialValues)
   const [isDirty, setDirty] = useState<boolean>(false)
-  const [errors, setErrors] =
-    useState<{ [K in keyof T]: string }>(initialErrors)
-  const [isTouched, setTouched] = useState<{ [K in keyof T]: boolean }>(
+  const [errors, setErrors] = useState<UseFormErrors<T>>(initialErrors)
+  const [isTouched, setTouched] = useState<Record<keyof T, boolean>>(
     getEmptyValues(initialValues, false)
   )
 

--- a/src/types/common/types/common.types.ts
+++ b/src/types/common/types/common.types.ts
@@ -29,3 +29,29 @@ export type Country = {
   name: string
   iso2: string
 }
+
+export type FormInputValueChange<Value, Fields> = (
+  id: string,
+  field: keyof Fields,
+  value: Value
+) => void
+
+export type FormNonInputValueChange<Value, Fields> = (
+  key: keyof Fields,
+  value: Value
+) => void
+
+export type UseFormEventHandler<Fields, Event> = (
+  key: keyof Fields
+) => (event: Event) => void
+
+type FormValidationHandler<TData, TValue> = (
+  value: TValue | string,
+  data: TData
+) => string | undefined
+
+export type UseFormValidations<T> = {
+  [Key in keyof T]: FormValidationHandler<T, T[Key]>
+}
+
+export type UseFormErrors<T> = Record<keyof T, string>

--- a/src/types/findOffers/interfaces/findOffers.interfaces.ts
+++ b/src/types/findOffers/interfaces/findOffers.interfaces.ts
@@ -34,7 +34,7 @@ export interface FindOffersFiltersActions<T> {
 
 export interface CreateOfferBlockProps<T> {
   data: T
-  errors: { [K in keyof T]: string }
+  errors: Record<keyof T, string>
   handleNonInputValueChange: <K extends keyof T>(key: K, value: T[K]) => void
   handleBlur: (
     key: keyof T

--- a/src/utils/helper-functions.tsx
+++ b/src/utils/helper-functions.tsx
@@ -58,10 +58,10 @@ export const parseQueryParams = <T extends object>(
 export const getEmptyValues = <T extends object, R>(
   initialValues: T,
   defaultValue: R
-): { [K in keyof T]: R } => {
+) => {
   return Object.keys(initialValues).reduce(
     (acc, key) => ({ ...acc, [key]: defaultValue }),
-    {} as { [K in keyof T]: R }
+    {} as Record<keyof T, R>
   )
 }
 


### PR DESCRIPTION
Replaced mapped types like `{ [ K in keyof T ]: string }` to `Record` utility type and splitted some complex types and reused them