### PR TITLE
Improve coverage for the QuestionEditor component

### DIFF
--- a/src/components/question-editor/QuestionEditor.tsx
+++ b/src/components/question-editor/QuestionEditor.tsx
@@ -74,7 +74,7 @@ const QuestionEditor: FC<QuestionEditorProps> = ({
   }))
 
   const setTypeValue = (value: string) => {
-    handleNonInputValueChange('type', value ?? sortQuestions[0].value)
+    handleNonInputValueChange('type', value)
   }
 
   const sortOptions = sortQuestions.map(({ icon, title, value }) => ({
@@ -217,7 +217,11 @@ const QuestionEditor: FC<QuestionEditorProps> = ({
       {isSingleChoice && <RadioGroup sx={styles.group}>{options}</RadioGroup>}
 
       {!isOpenAnswer && (
-        <Box onClick={addNewOneAnswer} sx={styles.addRadio(isEmptyAnswer)}>
+        <Box
+          data-testid='addNewAnswerBtn'
+          onClick={addNewOneAnswer}
+          sx={styles.addRadio(isEmptyAnswer)}
+        >
           <FormControlLabel
             checked={false}
             control={isMultipleChoice ? <Checkbox /> : <Radio />}

--- a/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -1,33 +1,43 @@
 import QuestionEditor from '~/components/question-editor/QuestionEditor'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '~tests/test-utils'
-import { beforeEach, describe } from 'vitest'
+import { afterEach, beforeEach, describe, expect } from 'vitest'
 
-const data = {
-  type: 'openAnswer',
-  title: 'question 1',
-  category: null,
-  text: '',
-  openAnswer: '',
-  answers: []
-}
 const handleInputChange = vi.fn()
 const handleNonInputValueChange = vi.fn()
 const onEditMock = vi.fn()
+const onSave = vi.fn()
 
 const props = {
-  data,
   handleInputChange,
   handleNonInputValueChange,
   onCancel: vi.fn(),
   onEdit: onEditMock,
-  onSave: vi.fn(),
+  onSave,
   isQuizQuestion: true
 }
 
-describe('QuestionEditor component', () => {
+describe('QuestionEditor component with an open question type', () => {
+  const openQuestionData = {
+    type: 'openAnswer',
+    title: 'question 1',
+    category: null,
+    text: 'question text',
+    openAnswer: 'answer',
+    answers: []
+  }
+
+  const openQuestionProps = {
+    ...props,
+    data: openQuestionData
+  }
+
   beforeEach(() => {
-    renderWithProviders(<QuestionEditor {...props} />)
+    renderWithProviders(<QuestionEditor {...openQuestionProps} />)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should renders question input field', () => {
@@ -92,5 +102,126 @@ describe('QuestionEditor component', () => {
     fireEvent.click(updateIcon)
 
     expect(onEditMock).toHaveBeenCalled()
+  })
+
+  it('should save the question', () => {
+    const saveButton = screen.getByRole('button', { name: 'common.save' })
+
+    fireEvent.click(saveButton)
+
+    expect(onSave).toHaveBeenCalled()
+  })
+})
+
+describe('QuestionEditor component with a multiple choice question type', () => {
+  const multipleChoiceData = {
+    type: 'multipleChoice',
+    title: 'Question 2',
+    category: null,
+    text: 'Question',
+    openAnswer: '',
+    answers: [{ text: 'Answer 1' }, { text: 'Answer 2' }]
+  }
+
+  const multipleChoiceProps = {
+    ...props,
+    data: multipleChoiceData
+  }
+
+  beforeEach(() => {
+    renderWithProviders(<QuestionEditor {...multipleChoiceProps} />)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render answer options', () => {
+    const answerInput = screen.getByDisplayValue('Answer 1')
+
+    expect(answerInput).toBeInTheDocument()
+  })
+
+  it('should change the answer field value', () => {
+    const answerInput = screen.getByDisplayValue('Answer 1')
+
+    fireEvent.change(answerInput, {
+      target: { value: 'New answer' }
+    })
+
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+
+  it('should change the checkbox state', () => {
+    const [answerCheckbox] = screen.getAllByRole('checkbox')
+
+    fireEvent.click(answerCheckbox)
+
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+
+  it('should add a new answer', () => {
+    const addNewAnswer = screen.getByTestId('addNewAnswerBtn')
+
+    fireEvent.click(addNewAnswer)
+
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+
+  it('should delete an answer', () => {
+    const [deleteAnswerBtn] = screen.getAllByTestId('CloseIcon')
+
+    fireEvent.click(deleteAnswerBtn)
+
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+
+  it('should change question type and answers accordingly', () => {
+    const appSelect = screen.getByTestId('app-select')
+
+    fireEvent.click(appSelect)
+    fireEvent.change(appSelect, {
+      target: { value: 'oneAnswer' }
+    })
+
+    expect(handleNonInputValueChange).toHaveBeenCalled()
+  })
+})
+
+describe('QuestionEditor component with a single choice question type', () => {
+  const singleChoiceData = {
+    type: 'oneAnswer',
+    title: 'Question 3',
+    category: null,
+    text: 'Question',
+    openAnswer: '',
+    answers: [{ text: 'Answer 1' }, { text: 'Answer 2' }]
+  }
+
+  const singleChoiceProps = {
+    ...props,
+    data: singleChoiceData
+  }
+
+  beforeEach(() => {
+    renderWithProviders(<QuestionEditor {...singleChoiceProps} />)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render answer options', () => {
+    const answerInput = screen.getByDisplayValue('Answer 1')
+
+    expect(answerInput).toBeInTheDocument()
+  })
+
+  it('should change the radio input state', () => {
+    const [answerRadio] = screen.getAllByRole('radio')
+
+    fireEvent.click(answerRadio)
+
+    expect(handleNonInputValueChange).toHaveBeenCalled()
   })
 })

--- a/tests/unit/components/question-editor/QuestionEditor.spec.jsx
+++ b/tests/unit/components/question-editor/QuestionEditor.spec.jsx
@@ -1,7 +1,6 @@
 import QuestionEditor from '~/components/question-editor/QuestionEditor'
 import { screen, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '~tests/test-utils'
-import { afterEach, beforeEach, describe, expect } from 'vitest'
 
 const handleInputChange = vi.fn()
 const handleNonInputValueChange = vi.fn()


### PR DESCRIPTION
Added tests for the `QuestionEditor` component to improve coverage.

In `QuestionEditor.tsx`:
- had to add `data-testid='addNewAnswerBtn'` to test the function, since there's no other way to get this element
- remove the unnecessary nullish operator in the `setTypeValue` function, since we don't expect any other type of `value` exept `string`

<img width="1704" alt="Screenshot 2024-04-10 at 11 58 59" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/110097862/b09c8c07-ee4e-44ef-9987-1a21e1f0435a">
