### PR TITLE
Feature/1771/scss mixins

### DIFF
--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -1,4 +1,3 @@
-@use "sass:list";
 /*=============================================
 =                 #MIXINS                     =
 =============================================*/
@@ -130,8 +129,11 @@
  */
 
 @mixin text-truncate($line-clamp: 1) {
+    @if $line-clamp != round($line-clamp) {
+        @error "#{$line-clamp} is not a valid property. Expected an plain integer.";
+    }
     display: -webkit-box;
-    -webkit-line-clamp: $line-clamp; // values are: integer or none;
+    -webkit-line-clamp: $line-clamp; // value is: integer;
     -webkit-box-orient: vertical;
 }
 
@@ -153,26 +155,29 @@
  * 
  */
 
-@mixin font-setup-rubik($size: false, $color: false, $weight: false, $height: false, $letter-space: false) {
+@mixin font-setup-rubik($font-size: false, $color: false, $font-weight: false, $line-height: false, $letter-spacing: false) {
     font-family: $rubik;
-    @if $size {
-        $extractedSize: map-get($fs, $size);
+    @if $font-size {
+        $allSizes: map-merge($fs, $fs-h);
+        $extractedSize: map-get($allSizes, $font-size);
         font-size: $extractedSize;
     }
     @if $color {
         color: $color;
     }
-    @if $weight {
-        $extractedWeight: map-get($fw, $weight);
+    @if $font-weight {
+        $extractedWeight: map-get($fw, $font-weight);
         font-weight: $extractedWeight;
     }
-    @if $height {
-        $extractedHeight: map-get($lh, $height);
+    @if $line-height {
+        $allHeights: map-merge($lh, $lh-h);
+        $extractedHeight: map-get($allHeights, $line-height);
         line-height: $extractedHeight;
     }
-    @if $letter-space {
-        $extractedSpace: map-get($ls, $letter-space);
-        letter-spacing: $extractedSpace;
+    @if $letter-spacing {
+        $allSpacings: map-merge($ls, $ls-h);
+        $extractedSpacing: map-get($allSpacings, $letter-spacing);
+        letter-spacing: $extractedSpacing;
     }
 }
 

--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -1,8 +1,7 @@
+@use "sass:list";
 /*=============================================
 =                 #MIXINS                     =
 =============================================*/
-
-
 
 /**
  *
@@ -11,6 +10,172 @@
  *
  */
 
+/*=============================================
+ =                @media rules                =
+ =============================================*/
 
+@mixin tablet {
+    @media (min-width: map-get($breakpoints, "tablet")) {
+        @content;
+    }
+}
 
+@mixin desktop {
+    @media (min-width: map-get($breakpoints, "desktop")) {
+        @content;
+    }
+}
 
+@mixin mobile {
+    @media (min-width: map-get($breakpoints, "mobile")) {
+        @content;
+    }
+}
+
+/*=============================================
+=                 Spacings                    =
+=============================================*/
+
+/**
+ * use it set up margin or padding 
+ * 
+ * @include spacing(margin, 'lg', 'xxs') - will set up margin vertical for 32px and horizontal for 8px 
+ */
+
+@mixin spacing($property, $values...) {
+    $valid-properties: margin, padding;
+
+    @if not list.index($valid-properties, $property) {
+        @error "#{$property} is not a valid property. Expected one of #{$valid-properties}.";
+    }
+
+    $propertyValues: ();
+
+    @each $value in $values {
+        $spacingValue: map-get($spacing, $value);
+        $propertyValues: append($propertyValues, $spacingValue);
+    }
+
+    #{$property}: $propertyValues;
+}
+
+/*=============================================
+=              Containers sizings            =
+=============================================*/
+
+/**
+ * defines width and height in one go
+ * 
+ * @include box(1rem, 2rem) => width: 1rem;  height: 2rem
+ */
+
+@mixin box($width, $height: $width) {
+    width: $width;
+    height: $height;
+}
+
+/**
+ *
+ * Defines box-sizing with support for older browsers
+ *
+ */
+
+@mixin box-sizing($type) {
+    -webkit-box-sizing: $type;
+    -moz-box-sizing: $type;
+    box-sizing: $type;
+}
+
+/*=============================================
+=               FLEX/GRID Toolkit            =
+=============================================*/
+
+/**
+ * Setup for flexbox container
+ *
+ * example usage: 
+ * @include flexbox(column, space-between)
+ * @include flexbox($justify: center)
+ *
+ */
+
+@mixin flexbox($direction: row, $justify: center, $align: center, $wrap: nowrap, $gap: normal) {
+    display: flex;
+    flex-direction: $direction;
+    justify-content: $justify;
+    align-items: $align;
+    flex-wrap: $wrap;
+    gap: $gap;
+}
+
+/**
+ * Setup for grid container
+ *    
+ * @include grid-container(1fr 1fr, 30px, start, center);
+ *
+ */
+
+@mixin grid($columns: auto, $rows: auto, $gap: 20px, $justify: center, $align: center) {
+    display: grid;
+    grid-template-columns: $columns;
+    grid-template-rows: $rows;
+    gap: $gap;
+    justify-items: $justify;
+    align-items: $align;
+}
+
+/*=============================================
+=            Text manipulations            =
+=============================================*/
+
+/**
+ * This mixin is used to truncate text that overflows its container.
+ * 
+ * To truncate text with ellipsis: @include text-truncate;
+ * 
+ * To truncate text with a custom string: @include text-truncate('...');
+ * 
+ * To clip the text without any ellipsis: @include text-truncate('clip');
+ * 
+ */
+
+@mixin text-truncate($overflow: ellipsis) {
+    overflow: hidden;
+    text-overflow: $overflow; // values are: clip, ellipsis, or a string
+    white-space: nowrap;
+}
+
+/*=============================================
+=                Useful resets               =
+=============================================*/
+
+/**
+ * mixin is used to reset the margin, padding, and list-style of the <ul> element.
+ *
+ * example usage: @include listReset;
+ *
+ */
+
+@mixin listReset {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+/**
+ * mixin is applied to create a clearfix, ensuring that it contains floated elements properly.
+ *
+ * example usage: @include clearFix;
+ *
+ */
+
+@mixin clearFix {
+    &:before,
+    &:after {
+        content: "";
+        display: table;
+    }
+    &:after {
+        clear: both;
+    }
+}

--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -74,18 +74,6 @@
     height: $height;
 }
 
-/**
- *
- * Defines box-sizing with support for older browsers
- *
- */
-
-@mixin box-sizing($type) {
-    -webkit-box-sizing: $type;
-    -moz-box-sizing: $type;
-    box-sizing: $type;
-}
-
 /*=============================================
 =               FLEX/GRID Toolkit            =
 =============================================*/

--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -169,10 +169,10 @@
  *
  */
 
-@mixin clearFix {
+@mixin clearFix($content: "") {
     &:before,
     &:after {
-        content: "";
+        content: $content;
         display: table;
     }
     &:after {

--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -50,7 +50,7 @@
  * 
  * Example usage:
  * margin: spacing(2) => margin: 0.5rem // 8px
- * padding-right: spacing() => padding-right: 0.25rem // 4px
+ * padding-right: spacing(1) => padding-right: 0.25rem // 4px
  */
 
 @function spacing($value: 1) {
@@ -141,7 +141,7 @@
  * This mixin is used to set up all font configuration in one go
  * 
  * Example usage:
- * @include font-setup-rubik('h1',$white,'regular','base','2xs') => 
+ * @include font-setup-rubik(h1, $white, regular, base, 2xs) => 
  *      { 
  *          font-family: "Rubik, -apple-system, Arial, sans-serif"; 
  *          color: #ffffff;

--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -14,15 +14,12 @@
  =                @media rules                =
  =============================================*/
 
- 
- /**
+/**
   *
   * Set of mixins for different screen resolutions
   *
   * example usage: @include tablet { color: $pink }
   */
- 
- 
 
 @mixin tablet {
     @media (min-width: map-get($breakpoints, "tablet")) {
@@ -47,26 +44,21 @@
 =============================================*/
 
 /**
- * use it set up margin or padding 
+ * Function which returns values for spacing according to our design system. For your understanding,
+ * you can multiply value to 4 to get value in px
+ *
+ * $value is expected to be a plain integer without unit name => 1; 2; 4;
  * 
- * @include spacing(margin, 'lg', 'xxs') - will set up margin vertical for 32px and horizontal for 8px 
+ * Example usage:
+ * margin: spacing(2) => margin: 0.5rem // 8px
+ * padding-right: spacing() => padding-right: 0.25rem // 4px
  */
 
-@mixin spacing($property, $values...) {
-    $valid-properties: margin, padding;
-
-    @if not list.index($valid-properties, $property) {
-        @error "#{$property} is not a valid property. Expected one of #{$valid-properties}.";
+@function spacing($value: 1) {
+    @if $value != round($value) {
+        @error "#{$value} is not a valid property. Expected an plain integer.";
     }
-
-    $propertyValues: ();
-
-    @each $value in $values {
-        $spacingValue: map-get($spacing, $value);
-        $propertyValues: append($propertyValues, $spacingValue);
-    }
-
-    #{$property}: $propertyValues;
+    @return $spacing-scale-factor * $value;
 }
 
 /*=============================================
@@ -77,6 +69,7 @@
  * defines width and height in one go
  * 
  * @include box(1rem, 2rem) => width: 1rem;  height: 2rem
+ * @include box(1rem) => width: 1rem; height 1rem;
  */
 
 @mixin box($width, $height: $width) {
@@ -92,8 +85,8 @@
  * Setup for flexbox container
  *
  * example usage: 
- * @include flexbox(column, space-between)
- * @include flexbox($justify: center)
+ * @include flexbox(column, space-between) - if you want to change values in their order in function
+ * @include flexbox($justify: center) - if you want to change specific values, in random order
  *
  */
 
@@ -109,11 +102,12 @@
 /**
  * Setup for grid container
  *    
- * @include grid-container(1fr 1fr, 30px, start, center);
+ * @include grid(1fr 1fr, 30px, start, center); - if you want to change values in their order in function
+ * @include grid($justify: center) - if you want to change specific values, in random order
  *
  */
 
-@mixin grid($columns: auto, $rows: auto, $gap: 20px, $justify: center, $align: center) {
+@mixin grid($columns: auto, $rows: auto, $gap: map-get($spacing, "none"), $justify: center, $align: center) {
     display: grid;
     grid-template-columns: $columns;
     grid-template-rows: $rows;
@@ -129,18 +123,57 @@
 /**
  * This mixin is used to truncate text that overflows its container.
  * 
- * To truncate text with ellipsis: @include text-truncate;
- * 
- * To truncate text with a custom string: @include text-truncate('...');
- * 
- * To clip the text without any ellipsis: @include text-truncate('clip');
+ * To truncate text on the 1 row: @include text-truncate; => 'Some text...'
+ * To truncate text on the 2 row: @include text-truncate(2); => 'Some text with meaning
+ *                                                               and its continue....'
  * 
  */
 
-@mixin text-truncate($overflow: ellipsis) {
-    overflow: hidden;
-    text-overflow: $overflow; // values are: clip, ellipsis, or a string
-    white-space: nowrap;
+@mixin text-truncate($line-clamp: 1) {
+    display: -webkit-box;
+    -webkit-line-clamp: $line-clamp; // values are: integer or none;
+    -webkit-box-orient: vertical;
+}
+
+/**
+ * This mixin is used to set up all font configuration in one go
+ * 
+ * Example usage:
+ * @include font-setup-rubik('h1',$white,'regular','base','2xs') => 
+ *      { 
+ *          font-family: "Rubik, -apple-system, Arial, sans-serif"; 
+ *          color: #ffffff;
+ *          font-size: 4.5rem; // 72px
+ *          font-weight: 400;
+ *          line-height: 1.5rem; // 24px
+ *          letter-spacing: 0.006rem; // 0.1px
+ *      }
+ *
+ * @include font-setup-rubik($color: $success-50) => font-family: "Rubik, -apple-system, Arial, sans-serif"; color: #ebf3eb;
+ * 
+ */
+
+@mixin font-setup-rubik($size: false, $color: false, $weight: false, $height: false, $letter-space: false) {
+    font-family: $rubik;
+    @if $size {
+        $extractedSize: map-get($fs, $size);
+        font-size: $extractedSize;
+    }
+    @if $color {
+        color: $color;
+    }
+    @if $weight {
+        $extractedWeight: map-get($fw, $weight);
+        font-weight: $extractedWeight;
+    }
+    @if $height {
+        $extractedHeight: map-get($lh, $height);
+        line-height: $extractedHeight;
+    }
+    @if $letter-space {
+        $extractedSpace: map-get($ls, $letter-space);
+        letter-spacing: $extractedSpace;
+    }
 }
 
 /*=============================================
@@ -167,7 +200,7 @@
  *
  */
 
-@mixin clear-fix($content: "") {
+@mixin clearfix($content: "") {
     &:before,
     &:after {
         content: $content;

--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -155,29 +155,39 @@
  * 
  */
 
-@mixin font-setup-rubik($font-size: false, $color: false, $font-weight: false, $line-height: false, $letter-spacing: false) {
+@mixin font-setup-rubik(
+    $font-size: false,
+    $color: false,
+    $font-weight: false,
+    $line-height: false,
+    $letter-spacing: false
+) {
     font-family: $rubik;
     @if $font-size {
-        $allSizes: map-merge($fs, $fs-h);
-        $extractedSize: map-get($allSizes, $font-size);
-        font-size: $extractedSize;
+        $all-font-sizes: map-merge($fs, $fs-h);
+        $extracted-font-size: map-get($all-font-sizes, $font-size);
+
+        font-size: $extracted-font-size;
     }
     @if $color {
         color: $color;
     }
     @if $font-weight {
-        $extractedWeight: map-get($fw, $font-weight);
-        font-weight: $extractedWeight;
+        $extracted-font-weight: map-get($fw, $font-weight);
+
+        font-weight: $extracted-font-weight;
     }
     @if $line-height {
-        $allHeights: map-merge($lh, $lh-h);
-        $extractedHeight: map-get($allHeights, $line-height);
-        line-height: $extractedHeight;
+        $all-line-heights: map-merge($lh, $lh-h);
+        $extracted-line-height: map-get($all-line-heights, $line-height);
+
+        line-height: $extracted-line-height;
     }
     @if $letter-spacing {
-        $allSpacings: map-merge($ls, $ls-h);
-        $extractedSpacing: map-get($allSpacings, $letter-spacing);
-        letter-spacing: $extractedSpacing;
+        $all-letter-spacings: map-merge($ls, $ls-h);
+        $extracted-letter-spacing: map-get($all-letter-spacings, $letter-spacing);
+
+        letter-spacing: $extracted-letter-spacing;
     }
 }
 

--- a/src/scss/src/foundation/_mixins.scss
+++ b/src/scss/src/foundation/_mixins.scss
@@ -14,6 +14,16 @@
  =                @media rules                =
  =============================================*/
 
+ 
+ /**
+  *
+  * Set of mixins for different screen resolutions
+  *
+  * example usage: @include tablet { color: $pink }
+  */
+ 
+ 
+
 @mixin tablet {
     @media (min-width: map-get($breakpoints, "tablet")) {
         @content;
@@ -144,7 +154,7 @@
  *
  */
 
-@mixin listReset {
+@mixin list-reset {
     margin: 0;
     padding: 0;
     list-style: none;
@@ -157,7 +167,7 @@
  *
  */
 
-@mixin clearFix($content: "") {
+@mixin clear-fix($content: "") {
     &:before,
     &:after {
         content: $content;

--- a/src/scss/src/foundation/_typography.scss
+++ b/src/scss/src/foundation/_typography.scss
@@ -43,7 +43,7 @@ $body-1-font-size: var(--s2s-body1-font-size, $fs-base) !default;
 $body-2-font-size: var(--s2s-body2-font-size, $fs-sm) !default;
 $caption1-font-size: var(--s2s-caption1-font-size, $fs-xs) !default;
 $caption2-font-size: var(--s2s-caption2-font-size, $fs-xs) !default;
-$overline-font-size: var(--s2s-overline-font-size, $fs-xxs) !default;
+$overline-font-size: var(--s2s-overline-font-size, $fs-2xs) !default;
 $button1-font-size: var(--s2s-button1-font-size, $fs-base) !default;
 $button2-font-size: var(--s2s-button2-font-size, $fs-sm) !default;
 
@@ -121,10 +121,10 @@ $mid-title-letter-spacing: var(
 $subtitle1-letter-spacing: var(--s2s-subtitle1-letter-spacing, $ls-xs) !default;
 $subtitle2-letter-spacing: var(
   --s2s-subtitle2-letter-spacing,
-  $ls-xxs
+  $ls-2xs
 ) !default;
 $body-1-letter-spacing: var(--s2s-body1-letter-spacing, $ls-base) !default;
-$body-2-letter-spacing: var(--s2s-body2-letter-spacing, $ls-xxxs) !default;
+$body-2-letter-spacing: var(--s2s-body2-letter-spacing, $ls-3xs) !default;
 $caption1-letter-spacing: var(--s2s-caption1-letter-spacing, $ls-sm) !default;
 $caption2-letter-spacing: var(--s2s-caption2-letter-spacing, $ls-sm) !default;
 $overline-letter-spacing: var(--s2s-overline-letter-spacing, $ls-lg) !default;

--- a/src/scss/src/foundation/_variables.scss
+++ b/src/scss/src/foundation/_variables.scss
@@ -302,15 +302,15 @@ $spacing: (
 =                  SHADOWS                   =
 =============================================*/
 
-$main-shadow:
+$shadow-main:
   0px 5px 6px -3px rgba(144, 164, 174, 0.2),
   0px 9px 12px 1px rgba(144, 164, 174, 0.14),
   0px 3px 16px 2px rgba(144, 164, 174, 0.12);
 
-$common-shadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.12);
+$shadow-common: 0px 3px 16px 2px rgba(144, 164, 174, 0.12);
 
-$common-hover-shadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.56);
+$shadow-common-hover: 0px 3px 16px 2px rgba(144, 164, 174, 0.56);
 
-$small-hover-shadow: 0 3px 1px rgba(144, 164, 174, 0.56);
+$shadow-small-hover: 0 3px 1px rgba(144, 164, 174, 0.56);
 
 /*=====  End of SHADOWS  ======*/

--- a/src/scss/src/foundation/_variables.scss
+++ b/src/scss/src/foundation/_variables.scss
@@ -302,15 +302,15 @@ $spacing: (
 =                  SHADOWS                   =
 =============================================*/
 
-$mainShadow:
+$main-shadow:
   0px 5px 6px -3px rgba(144, 164, 174, 0.2),
   0px 9px 12px 1px rgba(144, 164, 174, 0.14),
   0px 3px 16px 2px rgba(144, 164, 174, 0.12);
 
-$commonShadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.12);
+$common-shadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.12);
 
-$commonHoverShadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.56);
+$common-hover-shadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.56);
 
-$smallHoverShadow: 0 3px 1px rgba(144, 164, 174, 0.56);
+$small-hover-shadow: 0 3px 1px rgba(144, 164, 174, 0.56);
 
 /*=====  End of SHADOWS  ======*/

--- a/src/scss/src/foundation/_variables.scss
+++ b/src/scss/src/foundation/_variables.scss
@@ -124,7 +124,7 @@ $error-900: #b91f1b;
 
 /* Font families */
 
-$rubik: 'Rubik, -apple-system, Arial, sans-serif';
+$rubik: "Rubik, -apple-system, Arial, sans-serif";
 
 /* Font weights */
 
@@ -297,3 +297,20 @@ $spacing: (
 );
 
 /*=====  End of BREAKPOINTS  ======*/
+
+/*=============================================
+=                  SHADOWS                   =
+=============================================*/
+
+$mainShadow:
+  0px 5px 6px -3px rgba(144, 164, 174, 0.2),
+  0px 9px 12px 1px rgba(144, 164, 174, 0.14),
+  0px 3px 16px 2px rgba(144, 164, 174, 0.12);
+
+$commonShadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.12);
+
+$commonHoverShadow: 0px 3px 16px 2px rgba(144, 164, 174, 0.56);
+
+$smallHoverShadow: 0 3px 1px rgba(144, 164, 174, 0.56);
+
+/*=====  End of SHADOWS  ======*/

--- a/src/scss/src/foundation/_variables.scss
+++ b/src/scss/src/foundation/_variables.scss
@@ -174,8 +174,6 @@ $fs: (
   lg: $fs-lg
 );
 
-$fs: map-merge($fs, $fs-h);
-
 /* Line heights (headings) */
 
 $lh-h1: 5.313rem; // 85px
@@ -206,7 +204,6 @@ $lh: (
   base: $lh-base
 );
 
-$lh: map-merge($lh, $lh-h);
 /* Letter spacings (headings) */
 
 $ls-h1: -0.094rem; // -1.5px
@@ -244,8 +241,6 @@ $ls: (
   base: $ls-base,
   lg: $ls-lg
 );
-
-$ls: map-merge($ls, $ls-h);
 
 /* Text transforms */
 

--- a/src/scss/src/foundation/_variables.scss
+++ b/src/scss/src/foundation/_variables.scss
@@ -160,19 +160,21 @@ $fs-h: (
 
 /* Font sizes (texts) */
 
-$fs-xxs: 0.625rem; // 10px
+$fs-2xs: 0.625rem; // 10px
 $fs-xs: 0.75rem; // 12px
 $fs-sm: 0.875rem; // 14px
 $fs-base: 1rem; // 16px
 $fs-lg: 1.125rem; // 18px
 
 $fs: (
-  xxs: $fs-xxs,
+  2xs: $fs-2xs,
   xs: $fs-xs,
   sm: $fs-sm,
   base: $fs-base,
   lg: $fs-lg
 );
+
+$fs: map-merge($fs, $fs-h);
 
 /* Line heights (headings) */
 
@@ -204,6 +206,7 @@ $lh: (
   base: $lh-base
 );
 
+$lh: map-merge($lh, $lh-h);
 /* Letter spacings (headings) */
 
 $ls-h1: -0.094rem; // -1.5px
@@ -225,8 +228,8 @@ $ls-h: (
 /* Letter spacings (texts) */
 
 $ls-none: normal; // normal
-$ls-xxxs: 0.0025rem; // 0.04px
-$ls-xxs: 0.006rem; // 0.1px
+$ls-3xs: 0.0025rem; // 0.04px
+$ls-2xs: 0.006rem; // 0.1px
 $ls-xs: 0.009rem; // 0.15px
 $ls-sm: 0.025rem; // 0.4px
 $ls-base: 0.031rem; // 0.5px
@@ -234,13 +237,15 @@ $ls-lg: 0.094rem; // 1.5px
 
 $ls: (
   none: $ls-none,
-  xxxs: $ls-xxxs,
-  xxs: $ls-xxs,
+  3xs: $ls-3xs,
+  2xs: $ls-2xs,
   xs: $ls-xs,
   sm: $ls-sm,
   base: $ls-base,
   lg: $ls-lg
 );
+
+$ls: map-merge($ls, $ls-h);
 
 /* Text transforms */
 
@@ -273,8 +278,8 @@ $breakpoints: (
 =============================================*/
 
 $spacing-none: 0;
-$spacing-xxxs: 0.25rem; // 4px
-$spacing-xxs: 0.5rem; // 8px
+$spacing-3xs: 0.25rem; // 4px
+$spacing-2xs: 0.5rem; // 8px
 $spacing-xs: 0.75rem; // 12px
 $spacing-sm: 1rem; // 16px
 $spacing-md: 1.5rem; // 24px
@@ -285,8 +290,8 @@ $spacing-3xl: 6rem; // 96px
 
 $spacing: (
   none: $spacing-none,
-  xxxs: $spacing-xxxs,
-  xxs: $spacing-xxs,
+  3xs: $spacing-3xs,
+  2xs: $spacing-2xs,
   xs: $spacing-xs,
   sm: $spacing-sm,
   md: $spacing-md,
@@ -295,6 +300,8 @@ $spacing: (
   2xl: $spacing-2xl,
   3xl: $spacing-3xl
 );
+
+$spacing-scale-factor: 0.25rem; // 4px
 
 /*=====  End of BREAKPOINTS  ======*/
 


### PR DESCRIPTION
Added a collection of mixins to enhance the maintainability and flexibility of styling across components. There are mixins for handling responsive design using media queries (tablet, desktop, mobile), spacing utilities (spacing mixin), container sizing shortcuts (box mixin), flexbox and grid layout helpers (flexbox and grid mixins), text manipulation tools (text-truncate mixin), and useful resets (listReset and clearFix mixins).

#### Usage Examples:
```
@include tablet { ... } - Applies styles within a tablet media query.
@include spacing(margin, 'lg', 'xxs') - Sets up margin vertically for 32px and horizontally for 8px.
@include box(1rem, 2rem) - Defines width as 1rem and height as 2rem.
@include flexbox(column, space-between) - Sets up a flexbox container with column direction and space-between alignment.
@include text-truncate('...') - Truncates text with a custom ellipsis string.
@include listReset - Resets margin, padding, and list-style for <ul> elements.
@include clearFix - Creates a clearfix for containing floated elements properly.
```