### PR TITLE
Fixed authorized user redirection from home to 404 page

### DIFF
--- a/src/router/helpers/HomeRoute.tsx
+++ b/src/router/helpers/HomeRoute.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAppSelector } from '~/hooks/use-redux'
 import GuestHomePage from '~/pages/guest-home-page/GuestHome'
@@ -7,9 +7,11 @@ import { guestRoutes } from '~/router/constants/guestRoutes'
 const HomeRoute = () => {
   const navigate = useNavigate()
   const { userRole } = useAppSelector((state) => state.appMain)
+  const wasNavigateTriggeredRef = useRef(false)
 
   useEffect(() => {
-    if (userRole) {
+    if (userRole && !wasNavigateTriggeredRef.current) {
+      wasNavigateTriggeredRef.current = true
       navigate(guestRoutes[userRole].route)
     }
   }, [navigate, userRole])


### PR DESCRIPTION
Fixed bug when authorized user (student or tutor) was redirected to 404 error page when he tried to navigate to home page

Before:

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/a8f4ba68-bf3c-408d-9fc3-1a7f44b9d61f

After:

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/d41bef81-fdd2-4426-a586-03cb0115602b



The problem was arising in React's `strict mode`, which triggered `useEffect`'s code to run twice. As a result, navigation also happened twice, so we were getting strange url `/student/student` or `/tutor/tutor`, which is caught by `react-router-dom`'s `errorElement`, that redirects us to 404 page
  
  