### PR TITLE
Styles for edit profile container and Sidebar Menu #1721

### DIFF
--- a/src/components/sidebar-menu/SidebarMenu.styles.ts
+++ b/src/components/sidebar-menu/SidebarMenu.styles.ts
@@ -1,0 +1,31 @@
+import palette from '~/styles/app-theme/app.pallete'
+
+export const styles = {
+  sidebarButton: {
+    width: '30%',
+    pr: { lg: '96px' },
+    pt: '0px',
+    '& .MuiListItem-root': {
+      pl: '0px',
+      '&:first-child': {
+        pt: '0px'
+      },
+      '&:not(:first-child)': {
+        pt: '18px'
+      }
+    },
+    '& .MuiListItemButton-root div': {
+      minWidth: '34px'
+    },
+    '& .MuiButtonBase-root:hover': {
+      backgroundColor: palette.basic.grey,
+      '& .MuiTypography-body1': {
+        color: palette.basic.black,
+        fontWeight: '600'
+      },
+      '& .MuiListItemIcon-root svg': {
+        color: palette.basic.black
+      }
+    }
+  }
+}

--- a/src/components/sidebar-menu/SidebarMenu.styles.ts
+++ b/src/components/sidebar-menu/SidebarMenu.styles.ts
@@ -3,14 +3,13 @@ import palette from '~/styles/app-theme/app.pallete'
 export const styles = {
   sidebarButton: {
     width: '30%',
-    pr: { lg: '96px' },
     pt: '0px',
     '& .MuiListItem-root': {
       pl: '0px',
-      '&:first-child': {
+      '&:first-of-type': {
         pt: '0px'
       },
-      '&:not(:first-child)': {
+      '&:not(:first-of-type)': {
         pt: '18px'
       }
     },

--- a/src/components/sidebar-menu/SidebarMenu.tsx
+++ b/src/components/sidebar-menu/SidebarMenu.tsx
@@ -3,7 +3,7 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import List from '@mui/material/List'
 import ListItemIcon from '@mui/material/ListItemIcon'
-import { SxProps, Theme } from '@mui/material/styles'
+// import { SxProps, Theme } from '@mui/material/styles'
 
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -11,13 +11,14 @@ import { useTranslation } from 'react-i18next'
 import { TutorProfileProps } from '~/pages/edit-profile/EditProfile.constants'
 import { TutorProfileTabsEnum } from '~/types'
 
+import { styles } from '~/components/sidebar-menu/SidebarMenu.styles'
+
 interface SidebarMenu {
   tabsData: TutorProfileProps
   handleClick: (tab: TutorProfileTabsEnum) => void
-  styles?: SxProps<Theme>
 }
 
-const SidebarMenu: FC<SidebarMenu> = ({ handleClick, tabsData, styles }) => {
+const SidebarMenu: FC<SidebarMenu> = ({ handleClick, tabsData }) => {
   const { t } = useTranslation()
 
   const list = Object.keys(tabsData).map((key) => {
@@ -33,7 +34,7 @@ const SidebarMenu: FC<SidebarMenu> = ({ handleClick, tabsData, styles }) => {
     )
   })
 
-  return <List sx={styles}>{list}</List>
+  return <List sx={styles.sidebarButton}>{list}</List>
 }
 
 export default SidebarMenu

--- a/src/components/sidebar-menu/SidebarMenu.tsx
+++ b/src/components/sidebar-menu/SidebarMenu.tsx
@@ -3,7 +3,6 @@ import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import List from '@mui/material/List'
 import ListItemIcon from '@mui/material/ListItemIcon'
-// import { SxProps, Theme } from '@mui/material/styles'
 
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/src/containers/tutor-profile/security-block/SecurityBlock.styles.js
+++ b/src/containers/tutor-profile/security-block/SecurityBlock.styles.js
@@ -7,6 +7,8 @@ export const styles = {
     flexDirection: 'column',
     width: '100%',
     boxSizing: 'border-box',
+    maxWidth: '768px',
+    m: '0 auto',
     p: '20px 40px',
     backgroundColor: 'basic.white',
     borderRadius: '4px',

--- a/src/containers/tutor-profile/security-block/SecurityBlock.styles.js
+++ b/src/containers/tutor-profile/security-block/SecurityBlock.styles.js
@@ -5,7 +5,6 @@ export const styles = {
   container: {
     display: 'flex',
     flexDirection: 'column',
-    maxWidth: '630px',
     width: '100%',
     boxSizing: 'border-box',
     p: '20px 40px',

--- a/src/pages/edit-profile/EditProfile.styles.ts
+++ b/src/pages/edit-profile/EditProfile.styles.ts
@@ -1,6 +1,9 @@
 import { TypographyVariantEnum } from '~/types'
 
 export const styles = {
+  sectionsWrapper: {
+    px: { lg: '156px' }
+  },
   headerContainer: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -19,15 +22,11 @@ export const styles = {
   backBtn: {
     padding: '10px'
   },
-  sidebarMenu: {
-    width: '30%'
-  },
   mainContainer: {
     display: 'flex',
     justifyContent: 'space-between'
   },
   mainContent: {
-    width: '65%',
-    mr: '10%'
+    width: '65%'
   }
 }

--- a/src/pages/edit-profile/EditProfile.styles.ts
+++ b/src/pages/edit-profile/EditProfile.styles.ts
@@ -1,9 +1,6 @@
 import { TypographyVariantEnum } from '~/types'
 
 export const styles = {
-  sectionsWrapper: {
-    px: { lg: '156px' }
-  },
   headerContainer: {
     display: 'flex',
     justifyContent: 'space-between',

--- a/src/pages/edit-profile/EditProfile.styles.ts
+++ b/src/pages/edit-profile/EditProfile.styles.ts
@@ -7,7 +7,7 @@ export const styles = {
     alignItems: 'center'
   },
   title: {
-    typography: TypographyVariantEnum.H5
+    typography: TypographyVariantEnum.H4
   },
   description: {
     typography: TypographyVariantEnum.Subtitle1,

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -54,7 +54,7 @@ const EditProfile = () => {
     activeTab && tabsData[activeTab]?.content?.(response)
 
   return (
-    <PageWrapper>
+    <PageWrapper sx={styles.sectionsWrapper}>
       <Box sx={styles.headerContainer}>
         <Box>
           <Typography sx={styles.title}>
@@ -65,7 +65,7 @@ const EditProfile = () => {
           </Typography>
         </Box>
         <AppButton
-          size={SizeEnum.Small}
+          size={SizeEnum.Large}
           sx={styles.backBtn}
           variant={ButtonVariantEnum.Tonal}
         >
@@ -74,11 +74,7 @@ const EditProfile = () => {
       </Box>
       <Divider sx={styles.line} />
       <Box sx={styles.mainContainer}>
-        <SidebarMenu
-          handleClick={handleClick}
-          styles={styles.sidebarMenu}
-          tabsData={tabsData}
-        />
+        <SidebarMenu handleClick={handleClick} tabsData={tabsData} />
         <Box sx={styles.mainContent}>{cooperationContent}</Box>
       </Box>
     </PageWrapper>

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -54,7 +54,7 @@ const EditProfile = () => {
     activeTab && tabsData[activeTab]?.content?.(response)
 
   return (
-    <PageWrapper sx={styles.sectionsWrapper}>
+    <PageWrapper>
       <Box sx={styles.headerContainer}>
         <Box>
           <Typography sx={styles.title}>


### PR DESCRIPTION
-Added styles for EditProfile container accordance to mockup
(The width of EditProfile container wasn't fix, because  maxWidth shoutd be added to all page-content-containers together)
-Added styles for SidebarMenu component into separate style file
There no mockup for mobile

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/54ccaca5-7565-4048-ba15-d8cec13e30e1

Mockup

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/511c436f-cfde-40cc-af45-82776951b365)