### PR TITLE
Added redirection after user logs in on authorization error page

### DIFF
--- a/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
+++ b/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
@@ -13,6 +13,9 @@ import loginImg from '~/assets/img/login-dialog/login.svg'
 import { login, snackbarVariants } from '~/constants'
 
 import styles from '~/containers/guest-home-page/login-dialog/LoginDialog.styles'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { errorRoutes } from '~/router/constants/errorRoutes'
+import { guestRoutes } from '~/router/constants/guestRoutes'
 
 const LoginDialog = () => {
   const { t } = useTranslation()
@@ -20,12 +23,18 @@ const LoginDialog = () => {
   const { setAlert } = useSnackBarContext()
   const [loginUser] = useLoginMutation()
 
+  const { pathname, state } = useLocation()
+  const navigate = useNavigate()
+
   const { handleSubmit, handleInputChange, handleBlur, data, errors } = useForm(
     {
       onSubmit: async () => {
         try {
           await loginUser(data).unwrap()
           closeModal()
+          if (pathname === errorRoutes.authPolicy.path) {
+            navigate(state?.prevPage || guestRoutes.home.path)
+          }
         } catch (e) {
           setAlert({
             severity: snackbarVariants.error,

--- a/src/router/helpers/PrivateRoute.tsx
+++ b/src/router/helpers/PrivateRoute.tsx
@@ -1,5 +1,10 @@
 import { FC } from 'react'
-import { Navigate, Outlet, useOutletContext } from 'react-router-dom'
+import {
+  Navigate,
+  Outlet,
+  useLocation,
+  useOutletContext
+} from 'react-router-dom'
 import { useAppSelector } from '~/hooks/use-redux'
 import { errorRoutes } from '~/router/constants/errorRoutes'
 import { UserRole } from '~/types'
@@ -12,8 +17,16 @@ const PrivateRoute: FC<PrivateRouteProps> = ({ role }) => {
   const context = useOutletContext()
   const { userRole } = useAppSelector((state) => state.appMain)
 
+  const { pathname, search } = useLocation()
+
   if (!userRole || !role.includes(userRole)) {
-    return <Navigate replace to={errorRoutes.authPolicy.path} />
+    return (
+      <Navigate
+        replace
+        state={{ prevPage: pathname + search }}
+        to={errorRoutes.authPolicy.path}
+      />
+    )
   }
 
   return <Outlet context={context} />

--- a/tests/unit/router/helpers/PrivateRoute.spec.jsx
+++ b/tests/unit/router/helpers/PrivateRoute.spec.jsx
@@ -22,14 +22,19 @@ const inappropriateState = {
   appMain: { usrRole: 'tutor' }
 }
 
+const properNavigateProps = {
+  replace: true,
+  to: '/error/401',
+  state: {
+    prevPage: '/'
+  }
+}
+
 describe('PrivateRoute component', () => {
   it('should navigate to error page (no user)', () => {
     renderWithProviders(<PrivateRoute role='student' />)
 
-    expect(Navigate).toHaveBeenCalledWith(
-      { replace: true, to: '/error/401' },
-      {}
-    )
+    expect(Navigate).toHaveBeenCalledWith(properNavigateProps, {})
   })
 
   it('should navigate to error page (inappropriate role)', () => {
@@ -37,10 +42,7 @@ describe('PrivateRoute component', () => {
       preloadedState: inappropriateState
     })
 
-    expect(Navigate).toHaveBeenCalledWith(
-      { replace: true, to: '/error/401' },
-      {}
-    )
+    expect(Navigate).toHaveBeenCalledWith(properNavigateProps, {})
   })
 
   it('should render outlet', () => {


### PR DESCRIPTION
- Passed `prevPage` to react-router's `Navigate` component that redirects user to Authorization error page, so `prevPage` value can be accessed later.
- Added user redirection after he logs in on Authorization error page. After login, the user will be redirected to the previous page (if the user was redirected to Authorization error page by `PrivateRoute` component), or to the index page (in case the user accessed `/error/401` directly through browser search field or a link).
- Added `prevPage` value to `PrivateRoute` props tests.

**Behaviour with redirection:**

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/7a065b7e-f9de-494a-9d00-f56c7303c999

