### PR TITLE
Added sass package and configured script to compile it to css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-router-dom": "^6.18.0",
         "react-swipeable-views": "^0.14.0",
         "react-transition-group": "^4.4.5",
+        "sass": "^1.74.1",
         "simplebar-react": "^3.2.4",
         "vite-plugin-svgr": "^4.1.0",
         "web-vitals": "^3.5.0"
@@ -13764,7 +13765,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -14656,7 +14656,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -14879,7 +14878,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -15427,7 +15425,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -15454,7 +15451,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -19237,7 +19233,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -20868,6 +20863,11 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -21084,7 +21084,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -21257,7 +21256,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21323,7 +21321,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -21399,7 +21396,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -24152,7 +24148,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26208,7 +26203,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -27182,6 +27176,22 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.74.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.74.1.tgz",
+      "integrity": "sha512-w0Z9p/rWZWelb88ISOLyvqTWGmtmu2QJICqDBGyNnfG4OUnPX9BBjjYIXUpXCMOOg5MQWNpqzt876la1fsTvUA==",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/saxes": {
@@ -28732,7 +28742,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-router-dom": "^6.18.0",
     "react-swipeable-views": "^0.14.0",
     "react-transition-group": "^4.4.5",
+    "sass": "^1.74.1",
     "simplebar-react": "^3.2.4",
     "vite-plugin-svgr": "^4.1.0",
     "web-vitals": "^3.5.0"
@@ -94,7 +95,8 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -o build-story",
     "prepare": "husky install",
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "compile-scss": "node src/scss/src/scripts/compile-scss.js --logger"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/src/scss/src/scripts/compile-scss.js
+++ b/src/scss/src/scripts/compile-scss.js
@@ -1,0 +1,86 @@
+const fs = require('fs')
+const path = require('path')
+const sass = require('sass')
+
+const INPUT_FOLDER_PATH = path.resolve(__dirname, '..')
+const OUTPUT_FOLDER_PATH = path.resolve(__dirname, '..', '..', 'lib')
+const ATOMIC_DESIGN_FOLDERS = ['atoms', 'molecules', 'organisms']
+
+const CONSOLE_COLORS = {
+  green: '\x1b[32m',
+  gray: '\x1b[90m',
+  reset: '\x1b[0m',
+  white: '\x1b[37m'
+}
+
+// Example usage: "npm run scss-compile --logger --compact"
+const isLoggerEnabled = process.argv.includes('--logger')
+const isCompactCompilationStyle = process.argv.includes('--compact')
+
+if (!fs.existsSync(OUTPUT_FOLDER_PATH)) {
+  fs.mkdirSync(OUTPUT_FOLDER_PATH)
+}
+
+compile(
+  path.resolve(INPUT_FOLDER_PATH, 'global.scss'),
+  path.resolve(OUTPUT_FOLDER_PATH, 'global.css')
+)
+getComponents().forEach(({ inputFilePath, outputFilePath }) =>
+  compile(inputFilePath, outputFilePath)
+)
+
+function log(message, color = CONSOLE_COLORS.white) {
+  console.log(color, message, CONSOLE_COLORS.reset)
+}
+
+function compile(scssFilePath, cssFilePath) {
+  const result = sass.compile(scssFilePath, {
+    sourceMap: true,
+    style: isCompactCompilationStyle ? 'compressed' : 'expanded',
+    loadPaths: [INPUT_FOLDER_PATH]
+  })
+
+  fs.writeFileSync(cssFilePath, result.css)
+}
+
+function getComponents() {
+  const components = []
+
+  ATOMIC_DESIGN_FOLDERS.forEach((folder) => {
+    if (isLoggerEnabled) {
+      log(`[${folder}]`, CONSOLE_COLORS.green)
+    }
+
+    const folderByTypePath = path.resolve(INPUT_FOLDER_PATH, folder)
+    const files = fs.readdirSync(folderByTypePath)
+
+    for (const filePath of files) {
+      const isScssFile = path.extname(filePath) === '.scss'
+
+      if (!isScssFile) {
+        const filename = path.basename(filePath)
+        if (isLoggerEnabled) {
+          log(
+            `  [skip] "${filename}" is not a .scss file and won't be compiled!`,
+            CONSOLE_COLORS.gray
+          )
+        }
+        continue
+      }
+
+      if (isLoggerEnabled) {
+        log(`  [file] Compiling "${filePath}" file...`)
+      }
+
+      const inputFilePath = path.resolve(folderByTypePath, filePath)
+      const outputFilePath = path.resolve(
+        OUTPUT_FOLDER_PATH,
+        filePath.replace(/scss$/, 'css')
+      )
+
+      components.push({ inputFilePath, outputFilePath })
+    }
+  })
+
+  return components
+}


### PR DESCRIPTION
Added `sass` package (https://www.npmjs.com/package/sass) and created `compile-scss.js` script to compile `.scss` files to `.css`

### Usage:

`npm run compile-scss --logger --compact`


### Options:

- `--logger` (optional): adds pretty console logs to make debug of compiling a bit easier. Recommended to use in development

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/b23034a7-6fdb-4cae-93ab-b696f709217a)

> Files with extension different than `.scss` are skipped and not compiled.

- `--compact` (optional): minifies css. Recommended to use in production

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/8fbcd50a-366f-4b3c-a1fb-8f688b467c7e)

### Example:

Input `.scss` file (`atoms/Button.scss`):

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/260945f3-5fb2-4997-9862-1341fbaab295)

Output `.css` file (`lib/Button.css`) (without `--compact` option):

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/f53f299c-ebe4-416e-9447-851565b0a401)


