### PR TITLE
Added breakpoints and spacings to design system variables

### DIFF
--- a/src/scss/src/foundation/_variables.scss
+++ b/src/scss/src/foundation/_variables.scss
@@ -258,6 +258,42 @@ $tt: (
 =                BREAKPOINTS                  =
 =============================================*/
 
-/* Breakpoints */
+$mobile: 25.875rem; // 414px
+$tablet: 55rem; // 880px
+$desktop: 90rem; // 1440px
+
+$breakpoints: (
+  mobile: $mobile,
+  tablet: $tablet,
+  desktop: $desktop
+);
+
+/*=============================================
+=                  SPACING                   =
+=============================================*/
+
+$spacing-none: 0;
+$spacing-xxxs: 0.25rem; // 4px
+$spacing-xxs: 0.5rem; // 8px
+$spacing-xs: 0.75rem; // 12px
+$spacing-sm: 1rem; // 16px
+$spacing-md: 1.5rem; // 24px
+$spacing-lg: 2rem; // 32px
+$spacing-xl: 3rem; // 48px
+$spacing-2xl: 4.5rem; // 72px
+$spacing-3xl: 6rem; // 96px
+
+$spacing: (
+  none: $spacing-none,
+  xxxs: $spacing-xxxs,
+  xxs: $spacing-xxs,
+  xs: $spacing-xs,
+  sm: $spacing-sm,
+  md: $spacing-md,
+  lg: $spacing-lg,
+  xl: $spacing-xl,
+  2xl: $spacing-2xl,
+  3xl: $spacing-3xl
+);
 
 /*=====  End of BREAKPOINTS  ======*/


### PR DESCRIPTION
- [x] Added variables for breakpoints to file `_variables.scss`.

### Structure of variables:
I organized the structure of variables as following (`breakpoints` example):

```scss
$mobile: 25.875rem; // 414px
$tablet: 55rem; // 880px
$desktop: 90rem; // 1440px

$breakpoints: (
  mobile: $mobile,
  tablet: $tablet,
  desktop: $desktop
);
```

I created a `map` for every variable set for futher usage inside scss `mixins` or `loops` to generate classes.

### Example of possible usage (after defining `mixins` in #1771):

`.scss` file:

```scss
@mixin tablet {
  @media (min-width: map-get($breakpoints, 'tablet')) {
    @content;
  }
}

@mixin desktop {
  @media (min-width: map-get($breakpoints, 'desktop')) {
    @content;
  }
}

@mixin padding($space) {
  padding: map-get($spacing, $space);
}

.test {
  color: black;
  @include padding('md');

  @include tablet {
    color: blue;
  }
  @include desktop {
    color: red;
  }
}
```

Compiled `.css` file:

```scss
.test {
  color: black;
  padding: 1.5rem;
}
@media (min-width: 55rem) {
  .test {
    color: blue;
  }
}
@media (min-width: 90rem) {
  .test {
    color: red;
  }
}
```