### PR TITLE
Add coverage for cooperation notes and cooperation activities list

### DIFF
--- a/src/containers/my-cooperations/cooperation-notes/CooperationNotes.tsx
+++ b/src/containers/my-cooperations/cooperation-notes/CooperationNotes.tsx
@@ -35,7 +35,7 @@ const CooperationNotes = () => {
     (error: ErrorResponse) => {
       setAlert({
         severity: snackbarVariants.error,
-        message: `errors.${error.message}`
+        message: error ? `errors.${error.message}` : ''
       })
     },
     [setAlert]

--- a/src/containers/my-cooperations/cooperation-notes/CooperationNotes.tsx
+++ b/src/containers/my-cooperations/cooperation-notes/CooperationNotes.tsx
@@ -35,7 +35,7 @@ const CooperationNotes = () => {
     (error: ErrorResponse) => {
       setAlert({
         severity: snackbarVariants.error,
-        message: error ? `errors.${error.message}` : ''
+        message: `errors.${error.message}`
       })
     },
     [setAlert]

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
@@ -1,43 +1,226 @@
-import { screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import CooperationActivitiesList from '~/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList'
 import { renderWithProviders } from '~tests/test-utils'
+import { sectionInitialData } from '~/pages/create-course/CreateCourse.constants'
 
-const mockedData = {
+const originalDateNow = Date.now
+Date.now = () => 1487076708000
+
+const { useCooperationContextMock } = vi.hoisted(() => {
+  return {
+    useCooperationContextMock: vi.fn()
+  }
+})
+
+vi.mock('~/context/cooperation-context', async () => {
+  const actual = await vi.importActual('~/context/cooperation-context')
+  return {
+    ...actual,
+    useCooperationContext: useCooperationContextMock
+  }
+})
+
+const mockedCourseData = {
+  title: 'Course title',
+  description: 'Course description',
   sections: [
     {
-      title: 'Section1 title',
-      description: 'Section1 description',
+      title: 'Course section1 title',
+      description: 'Course section1 description',
       lessons: [],
       quizzes: [],
       attachments: [],
-      id: '17121748017180'
-    },
-    {
-      title: 'Section2 title',
-      description: 'Section2 description',
-      lessons: [],
-      quizzes: [],
-      attachments: [],
-      id: '17121748017181'
+      id: '17121748017182'
     }
   ]
 }
 
-describe('CooperationActivitiesList', () => {
+const handleNonInputValueChange = vi.fn()
+
+const renderWithMockData = (
+  mockedData,
+  sectionIndex,
+  isAddedClicked = true
+) => {
+  useCooperationContextMock.mockReturnValue({
+    selectedCourse: mockedCourseData,
+    isAddedClicked: isAddedClicked,
+    currentSectionIndex: sectionIndex,
+    setCurrentSectionIndex: vi.fn()
+  })
+
+  renderWithProviders(
+    <CooperationActivitiesList
+      data={mockedData}
+      handleNonInputValueChange={handleNonInputValueChange}
+    />
+  )
+}
+
+describe('CooperationActivitiesList with section data', () => {
+  const mockedSectionsData = {
+    sections: [
+      {
+        title: 'Section1 title',
+        description: 'Section1 description',
+        order: ['66183816fb40f35f91bb77ce'],
+        lessons: [
+          {
+            _id: '66183816fb40f35f91bb77ce',
+            title: 'Lesson 1',
+            description: 'Lesson 1 description',
+            content: 'Lesson 1 content',
+            resourceType: 'lessons'
+          }
+        ],
+        quizzes: [],
+        attachments: [],
+        id: '17121748017180'
+      },
+      {
+        title: 'Section2 title',
+        description: 'Section2 description',
+        lessons: [],
+        quizzes: [],
+        attachments: [],
+        id: '17121748017181'
+      }
+    ]
+  }
+
+  beforeEach(() => {
+    renderWithMockData(mockedSectionsData, 0)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should add a new section when Add activity button is clicked', async () => {
-    renderWithProviders(<CooperationActivitiesList data={mockedData} />)
-    const hoverElement = await screen.findAllByTestId('addActivity-container')
+    const [hoverElement] = await screen.findAllByTestId('addActivity-container')
+    fireEvent.mouseOver(hoverElement)
 
-    fireEvent.mouseOver(hoverElement[0])
+    const [addButton] = screen.getAllByText('Add activity')
+    fireEvent.click(addButton)
 
-    const addButton = screen.getAllByText('Add activity')
-
-    fireEvent.click(addButton[0])
-    const menuItem = await screen.findAllByText(
+    const [menuItem] = await screen.findAllByText(
       'cooperationsPage.manyTypes.module'
     )
-    fireEvent.click(menuItem[0])
+    fireEvent.click(menuItem)
+
     const sections = await screen.findAllByTestId('addActivity-container')
     expect(sections.length).toBe(2)
+  })
+
+  it('should delete section resource', async () => {
+    await waitFor(() => {
+      const deleteResourceBtn = screen.getByTestId('CloseIcon').parentElement
+      fireEvent.click(deleteResourceBtn)
+    })
+
+    const resource = screen.queryByText('Lesson 1 description')
+
+    await waitFor(() => {
+      expect(resource).not.toBeInTheDocument()
+    })
+  })
+
+  it('should change the activity title', async () => {
+    const titleInput = await screen.findByDisplayValue(
+      mockedSectionsData.sections[0].title
+    )
+    const newTitle = 'New section title'
+
+    fireEvent.blur(titleInput, {
+      target: { value: newTitle }
+    })
+
+    await waitFor(() => {
+      expect(titleInput.value).toBe(newTitle)
+    })
+  })
+
+  it('should set sections from the data first in order if the current section index is undefined', async () => {
+    renderWithMockData(mockedSectionsData, undefined)
+
+    const newSectionData = mockedCourseData.sections.map((section, index) => ({
+      ...section,
+      id: Date.now().toString() + index
+    }))
+    const newSections = [...mockedSectionsData.sections, ...newSectionData]
+
+    await waitFor(() => {
+      expect(handleNonInputValueChange).toHaveBeenCalledWith(
+        'sections',
+        newSections
+      )
+    })
+  })
+
+  it('should set sections from the data first in order if a new section index is null', async () => {
+    renderWithMockData(mockedSectionsData, null)
+
+    const [hoverElement] = await screen.findAllByTestId('addActivity-container')
+    fireEvent.mouseOver(hoverElement)
+
+    const [addButton] = screen.getAllByText('Add activity')
+    fireEvent.click(addButton)
+
+    const [menuItem] = await screen.findAllByText(
+      'cooperationsPage.manyTypes.module'
+    )
+    fireEvent.click(menuItem)
+
+    const newSectionData = { ...sectionInitialData }
+    newSectionData.id = Date.now().toString()
+    const newSections = [...mockedSectionsData.sections, newSectionData]
+
+    await waitFor(() => {
+      expect(handleNonInputValueChange).toHaveBeenCalledWith(
+        'sections',
+        newSections
+      )
+    })
+  })
+})
+
+describe('CooperationActivitiesList without section data', () => {
+  const mockedSectionsData = {
+    sections: []
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should set only selected course sections in the data when no section was added', async () => {
+    renderWithMockData(mockedSectionsData, 0)
+
+    const allSections = mockedCourseData.sections.map((section, index) => ({
+      ...section,
+      id: Date.now().toString() + index
+    }))
+
+    await waitFor(() => {
+      expect(handleNonInputValueChange).toHaveBeenCalledWith(
+        'sections',
+        allSections
+      )
+    })
+  })
+
+  it('should add a new section when no section was added and no course was selected', async () => {
+    renderWithMockData(mockedSectionsData, 0, false)
+
+    const newSectionData = { ...sectionInitialData }
+    newSectionData.id = Date.now().toString()
+
+    await waitFor(() => {
+      expect(handleNonInputValueChange).toHaveBeenCalledWith('sections', [
+        newSectionData
+      ])
+    })
+
+    Date.now = originalDateNow
   })
 })

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
@@ -220,7 +220,5 @@ describe('CooperationActivitiesList without section data', () => {
         newSectionData
       ])
     })
-
-    console.log('newSectionData: ', newSectionData)
   })
 })

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
@@ -6,17 +6,13 @@ import { sectionInitialData } from '~/pages/create-course/CreateCourse.constants
 const originalDateNow = Date.now
 Date.now = () => 1487076708000
 
