### PR TITLE
Changed video presentation behaviour

### DIFF
--- a/src/pages/tutor-profile/TutorProfile.jsx
+++ b/src/pages/tutor-profile/TutorProfile.jsx
@@ -16,6 +16,8 @@ import { defaultResponses } from '~/constants'
 import { responseMock } from '~/pages/tutor-profile/constants'
 import AboutTutorBlock from '~/containers/tutor-profile/about-tutor-block/AboutTutorBlock'
 
+import { UserRoleEnum } from '~/types'
+
 const TutorProfile = () => {
   const { id } = useParams()
   const [searchParams] = useSearchParams()
@@ -25,9 +27,12 @@ const TutorProfile = () => {
 
   const { userId, userRole } = useAppSelector((state) => state.appMain)
 
+  const preferredRole = paramsRole || userRole
+  const preferredId = id || userId
+
   const getUserData = useCallback(
-    () => userService.getUserById(id || userId, paramsRole || userRole),
-    [userId, userRole, id, paramsRole]
+    () => userService.getUserById(preferredId, preferredRole),
+    [preferredId, preferredRole]
   )
 
   const { loading, response } = useAxios({
@@ -40,12 +45,16 @@ const TutorProfile = () => {
     return <Loader pageLoad size={70} />
   }
 
+  const isTutor = preferredRole === UserRoleEnum.Tutor
+  const shouldShowPresentation =
+    isTutor || (!isTutor && response.videoLink?.student)
+
   return (
     <PageWrapper>
       <ProfileInfo myRole={userRole} userData={response} />
       <CompleteProfileBlock data={response} profileItems={profileItems} />
       <AboutTutorBlock />
-      <VideoPresentation />
+      {shouldShowPresentation && <VideoPresentation />}
       <CommentsWithRatingBlock
         averageRating={response?.averageRating?.tutor}
         reviewsCount={reviews}


### PR DESCRIPTION
- Added conditions, so if profile's owner is tutor, VideoPresentation will always be shown. If owner is student, than VideoPresentation will be shown only if he has videoLink.
- Added test cases.

Behaviour in video, firstly for student without video link then after link was added. Also for tutor without link. 

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/12acf3f0-7e02-4dc5-a548-5e062c746e6d



