### PR TITLE
Fixed validation of signup form

### DIFF
--- a/src/constants/translations/en/common.json
+++ b/src/constants/translations/en/common.json
@@ -69,7 +69,8 @@
   "errorMessages": {
     "emailValid": "Email should be of the following format: “local-part@domain.com”",
     "passwordLength": "Password cannot be shorter than 8 and longer than 25 characters",
-    "passwordValid": "Password must contain at least one alphabetic and one numeric character",
+    "passwordAlphabeticAndNumeric": "Password must contain at least one alphabetic and one numeric character",
+    "passwordValidSymbols": "Password must contain only alphabetic, numeric and special characters",
     "emptyField": "This field cannot be empty",
     "nameLength": "This field cannot be longer than 30 characters",
     "nameAlphabeticOnly": "This field can contain alphabetic characters only",

--- a/src/utils/validations/common.ts
+++ b/src/utils/validations/common.ts
@@ -1,3 +1,5 @@
+import { validationPatterns } from '~/utils/validations/validations.constants'
+
 interface Validations {
   nameField: (value: string) => string
   numberField: (value: string) => string
@@ -10,13 +12,13 @@ const validations: Validations = {
     if (value.length > 30) {
       return 'common.errorMessages.nameLength'
     }
-    if (!RegExp(/^(?! )[a-zа-яєії ]+(?<! )$/i).test(value)) {
+    if (!validationPatterns.name.test(value)) {
       return 'common.errorMessages.nameAlphabeticOnly'
     }
     return ''
   },
   numberField: (value) => {
-    if (!RegExp(/^-?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/).test(value)) {
+    if (!validationPatterns.number.test(value)) {
       return 'common.errorMessages.numbersOnly'
     }
     if (Number(value) < 0) {
@@ -25,8 +27,11 @@ const validations: Validations = {
     return ''
   },
   password: (value) => {
-    if (!RegExp(/^(?=.*\d)(?=.*[a-zа-яєії])\S+$/i).test(value)) {
-      return 'common.errorMessages.passwordValid'
+    if (!validationPatterns.passwordAlphabeticAndNumeric.test(value)) {
+      return 'common.errorMessages.passwordAlphabeticAndNumeric'
+    }
+    if (!validationPatterns.passwordValid.test(value)) {
+      return 'common.errorMessages.passwordValidSymbols'
     }
     if (value.length < 8 || value.length > 25) {
       return 'common.errorMessages.passwordLength'
@@ -34,11 +39,7 @@ const validations: Validations = {
     return ''
   },
   email: (value) => {
-    if (
-      !RegExp(
-        /^([a-z\d]+([._-][a-z\d]+)*)@([a-z\d]+([.-][a-z\d]+)*\.[a-z]{2,})$/i
-      ).test(value)
-    ) {
+    if (!validationPatterns.email.test(value)) {
       return 'common.errorMessages.emailValid'
     }
     return ''

--- a/src/utils/validations/validations.constants.ts
+++ b/src/utils/validations/validations.constants.ts
@@ -1,0 +1,7 @@
+export const validationPatterns = {
+  name: /^[a-zа-яєії]+$/i,
+  number: /^-?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/,
+  email: /^([a-z\d]+([._-][a-z\d]+)*)@([a-z\d]+([.-][a-z\d]+)*\.[a-z]{2,})$/i,
+  passwordValid: /^\S+$/i,
+  passwordAlphabeticAndNumeric: /(?=.*\d)(?=.*[a-zа-яєії])/i
+}

--- a/tests/unit/utils/common.spec.jsx
+++ b/tests/unit/utils/common.spec.jsx
@@ -1,0 +1,102 @@
+import { expect } from 'vitest'
+import {
+  emptyField,
+  numberField,
+  nameField,
+  textField,
+  helperTextHandler
+} from '~/utils/validations/common'
+
+const mockedValues = {
+  nameWithNumbers: 'name2',
+  tooLongName: 'vvvveeeerrrryyyylllloooonnnnggggnnnnaaaammmmeeee',
+  invalidNumber: '8w5',
+  negativeNumber: '-5',
+  shortPassword: '111a?',
+  passwordWithoutNumbers: 'abc!dwga%g&sad',
+  passwordWithInvalidSymbol: '123qw er58',
+  invalidEmail: 'example2example.com',
+  shortText: 't',
+  longText: 'wwwwwwwwwwwwwwwwwwwwwwwwwwwwwww',
+  emptyField: ''
+}
+
+const errorMessages = {
+  nameAlphabeticOnly: 'common.errorMessages.nameAlphabeticOnly',
+  nameLength: 'common.errorMessages.nameLength',
+  numbersOnly: 'common.errorMessages.numbersOnly',
+  positiveNumbersOnly: 'common.errorMessages.positiveNumbersOnly',
+  passwordLength: 'common.errorMessages.passwordLength',
+  passwordAlphabeticAndNumeric:
+    'common.errorMessages.passwordAlphabeticAndNumeric',
+  passwordValidSymbols: 'common.errorMessages.passwordValidSymbols',
+  emailValid: 'common.errorMessages.emailValid',
+  shortText: 'common.errorMessages.shortText',
+  longText: 'common.errorMessages.longText',
+  emptyField: 'common.errorMessages.emptyField'
+}
+
+export const emailField = (value) => {
+  return helperTextHandler(value, 'email')
+}
+
+export const passwordField = (value) => {
+  return helperTextHandler(value, 'password')
+}
+
+describe('commonValidation', () => {
+  it('Should return error that only alphabetical characters are allowed', () => {
+    const result = nameField(mockedValues.nameWithNumbers)
+    expect(result).toBe(errorMessages.nameAlphabeticOnly)
+  })
+
+  it('Should return error that name is too long', () => {
+    const result = nameField(mockedValues.tooLongName)
+    expect(result).toBe(errorMessages.nameLength)
+  })
+
+  it('Should return error that only number are allowed', () => {
+    const result = numberField(mockedValues.invalidNumber)
+    expect(result).toBe(errorMessages.numbersOnly)
+  })
+
+  it('Should return error that only positive number is allowed', () => {
+    const result = numberField(mockedValues.negativeNumber)
+    expect(result).toBe(errorMessages.positiveNumbersOnly)
+  })
+
+  it('Should return error that password cannot be shorter than 8 and longer than 25 characters', () => {
+    const result = passwordField(mockedValues.shortPassword)
+    expect(result).toBe(errorMessages.passwordLength)
+  })
+
+  it('Should return error that password must contain at least one alphabetic and one numeric character', () => {
+    const result = passwordField(mockedValues.passwordWithoutNumbers)
+    expect(result).toBe(errorMessages.passwordAlphabeticAndNumeric)
+  })
+
+  it('Should return error that password must contain only valid symbols', () => {
+    const result = passwordField(mockedValues.passwordWithInvalidSymbol)
+    expect(result).toBe(errorMessages.passwordValidSymbols)
+  })
+
+  it('Should return error that email is invalid', () => {
+    const result = emailField(mockedValues.invalidEmail)
+    expect(result).toBe(errorMessages.emailValid)
+  })
+
+  it('Should return error that text is too short', () => {
+    const result = textField(10, 25)(mockedValues.shortText)
+    expect(result).toBe(errorMessages.shortText)
+  })
+
+  it('Should return error that text is too long', () => {
+    const result = textField(0, 15)(mockedValues.longText)
+    expect(result).toBe(errorMessages.longText)
+  })
+
+  it('Should return error that field must not be empty', () => {
+    const result = emptyField(mockedValues.emptyField)
+    expect(result).toBe(errorMessages.emptyField)
+  })
+})


### PR DESCRIPTION
I changed name validation pattern to match only values without spaces (Previously it was not handled on a client side, so server returned error in case of space in name or surname).

I also splited password validation pattern into two cases. One of them matches values with one alphabetic character and one numeric character, another one matches only valid values. I did because previously in both cases "Password must contain at least one alphabetic and one numeric character" error was returned. That is not descriptive in case of invalid character error (if there is a space in password, for example).

I also added new error message for invalid symbol in password.

Wrote tests for common validations.

**Before fix:**

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/5c5007cb-69fc-4dc5-9110-a159991cbd02



**After fix:**


https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/8694780c-afe1-48a6-aa96-3a88b0e29b7e