-const { useCooperationContextMock } = vi.hoisted(() => {
-  return {
-    useCooperationContextMock: vi.fn()
-  }
-})
+const useCooperationContextMock = vi.fn()
 
 vi.mock('~/context/cooperation-context', async () => {
   const actual = await vi.importActual('~/context/cooperation-context')
   return {
     ...actual,
-    useCooperationContext: useCooperationContextMock
+    useCooperationContext: () => useCooperationContextMock()
   }
 })
 
@@ -193,6 +189,10 @@ describe('CooperationActivitiesList without section data', () => {
     vi.clearAllMocks()
   })
 
+  afterAll(() => {
+    Date.now = originalDateNow
+  })
+
   it('should set only selected course sections in the data when no section was added', async () => {
     renderWithMockData(mockedSectionsData, 0)
 
@@ -221,6 +221,6 @@ describe('CooperationActivitiesList without section data', () => {
       ])
     })
 
-    Date.now = originalDateNow
+    console.log('newSectionData: ', newSectionData)
   })
 })

--- a/tests/unit/containers/my-cooperations/cooperation-notes/CooperationNotes.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-notes/CooperationNotes.spec.jsx
@@ -2,6 +2,9 @@ import { screen, fireEvent, act, waitFor } from '@testing-library/react'
 import CooperationNotes from '~/containers/my-cooperations/cooperation-notes/CooperationNotes'
 import { renderWithProviders } from '~tests/test-utils'
 import { CooperationNotesService } from '~/services/cooperation-service'
