### PR TITLE
Fixed bug when find offer toolbar was not mapped correctly to search params

### DIFF
--- a/src/components/search-filter-input/SearchFilterInput.tsx
+++ b/src/components/search-filter-input/SearchFilterInput.tsx
@@ -36,7 +36,7 @@ const SearchFilterInput = ({
     updateFilter('')
   }
 
-  const onEnterPress = (event: KeyboardEvent<HTMLInputElement>) => {
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     event.key === 'Enter' && onSearch()
   }
 
@@ -45,16 +45,18 @@ const SearchFilterInput = ({
     return searchParams.get('search') ?? ''
   }
 
+  const searchParam = getSearchOfferParams()
+
   useEffect(() => {
-    setSearch(getSearchOfferParams())
-  }, [])
+    setSearch(searchParam)
+  }, [searchParam])
 
   return (
     <Box sx={styles.container}>
       <InputWithIcon
         onChange={onChange}
         onClear={onClear}
-        onKeyPress={onEnterPress}
+        onKeyDown={onKeyDown}
         startIcon={<SearchIcon sx={styles.searchIcon} />}
         sx={styles.input}
         value={search}

--- a/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.tsx
+++ b/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.tsx
@@ -83,7 +83,7 @@ const AddCourseTemplateModal: FC<AddCourseTemplateModalProps> = ({
     defaultResponse: defaultResponses.itemsWithCount
   })
 
-  const { updateFilterInQuery, resetFilters } = filterQueryActions
+  const { updateFiltersInQuery, resetFilters } = filterQueryActions
 
   const onSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value)
