### PR TITLE
Fixed offer card title width

### DIFF
--- a/src/containers/find-offer/offer-card-square/OfferCardSquare.styles.ts
+++ b/src/containers/find-offer/offer-card-square/OfferCardSquare.styles.ts
@@ -32,7 +32,8 @@ export const styles = {
     ...ellipsisTextStyle(2),
     typography: 'midTitle',
     fontWeight: 600,
-    color: 'primary.700'
+    color: 'primary.700',
+    wordBreak: 'break-word'
   },
   iconButton: {
     color: 'basic.black',


### PR DESCRIPTION
Fixed offer card title width.
Before:
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/104922087/78b176bf-bd37-4b6a-bf1e-6ea6b864176c)

After fixing:
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/104922087/ea217edd-b3ad-4265-99a3-283319a4d903)