+import { ConfirmationDialogProvider } from '~/context/confirm-context'
+
+vi.mock('~/services/cooperation-service')
 
 const mockNotesData = [
   {
@@ -32,15 +35,21 @@ const mockNotesData = [
   }
 ]
 
-vi.mock('~/services/cooperation-service', () => ({
-  CooperationNotesService: {
-    getNotes: vi.fn()
-  }
-}))
+const userState = {
+  appMain: { userRole: 'tutor', userId: mockNotesData[0].author._id }
+}
 
 describe('CooperationNotes', () => {
-  beforeEach(async () => {
-    await waitFor(() => renderWithProviders(<CooperationNotes />))
+  beforeEach(() => {
+    CooperationNotesService.getNotes.mockResolvedValue({
+      data: mockNotesData
+    })
+    renderWithProviders(
+      <ConfirmationDialogProvider>
+        <CooperationNotes />
+      </ConfirmationDialogProvider>,
+      { preloadedState: userState }
+    )
   })
 
   it('should render CooperationNotes components', () => {
@@ -49,7 +58,7 @@ describe('CooperationNotes', () => {
     expect(notes).toBeInTheDocument()
   })
 
-  it('should open create note form', () => {
+  it('should open create note form and save the note', async () => {
     const addNoteBtn = screen.getByTestId('AddIcon')
 
     act(() => fireEvent.click(addNoteBtn))
@@ -59,10 +68,27 @@ describe('CooperationNotes', () => {
     )
 
     expect(noteFormSettings).toBeInTheDocument()
-  })
 
-  it('fetches data successfully', () => {
-    CooperationNotesService.getNotes.mockResolvedValue({ data: mockNotesData })
+    const noteTextInput = screen.getByLabelText(
+      'cooperationsPage.notes.noteText'
+    )
+    const saveButton = screen.getByRole('button', { name: 'common.save' })
+
+    act(() =>
+      fireEvent.change(noteTextInput, {
+        target: { value: 'Newly created note' }
+      })
+    )
+    act(() => fireEvent.click(saveButton))
+
+    CooperationNotesService.createNote.mockResolvedValue({
+      data: mockNotesData
+    })
+
+    await waitFor(() => {
+      const newNoteText = screen.getByText('Newly created note')
+      expect(newNoteText).toBeInTheDocument()
+    })
   })
 
   it('should close create note form', () => {
@@ -79,5 +105,82 @@ describe('CooperationNotes', () => {
     )
 
     expect(noteFormSettings).toBeNull()
+  })
+
+  it('should enable the edit mode and handle updates', () => {
+    const [menuButton] = screen.getAllByTestId('MoreVertIcon')
+
+    act(() => fireEvent.click(menuButton))
+
+    const editButton = screen.getByTestId('EditIcon')
+
+    act(() => fireEvent.click(editButton))
+
+    const [noteTextInput] = screen.getAllByDisplayValue(mockNotesData[0].text)
+    const saveButton = screen.getByRole('button', { name: 'common.save' })
+
+    act(() =>
+      fireEvent.change(noteTextInput, { target: { value: 'New note text' } })
+    )
+    act(() => fireEvent.click(saveButton))
+
+    CooperationNotesService.updateNote.mockResolvedValue({
+      data: mockNotesData
+    })
+
+    const newNoteText = screen.getByText('New note text')
+
+    expect(newNoteText).toBeInTheDocument()
+  })
+
+  it('should handle duplicate notes', async () => {
+    const [menuButton] = screen.getAllByTestId('MoreVertIcon')
+
+    act(() => fireEvent.click(menuButton))
+
+    const duplicateButton = screen.getByTestId('ContentCopyIcon')
+
+    act(() => fireEvent.click(duplicateButton))
+
+    await waitFor(() => {
+      expect(duplicateButton).not.toBeInTheDocument()
+    })
+  })
+
+  it('should handle delete notes', async () => {
+    const [menuButton] = screen.getAllByTestId('MoreVertIcon')
+
+    act(() => fireEvent.click(menuButton))
+
+    const deleteButton = screen.getByTestId('DeleteOutlineIcon')
+
+    act(() => fireEvent.click(deleteButton))
+
+    const confirmButton = screen.getByRole('button', { name: 'common.yes' })
+
+    act(() => fireEvent.click(confirmButton))
+
+    await waitFor(() => {
+      expect(confirmButton).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('CooperationNotes with error', () => {
+  const fakeError = {
+    message: 'Something went wrong'
+  }
+
+  beforeEach(() => {
+    CooperationNotesService.getNotes.mockRejectedValue({
+      response: { data: fakeError }
+    })
+    renderWithProviders(<CooperationNotes />, { preloadedState: userState })
+  })
+
+  it('should show the error message', () => {
+    const errorAlert = screen.getByText(`errors.${fakeError.message}`)
+
+    expect(errorAlert).toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/my-cooperations/cooperation-notes/CooperationNotes.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-notes/CooperationNotes.spec.jsx
@@ -1,15 +1,12 @@
-import { screen, fireEvent, act, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import CooperationNotes from '~/containers/my-cooperations/cooperation-notes/CooperationNotes'
 import { renderWithProviders } from '~tests/test-utils'
-import { CooperationNotesService } from '~/services/cooperation-service'
 import { ConfirmationDialogProvider } from '~/context/confirm-context'
-
-vi.mock('~/services/cooperation-service')
 
 const mockNotesData = [
   {
     _id: '65b03361bf20871d3adaeb9c',
-    text: 'Test note content',
+    text: 'Test note1 content',
     author: {
       _id: '6565fd508a848ff2202df79c',
       firstName: 'User',
@@ -22,7 +19,7 @@ const mockNotesData = [
   },
   {
     _id: '65b03361bf20871d3a3aeb9c',
-    text: 'Test note content',
+    text: 'Test note2 content',
     author: {
       _id: '6565fd508a848ff2202df79c',
       firstName: 'User',
@@ -35,21 +32,50 @@ const mockNotesData = [
   }
 ]
 
+const mockResponseData = {
+  data: ''
+}
+
+const mockGetNote = vi.fn()
+const mockUpdateNote = vi.fn().mockReturnValue(mockResponseData)
+const mockCreateNote = vi.fn().mockReturnValue(mockResponseData)
+const mockDeleteNote = vi.fn().mockReturnValue(mockResponseData)
+
+vi.mock('~/services/cooperation-service', async () => {
+  const actual = await vi.importActual('~/services/cooperation-service')
+  return {
+    ...actual,
+    CooperationNotesService: {
+      getNotes: () => mockGetNote(),
+      updateNote: () => mockUpdateNote(),
+      createNote: () => mockCreateNote(),
+      deleteNote: () => mockDeleteNote()
+    }
+  }
+})
+
 const userState = {
   appMain: { userRole: 'tutor', userId: mockNotesData[0].author._id }
 }
 
 describe('CooperationNotes', () => {
-  beforeEach(() => {
-    CooperationNotesService.getNotes.mockResolvedValue({
+  beforeEach(async () => {
+    mockGetNote.mockReturnValue({
       data: mockNotesData
     })
-    renderWithProviders(
-      <ConfirmationDialogProvider>
-        <CooperationNotes />
-      </ConfirmationDialogProvider>,
-      { preloadedState: userState }
-    )
+
+    await waitFor(() => {
+      renderWithProviders(
+        <ConfirmationDialogProvider>
+          <CooperationNotes />
+        </ConfirmationDialogProvider>,
+        { preloadedState: userState }
+      )
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should render CooperationNotes components', () => {
@@ -59,9 +85,9 @@ describe('CooperationNotes', () => {
   })
 
   it('should open create note form and save the note', async () => {
+    const newNoteText = 'Newly created note'
     const addNoteBtn = screen.getByTestId('AddIcon')
-
-    act(() => fireEvent.click(addNoteBtn))
+    fireEvent.click(addNoteBtn)
 
     const noteFormSettings = screen.getByText(
       'cooperationsPage.notes.privateSetting'
@@ -74,31 +100,23 @@ describe('CooperationNotes', () => {
     )
     const saveButton = screen.getByRole('button', { name: 'common.save' })
 
-    act(() =>
-      fireEvent.change(noteTextInput, {
-        target: { value: 'Newly created note' }
-      })
-    )
-    act(() => fireEvent.click(saveButton))
-
-    CooperationNotesService.createNote.mockResolvedValue({
-      data: mockNotesData
+    fireEvent.change(noteTextInput, {
+      target: { value: newNoteText }
     })
+    fireEvent.click(saveButton)
 
     await waitFor(() => {
-      const newNoteText = screen.getByText('Newly created note')
-      expect(newNoteText).toBeInTheDocument()
+      const newNote = screen.getByText(newNoteText)
+      expect(newNote).toBeInTheDocument()
     })
   })
 
   it('should close create note form', () => {
     const addNoteBtn = screen.getByTestId('AddIcon')
-
-    act(() => fireEvent.click(addNoteBtn))
+    fireEvent.click(addNoteBtn)
 
     const cancelButton = screen.getByText('common.cancel')
-
-    act(() => fireEvent.click(cancelButton))
+    fireEvent.click(cancelButton)
 
     const noteFormSettings = screen.queryByText(
       'cooperationsPage.notes.privateSetting'
@@ -107,61 +125,52 @@ describe('CooperationNotes', () => {
     expect(noteFormSettings).toBeNull()
   })
 
-  it('should enable the edit mode and handle updates', () => {
+  it('should enable the edit mode and handle updates', async () => {
+    const newNoteText = 'New note text'
     const [menuButton] = screen.getAllByTestId('MoreVertIcon')
-
-    act(() => fireEvent.click(menuButton))
+    fireEvent.click(menuButton)
 
     const editButton = screen.getByTestId('EditIcon')
-
-    act(() => fireEvent.click(editButton))
+    fireEvent.click(editButton)
 
     const [noteTextInput] = screen.getAllByDisplayValue(mockNotesData[0].text)
     const saveButton = screen.getByRole('button', { name: 'common.save' })
 
-    act(() =>
-      fireEvent.change(noteTextInput, { target: { value: 'New note text' } })
-    )
-    act(() => fireEvent.click(saveButton))
+    fireEvent.change(noteTextInput, { target: { value: newNoteText } })
+    fireEvent.click(saveButton)
 
-    CooperationNotesService.updateNote.mockResolvedValue({
-      data: mockNotesData
+    const newNote = screen.getByText(newNoteText)
+
+    await waitFor(() => {
+      expect(mockUpdateNote).toHaveBeenCalled()
+      expect(newNote).toBeInTheDocument()
     })
-
-    const newNoteText = screen.getByText('New note text')
-
-    expect(newNoteText).toBeInTheDocument()
   })
 
   it('should handle duplicate notes', async () => {
     const [menuButton] = screen.getAllByTestId('MoreVertIcon')
-
-    act(() => fireEvent.click(menuButton))
+    fireEvent.click(menuButton)
 
     const duplicateButton = screen.getByTestId('ContentCopyIcon')
-
-    act(() => fireEvent.click(duplicateButton))
+    fireEvent.click(duplicateButton)
 
     await waitFor(() => {
-      expect(duplicateButton).not.toBeInTheDocument()
+      expect(mockCreateNote).toHaveBeenCalled()
     })
   })
 
   it('should handle delete notes', async () => {
     const [menuButton] = screen.getAllByTestId('MoreVertIcon')
-
-    act(() => fireEvent.click(menuButton))
+    fireEvent.click(menuButton)
 
     const deleteButton = screen.getByTestId('DeleteOutlineIcon')
-
-    act(() => fireEvent.click(deleteButton))
+    fireEvent.click(deleteButton)
 
     const confirmButton = screen.getByRole('button', { name: 'common.yes' })
-
-    act(() => fireEvent.click(confirmButton))
+    fireEvent.click(confirmButton)
 
     await waitFor(() => {
-      expect(confirmButton).not.toBeInTheDocument()
+      expect(mockDeleteNote).toHaveBeenCalled()
     })
   })
 })
@@ -171,11 +180,14 @@ describe('CooperationNotes with error', () => {
     message: 'Something went wrong'
   }
 
-  beforeEach(() => {
-    CooperationNotesService.getNotes.mockRejectedValue({
+  beforeEach(async () => {
+    mockGetNote.mockRejectedValue({
       response: { data: fakeError }
     })
-    renderWithProviders(<CooperationNotes />, { preloadedState: userState })
+
+    await waitFor(() => {
+      renderWithProviders(<CooperationNotes />, { preloadedState: userState })
+    })
   })
 
   it('should show the error message', () => {


### PR DESCRIPTION
1. Added tests for the `CooperationActivitiesList` component:
<img width="1710" alt="Screenshot 2024-04-13 at 00 59 09" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/110097862/28ee60cb-d51f-4725-a845-906ad8c0ccfd">

2. Added tests for the `CooperationNotes` component:
<img width="1710" alt="Screenshot 2024-04-13 at 21 26 04" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/110097862/15046168-af68-40c7-9e36-232795ea8c2c">

The uncovered branches:
- This branch looks illogical, because reaching this branch means that an empty snackbar will be displayed. A new issue will be created to investigate and fix the bug.
<img width="607" alt="Screenshot 2024-04-13 at 21 25 47" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/110097862/2157efb2-3974-4986-b2ad-c8f5b885173c">

- This branch indicates a type issue. According to the `deleteNote` function in `CooperationNotesService` the parameters are required, but `ServiceFunction` type that we need to pass to the `useAxios` hook requires a union type like `type | undefined`. As I understand it, this solution was created to solve this issue. But passing an empty string is't a good idea, since the `deleteNote` function expects real ids. Therefore, a new issue will be created to investigate and fix the type issue. The `ServiceFunction` function type is already changed in #1795.
<img width="597" alt="Screenshot 2024-04-13 at 19 11 54" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/110097862/0223b631-13cc-448e-9e55-2524425597cb">