@@ -97,20 +97,19 @@ const AddCourseTemplateModal: FC<AddCourseTemplateModalProps> = ({
     _: SyntheticEvent,
     value: CategoryNameInterface | null
   ) => {
-    updateFilterInQuery(value?._id ?? '', 'category')
-    updateFilterInQuery('', 'subject')
+    updateFiltersInQuery({ category: value?._id ?? '', subject: '' })
   }
 
   const onSubjectChange = (
     _: SyntheticEvent,
     value: SubjectNameInterface | null
   ) => {
-    updateFilterInQuery(value?._id ?? '', 'subject')
+    updateFiltersInQuery({ subject: value?._id ?? '' })
   }
 
   const onLevelChange = (e: SelectChangeEvent<ProficiencyLevelEnum[]>) => {
     const selectedProficiencyLevels = e.target.value as ProficiencyLevelEnum[]
-    updateFilterInQuery(selectedProficiencyLevels, 'proficiencyLevel')
+    updateFiltersInQuery({ proficiencyLevel: selectedProficiencyLevels })
   }
 
   const onCreateCourse = () => {

--- a/src/containers/find-offer/filter-bar-menu/FilterBarMenu.tsx
+++ b/src/containers/find-offer/filter-bar-menu/FilterBarMenu.tsx
@@ -15,7 +15,7 @@ import { styles } from '~/containers/find-offer/filter-bar-menu/FilterBarMenu.st
 import {
   CardsView,
   FindOffersFilters,
-  FindOffersUpdateFilter,
+  UpdateFiltersInQuery,
   UserRoleEnum
 } from '~/types'
 import { sortTranslationKeys } from '~/containers/find-offer/offer-filter-block/OfferFilterBlock.constants'
@@ -26,19 +26,19 @@ interface FilterBarMenuProps {
   handleOffersView: (view: CardsView) => void
   offersView: CardsView
   onToggleTutorOffers: () => void
-  resetPage: () => void
-  updateFilter: FindOffersUpdateFilter<FindOffersFilters>
+  additionalParams: Record<string, unknown>
+  updateFilters: UpdateFiltersInQuery<FindOffersFilters>
   filters: FindOffersFilters
 }
 
 const FilterBarMenu: FC<FilterBarMenuProps> = ({
   chosenFiltersQty,
   toggleFilters,
-  updateFilter,
+  updateFilters,
   filters,
   handleOffersView,
   onToggleTutorOffers,
-  resetPage,
+  additionalParams,
   offersView
 }) => {
   const { isLaptopAndAbove, isMobile } = useBreakpoints()
@@ -57,8 +57,7 @@ const FilterBarMenu: FC<FilterBarMenuProps> = ({
   }
 
   const handleSortBy = (value: string) => {
-    updateFilter(value, 'sort')
-    resetPage()
+    updateFilters({ ...additionalParams, sort: value })
   }
   const sortOptions = sortTranslationKeys.map(({ title, value }) => ({
     title: t(title),

--- a/src/containers/find-offer/offer-filter-block/OfferFilterBlock.tsx
+++ b/src/containers/find-offer/offer-filter-block/OfferFilterBlock.tsx
@@ -24,7 +24,7 @@ interface OfferFilterBlockProps {
   filterActions: FindOffersFiltersActions<FindOffersFilters>
   onToggleTutorOffers: () => void
   closeFilters: () => void
-  resetPage: () => void
+  additionalParams: Record<string, unknown>
   open: boolean
   activeFilterCount?: number
   price: PriceRange
@@ -36,13 +36,14 @@ const OfferFilterBlock: FC<OfferFilterBlockProps> = ({
   onToggleTutorOffers,
   activeFilterCount,
   closeFilters,
-  resetPage,
+  additionalParams,
   open,
   price
 }) => {
   const { t } = useTranslation()
   const { isLaptopAndAbove } = useBreakpoints()
-  const { updateFilter, resetFilters, updateQueryParams } = filterActions
+  const { updateFiltersInQuery, resetFilters, updateQueryParams } =
+    filterActions
   const showingTutorOffers = filters.authorRole === UserRoleEnum.Student
 
   const switchOptions = {
@@ -59,12 +60,13 @@ const OfferFilterBlock: FC<OfferFilterBlockProps> = ({
 
   const updateFilterByKey =
     <K extends keyof FindOffersFilters>(key: K) =>
-    (value: FindOffersFilters[K]) =>
-      updateFilter(value, key)
+    (value: FindOffersFilters[K]) => {
+      updateFiltersInQuery({ [key]: value })
+    }
 
   const handleApplyFilters = () => {
     updateQueryParams()
-    resetPage()
+    updateFiltersInQuery(additionalParams)
     closeFilters()
   }
 
@@ -96,8 +98,8 @@ const OfferFilterBlock: FC<OfferFilterBlockProps> = ({
       <OfferFilterList
         filters={filters}
         price={price}
-        updateFilter={updateFilter}
         updateFilterByKey={updateFilterByKey}
+        updateFiltersInQuery={updateFiltersInQuery}
       />
       <AppButton onClick={handleApplyFilters} sx={styles.applyButton}>
         {t('button.applyFilters')}

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -15,23 +15,23 @@ import {
 import { styles } from '~/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.styles'
 import {
   FindOffersFilters,
-  FindOffersUpdateFilter,
   LanguageFilter,
   LanguagesEnum,
   PriceRange,
   ProficiencyLevelEnum,
+  UpdateFiltersInQuery,
   UpdateOfferFilterByKey
 } from '~/types'
 
 interface OfferFilterListProps {
   filters: FindOffersFilters
   updateFilterByKey: UpdateOfferFilterByKey
-  updateFilter: FindOffersUpdateFilter<FindOffersFilters>
+  updateFiltersInQuery: UpdateFiltersInQuery<FindOffersFilters>
   price: PriceRange
 }
 
 const OfferFilterList: FC<OfferFilterListProps> = ({
-  updateFilter,
+  updateFiltersInQuery,
   updateFilterByKey,
   filters,
   price
@@ -47,10 +47,10 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
   const handleLanguagesChange = (
     _: MouseEvent<HTMLLIElement>,
     value: LanguagesEnum | null
-  ) => updateFilter(value ?? '', 'language')
+  ) => updateFiltersInQuery({ language: value })
 
   const handleChecked = (_: SyntheticEvent<Element, Event>, checked: boolean) =>
-    updateFilter(checked.toString(), 'native')
+    updateFiltersInQuery({ native: checked.toString() })
 
   const languagesFilter = (
     <Box>

--- a/src/containers/find-offer/offer-search-toolbar/OfferSearchToolbar.tsx
+++ b/src/containers/find-offer/offer-search-toolbar/OfferSearchToolbar.tsx
@@ -22,17 +22,17 @@ import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
 interface OfferSearchToolbarProps {
   filters: FindOffersFilters
   filterActions: FindOffersFiltersActions<FindOffersFilters>
-  resetPage: () => void
+  additionalParams: Record<string, unknown>
 }
 
 const OfferSearchToolbar = ({
   filters,
-  resetPage,
+  additionalParams,
   filterActions
 }: OfferSearchToolbarProps) => {
   const { t } = useTranslation()
   const { isLaptopAndAbove, isMobile } = useBreakpoints()
-  const { updateFilterInQuery } = filterActions
+  const { updateFiltersInQuery } = filterActions
 
   const getSubjectsNames = useCallback(
     () => subjectService.getSubjectsNames(filters.categoryId),
@@ -43,22 +43,22 @@ const OfferSearchToolbar = ({
     _: React.SyntheticEvent,
     value: CategoryNameInterface | null
   ) => {
-    updateFilterInQuery(value?._id ?? '', 'categoryId')
-    updateFilterInQuery('', 'subjectId')
-    resetPage()
+    updateFiltersInQuery({
+      ...additionalParams,
+      subjectId: '',
+      categoryId: value?._id ?? ''
+    })
   }
 
   const onSubjectChange = (
     _: React.SyntheticEvent,
     value: SubjectNameInterface | null
   ) => {
-    updateFilterInQuery(value?._id ?? '', 'subjectId')
-    resetPage()
+    updateFiltersInQuery({ ...additionalParams, subjectId: value?._id ?? '' })
   }
 
   const updateName = (value: string) => {
-    updateFilterInQuery(value, 'search')
-    resetPage()
+    updateFiltersInQuery({ ...additionalParams, search: value })
   }
 
   const AppAutoCompleteList = (

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -100,28 +100,27 @@ const FindOffers = () => {
     })
   }, [fetchData, filters])
 
+  const searchString = searchParams.toString()
+
   useEffect(() => {
     updateInfo()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchData, searchParams, itemsPerPage, updateInfo])
+  }, [fetchData, searchString])
 
   const toggleFiltersOpen = () => (isOpen ? closeDrawer() : openDrawer())
 
-  const resetPage = () => {
-    filterQueryActions.updateFilterInQuery(
-      defaultFilters(oppositeRole).page,
-      'page'
-    )
-  }
+  const defaultParams = { page: defaultFilters(oppositeRole).page }
 
   const handlePageChange = (_: ChangeEvent<unknown>, page: number) => {
-    filterQueryActions.updateFilterInQuery(page, 'page')
+    filterQueryActions.updateFiltersInQuery({ page })
   }
 
   const handleShowingTutorOffers = () => {
     const updatedRole = getOpositeRole(filters.authorRole)
-    filterQueryActions.updateFilterInQuery(updatedRole, 'authorRole')
-    resetPage()
+    filterQueryActions.updateFiltersInQuery({
+      ...defaultParams,
+      authorRole: updatedRole
+    })
   }
 
   return (
@@ -140,19 +139,19 @@ const FindOffers = () => {
         />
       </Box>
       <OfferSearchToolbar
+        additionalParams={defaultParams}
         filterActions={filterQueryActions}
         filters={filters}
-        resetPage={resetPage}
       />
       <FilterBarMenu
+        additionalParams={defaultParams}
         chosenFiltersQty={activeFilterCount}
         filters={filters}
         handleOffersView={setCardsView}
         offersView={cardsView}
         onToggleTutorOffers={handleShowingTutorOffers}
-        resetPage={resetPage}
         toggleFilters={toggleFiltersOpen}
-        updateFilter={filterQueryActions.updateFilterInQuery}
+        updateFilters={filterQueryActions.updateFiltersInQuery}
       />
       <Box sx={styles.filterSection}>
         <AppDrawer
@@ -162,13 +161,13 @@ const FindOffers = () => {
         >
           <OfferFilterBlock
             activeFilterCount={activeFilterCount}
+            additionalParams={defaultParams}
             closeFilters={closeDrawer}
             filterActions={filterQueryActions}
             filters={filters}
             onToggleTutorOffers={handleShowingTutorOffers}
             open={isOpen}
             price={price}
-            resetPage={resetPage}
           />
         </AppDrawer>
         {offersLoading ? (

--- a/src/types/findOffers/interfaces/findOffers.interfaces.ts
+++ b/src/types/findOffers/interfaces/findOffers.interfaces.ts
@@ -1,13 +1,13 @@
 import {
   CategoryInterface,
   CategoryNameInterface,
-  FindOffersUpdateFilter,
   LanguageFilter,
   Offer,
   ProficiencyLevelEnum,
   RangeArray,
   RequestParams,
   SubjectNameInterface,
+  UpdateFiltersInQuery,
   UserRole
 } from '~/types'
 
@@ -26,8 +26,7 @@ export interface FindOffersFilters {
 }
 
 export interface FindOffersFiltersActions<T> {
-  updateFilter: FindOffersUpdateFilter<T>
-  updateFilterInQuery: FindOffersUpdateFilter<T>
+  updateFiltersInQuery: UpdateFiltersInQuery<T>
   resetFilters: () => void
   updateQueryParams: () => void
 }

--- a/src/types/findOffers/types/findOffers.types.ts
+++ b/src/types/findOffers/types/findOffers.types.ts
@@ -1,11 +1,8 @@
 import { CardsViewEnum, FindOffersFilters, LanguagesEnum } from '~/types'
 
 export type CardsView = CardsViewEnum.Grid | CardsViewEnum.Inline
-export type LanguageFilter = LanguagesEnum | ''
-export type FindOffersUpdateFilter<T> = <K extends keyof T>(
-  value: T[K],
-  key: K
-) => void
+export type LanguageFilter = LanguagesEnum | null
+export type UpdateFiltersInQuery<T> = (filtersToUpdate: Partial<T>) => void
 export type FilterFromQuery = {
   [key: string]: string | string[]
 }

--- a/tests/unit/containers/find-offer/filter-bar-menu/FilterBarMenu.spec.jsx
+++ b/tests/unit/containers/find-offer/filter-bar-menu/FilterBarMenu.spec.jsx
@@ -9,7 +9,7 @@ import useBreakpoints from '~/hooks/use-breakpoints'
 vi.mock('~/hooks/use-breakpoints')
 
 const mockChosenFiltersQty = 2
-const mockUpdateFilter = vi.fn()
+const mockUpdateFilters = vi.fn()
 const mockResetPage = vi.fn()
 const toggleFilters = vi.fn()
 const mockHandleOffersView = vi.fn()
@@ -26,7 +26,7 @@ describe('OfferFilterBlock', () => {
         onToggleTutorOffers={mockOnToggleTutorOffers}
         resetPage={mockResetPage}
         toggleFilters={toggleFilters}
-        updateFilter={mockUpdateFilter}
+        updateFilters={mockUpdateFilters}
       />
     )
   })
@@ -48,7 +48,7 @@ describe('OfferFilterBlock', () => {
       target: { value: 'rating' }
     })
 
-    expect(mockUpdateFilter).toHaveBeenCalled()
+    expect(mockUpdateFilters).toHaveBeenCalled()
   })
   it('it checks that app switcher exists on desktop size', () => {
     expect(screen.getByTestId('switch')).toBeInTheDocument()
@@ -65,7 +65,7 @@ describe('OfferBarMenu tests on tablet size', () => {
         handleOffersView={mockHandleOffersView}
         onToggleTutorOffers={mockOnToggleTutorOffers}
         toggleFilters={toggleFilters}
-        updateFilter={mockUpdateFilter}
+        updateFilter={mockUpdateFilters}
       />
     )
   })
@@ -85,7 +85,7 @@ describe('OfferBarMenu tests on mobile size', () => {
         handleOffersView={mockHandleOffersView}
         onToggleTutorOffers={mockOnToggleTutorOffers}
         toggleFilters={toggleFilters}
-        updateFilter={mockUpdateFilter}
+        updateFilter={mockUpdateFilters}
       />
     )
   })

--- a/tests/unit/containers/find-offer/offer-filter-block/OfferFilterBlock.spec.jsx
+++ b/tests/unit/containers/find-offer/offer-filter-block/OfferFilterBlock.spec.jsx
@@ -8,7 +8,7 @@ import useBreakpoints from '~/hooks/use-breakpoints'
 vi.mock('~/hooks/use-breakpoints')
 
 const filterActions = {
-  updateFilter: vi.fn(),
+  updateFiltersInQuery: vi.fn(),
   resetFilters: vi.fn(),
   updateQueryParams: vi.fn()
 }
@@ -16,7 +16,7 @@ const filterActions = {
 const price = { minPrice: 200, maxPrice: 400 }
 const onToggleTutorOffers = vi.fn()
 const closeFilters = vi.fn()
-const resetPage = vi.fn()
+const additionalParams = {}
 const activeFilterCount = 2
 const open = true
 useBreakpoints.mockImplementation(() => ({ isMobile: true }))
@@ -27,13 +27,13 @@ describe('OfferFilterBlock', () => {
       render(
         <OfferFilterBlock
           activeFilterCount={activeFilterCount}
+          additionalParams={additionalParams}
           closeFilters={closeFilters}
           filterActions={filterActions}
           filters={defaultFilters('student')}
           onToggleTutorOffers={onToggleTutorOffers}
           open={open}
           price={price}
-        resetPage={resetPage}
         />
       )
     })

--- a/tests/unit/containers/find-offer/offer-search-toolbar/offerSearchToolbar.spec.jsx
+++ b/tests/unit/containers/find-offer/offer-search-toolbar/offerSearchToolbar.spec.jsx
@@ -7,7 +7,7 @@ import { defaultFilters } from '~/pages/find-offers/FindOffers.constants'
 
 vi.mock('~/hooks/use-breakpoints')
 const filterActions = {
-  updateFilterInQuery: vi.fn()
+  updateFiltersInQuery: vi.fn()
 }
 const filters = defaultFilters('student')
 const resetPage = vi.fn()

--- a/tests/unit/pages/find-offers/FindOffers.spec.jsx
+++ b/tests/unit/pages/find-offers/FindOffers.spec.jsx
@@ -38,7 +38,7 @@ const filterQueryMock = {
     updateFilter: vi.fn(),
     resetFilters: vi.fn(),
     updateQueryParams: vi.fn(),
-    updateFilterInQuery: vi.fn()
+    updateFiltersInQuery: vi.fn()
   }
 }
 
@@ -95,7 +95,7 @@ describe('FindOffers component', () => {
     fireEvent.click(toggle)
 
     expect(
-      filterQueryMock.filterQueryActions.updateFilterInQuery
+      filterQueryMock.filterQueryActions.updateFiltersInQuery
     ).toHaveBeenCalled()
   })
 
@@ -134,7 +134,7 @@ describe('FindOffers component', () => {
     fireEvent.click(secondPage)
 
     expect(
-      filterQueryMock.filterQueryActions.updateFilterInQuery
+      filterQueryMock.filterQueryActions.updateFiltersInQuery
     ).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
State in toolbar is now synchronized with search params as shown in the video below (also works for both tutor's and student's requests):

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/63422792-15af-45d1-ad9c-57f805733394


The first thing, that caused problems was `updateFilterInQuery` method. There were several places where they were called consequently like following:

```jsx
updateFilterInQuery(value?._id ?? '', 'category')
updateFilterInQuery('', 'subject')
```

It caused problems, because browser url was changed twice (via `setSearchParams` call). As a result, the connection between history and state was lost. So I had to set all required search params per one action
To fix this bug I refactored method for updating filters as following:

```jsx
updateFiltersInQuery({ category: value?._id ?? '', subject: '' })
```

This method can accept as many filters as you want and it is type safe.
Also I deleted old method to avoid same issues in future.

Also I updated types and tests