### PR TITLE
Implemented functionality for Courses Filters Drawer

### DIFF
--- a/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.constants.tsx
+++ b/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.constants.tsx
@@ -1,7 +1,9 @@
 import { CourseFilters } from '~/types'
 
 export const coursesDefaultFilters: CourseFilters = {
+  title: '',
   category: '',
   subject: '',
-  proficiencyLevel: []
+  proficiencyLevel: [],
+  page: 1
 }

--- a/src/containers/find-offer/offer-filter-block/OfferFilterBlock.tsx
+++ b/src/containers/find-offer/offer-filter-block/OfferFilterBlock.tsx
@@ -11,7 +11,7 @@ import FiltersToggle from '~/components/filters-toggle/FiltersToggle'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import {
   FindOffersFilters,
-  FindOffersFiltersActions,
+  FiltersActions,
   PriceRange,
   UserRoleEnum
 } from '~/types'
@@ -21,7 +21,7 @@ import { styles } from '~/containers/find-offer/offer-filter-block/OfferFilterBl
 
 interface OfferFilterBlockProps {
   filters: FindOffersFilters
-  filterActions: FindOffersFiltersActions<FindOffersFilters>
+  filterActions: FiltersActions<FindOffersFilters>
   onToggleTutorOffers: () => void
   closeFilters: () => void
   additionalParams: Record<string, unknown>

--- a/src/containers/find-offer/offer-search-toolbar/OfferSearchToolbar.tsx
+++ b/src/containers/find-offer/offer-search-toolbar/OfferSearchToolbar.tsx
@@ -10,7 +10,7 @@ import AppToolbar from '~/components/app-toolbar/AppToolbar'
 import {
   CategoryNameInterface,
   FindOffersFilters,
-  FindOffersFiltersActions,
+  FiltersActions,
   SubjectNameInterface
 } from '~/types'
 
@@ -21,7 +21,7 @@ import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
 
 interface OfferSearchToolbarProps {
   filters: FindOffersFilters
-  filterActions: FindOffersFiltersActions<FindOffersFilters>
+  filterActions: FiltersActions<FindOffersFilters>
   additionalParams: Record<string, unknown>
 }
 

--- a/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
+++ b/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
@@ -22,7 +22,6 @@ import { styles } from '~/containers/my-courses/add-course-with-input/AddCourseW
 interface AddCoursesWithInputProps {
   additionalParams: Record<string, unknown>
   chosenFiltersQty?: number
-  fetchData: () => Promise<void>
   filterActions: CourseFiltersActions<CourseFilters>
   filters: CourseFilters
   setSort: (property: string) => void
@@ -34,7 +33,6 @@ const AddCourseWithInput: FC<AddCoursesWithInputProps> = ({
   chosenFiltersQty,
   filterActions,
   filters,
-  fetchData,
   setSort,
   sort
 }) => {
@@ -54,7 +52,6 @@ const AddCourseWithInput: FC<AddCoursesWithInputProps> = ({
       ...additionalParams,
       title: ''
     })
-    void fetchData()
   }
 
   const handleToggle = () => (isOpen ? closeDrawer() : openDrawer())

--- a/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
+++ b/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
@@ -20,7 +20,7 @@ import { CourseFilters, CourseFiltersActions } from '~/types'
 import { styles } from '~/containers/my-courses/add-course-with-input/AddCourseWithInput.styles'
 
 interface AddCoursesWithInputProps {
-  additionalParams: Record<string, unknown>
+  additionalParams: Record<string, number | string | undefined>
   chosenFiltersQty?: number
   filterActions: CourseFiltersActions<CourseFilters>
   filters: CourseFilters

--- a/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
+++ b/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
@@ -16,13 +16,13 @@ import { authRoutes } from '~/router/constants/authRoutes'
 import { useDrawer } from '~/hooks/use-drawer'
 import useBreakpoints from '~/hooks/use-breakpoints'
 
-import { CourseFilters, CourseFiltersActions } from '~/types'
+import { CourseFilters, FiltersActions } from '~/types'
 import { styles } from '~/containers/my-courses/add-course-with-input/AddCourseWithInput.styles'
 
 interface AddCoursesWithInputProps {
   additionalParams: Record<string, number | string | undefined>
   chosenFiltersQty?: number
-  filterActions: CourseFiltersActions<CourseFilters>
+  filterActions: FiltersActions<CourseFilters>
   filters: CourseFilters
   setSort: (property: string) => void
   sort: string

--- a/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
+++ b/src/containers/my-courses/add-course-with-input/AddCourseWithInput.tsx
@@ -1,4 +1,4 @@
-import { FC, ChangeEvent, useState, MutableRefObject } from 'react'
+import { FC, ChangeEvent } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import AddIcon from '@mui/icons-material/Add'
@@ -13,58 +13,47 @@ import CoursesFiltersDrawer from '~/containers/my-courses/courses-filters-drawer
 
 import { authRoutes } from '~/router/constants/authRoutes'
 
-import useForm from '~/hooks/use-form'
 import { useDrawer } from '~/hooks/use-drawer'
 import useBreakpoints from '~/hooks/use-breakpoints'
-import { useDebounce } from '~/hooks/use-debounce'
 
-import { CourseFilters } from '~/types'
+import { CourseFilters, CourseFiltersActions } from '~/types'
 import { styles } from '~/containers/my-courses/add-course-with-input/AddCourseWithInput.styles'
 
 interface AddCoursesWithInputProps {
+  additionalParams: Record<string, unknown>
+  chosenFiltersQty?: number
   fetchData: () => Promise<void>
-  searchRef: MutableRefObject<string>
+  filterActions: CourseFiltersActions<CourseFilters>
+  filters: CourseFilters
   setSort: (property: string) => void
   sort: string
 }
 
 const AddCourseWithInput: FC<AddCoursesWithInputProps> = ({
-  searchRef,
+  additionalParams,
+  chosenFiltersQty,
+  filterActions,
+  filters,
   fetchData,
   setSort,
   sort
 }) => {
   const { t } = useTranslation()
-  const [inputValue, setInputValue] = useState<string>('')
   const { openDrawer, closeDrawer, isOpen } = useDrawer()
   const { isTablet, isMobile } = useBreakpoints()
 
-  const {
-    data: filters,
-    handleNonInputValueChange,
-    resetData
-  } = useForm<CourseFilters>({
-    initialValues: {
-      title: '',
-      category: '',
-      subject: '',
-      proficiencyLevel: []
-    }
-  })
-
-  const debounceOnChange = useDebounce((text: string) => {
-    searchRef.current = text
-    void fetchData()
-  })
-
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value)
-    debounceOnChange(e.target.value)
+    filterActions.updateFiltersInQuery({
+      ...additionalParams,
+      title: e.target.value
+    })
   }
 
   const onClear = () => {
-    setInputValue('')
-    searchRef.current = ''
+    filterActions.updateFiltersInQuery({
+      ...additionalParams,
+      title: ''
+    })
     void fetchData()
   }
 
@@ -72,7 +61,10 @@ const AddCourseWithInput: FC<AddCoursesWithInputProps> = ({
 
   const desktopView = !isTablet && !isMobile && (
     <Box sx={styles.filtersBox(isTablet)}>
-      <FiltersToggle handleToggle={handleToggle} />
+      <FiltersToggle
+        chosenFiltersQty={chosenFiltersQty}
+        handleToggle={handleToggle}
+      />
       <CoursesFilterBar onValueChange={setSort} value={sort} />
       <InputWithIcon
         endAdornment={<SearchIcon sx={styles.searchIcon} />}
@@ -80,14 +72,17 @@ const AddCourseWithInput: FC<AddCoursesWithInputProps> = ({
         onClear={onClear}
         placeholder={t('common.search')}
         sx={styles.input}
-        value={inputValue}
+        value={filters.title}
       />
     </Box>
   )
 
   const tabletView = isTablet && (
     <Box sx={styles.filtersBox(isTablet)}>
-      <FiltersToggle handleToggle={handleToggle} />
+      <FiltersToggle
+        chosenFiltersQty={chosenFiltersQty}
+        handleToggle={handleToggle}
+      />
       <CoursesFilterBar onValueChange={setSort} value={sort} />
     </Box>
   )
@@ -110,6 +105,7 @@ const AddCourseWithInput: FC<AddCoursesWithInputProps> = ({
       {mobileView}
 
       <CoursesFiltersDrawer
+        additionalParams={additionalParams}
         deviceFields={
           isMobile && (
             <CoursesFilterBar
@@ -119,9 +115,8 @@ const AddCourseWithInput: FC<AddCoursesWithInputProps> = ({
             />
           )
         }
+        filterActions={filterActions}
         filters={filters}
-        handleFilterChange={handleNonInputValueChange}
-        handleReset={resetData}
         isOpen={isOpen}
         onClose={closeDrawer}
       />

--- a/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
+++ b/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { FC, ReactNode, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import FilterListIcon from '@mui/icons-material/FilterList'
 import Typography from '@mui/material/Typography'
@@ -6,47 +6,79 @@ import Button from '@mui/material/Button'
 import Box from '@mui/material/Box'
 
 import AppDrawer from '~/components/app-drawer/AppDrawer'
-import AppSelect from '~/components/app-select/AppSelect'
 import CheckboxList from '~/components/checkbox-list/CheckboxList'
 import FilterInput from '~/components/filter-input/FilterInput'
+import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
 
 import { spliceSx } from '~/utils/helper-functions'
+import { categoryService } from '~/services/category-service'
+import { subjectService } from '~/services/subject-service'
 import { styles } from '~/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.styles'
 import {
   ButtonVariantEnum,
+  CategoryNameInterface,
   CourseFilters,
+  CourseFiltersActions,
   PositionEnum,
   ProficiencyLevelEnum,
-  SizeEnum
+  SizeEnum,
+  SubjectNameInterface
 } from '~/types'
 
 interface CoursesFiltersDrawerProps {
+  additionalParams: Record<string, unknown>
+  filterActions: CourseFiltersActions<CourseFilters>
   filters: CourseFilters
-  handleFilterChange: (
-    key: keyof CourseFilters,
-    value: string | ProficiencyLevelEnum[]
-  ) => void
   onClose: () => void
   isOpen: boolean
-  handleReset: () => void
   deviceFields?: ReactNode
 }
-const fields = [
-  { value: 'music', title: 'Music' },
-  { value: 'lang', title: 'Languages' },
-  { value: 'development', title: 'Development' }
-]
 
 const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
+  additionalParams,
+  filterActions,
   filters,
-  handleFilterChange,
   onClose,
   isOpen,
-  handleReset,
   deviceFields
 }) => {
   const levelOptions = Object.values(ProficiencyLevelEnum)
   const { t } = useTranslation()
+  const { updateFiltersInQuery, resetFilters } = filterActions
+
+  const getSubjectsNames = useCallback(
+    () => subjectService.getSubjectsNames(filters.category),
+    [filters.category]
+  )
+
+  const onCategoryChange = (
+    _: React.SyntheticEvent,
+    value: CategoryNameInterface | null
+  ) => {
+    updateFiltersInQuery({
+      ...additionalParams,
+      subject: '',
+      category: value?._id ?? ''
+    })
+  }
+
+  const onSubjectChange = (
+    _: React.SyntheticEvent,
+    value: SubjectNameInterface | null
+  ) => {
+    updateFiltersInQuery({ ...additionalParams, subject: value?._id ?? '' })
+  }
+
+  const updateFilterByKey =
+    <K extends keyof CourseFilters>(key: K) =>
+    (value: CourseFilters[K]) => {
+      updateFiltersInQuery({ ...additionalParams, [key]: value })
+    }
+
+  const handleApplyFilters = () => {
+    updateFiltersInQuery(additionalParams)
+    onClose()
+  }
   return (
     <AppDrawer anchor={PositionEnum.Left} onClose={onClose} open={isOpen}>
       <Box sx={styles.titleWithIcon}>
@@ -61,17 +93,19 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
       <Box sx={styles.categorySelect}>
         <Typography sx={styles.titleMargin}>
           {t('myCoursesPage.coursesFilter.chooseThe')}
-          <Typography sx={styles.boldText}>
+          <Typography component={'span'} sx={styles.boldText}>
             {t('myCoursesPage.coursesFilter.category')}:
           </Typography>
         </Typography>
-        <AppSelect
-          fields={fields}
-          fullWidth
-          label={t('myCoursesPage.coursesFilter.categoryLabel')}
-          setValue={(value) => handleFilterChange('category', value)}
-          size={SizeEnum.Small}
+        <AsyncAutocomplete
+          labelField='name'
+          onChange={onCategoryChange}
+          service={categoryService.getCategoriesNames}
+          textFieldProps={{
+            label: t('myCoursesPage.coursesFilter.categoryLabel')
+          }}
           value={filters.category}
+          valueField='_id'
         />
       </Box>
 
@@ -84,31 +118,36 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
           }
         >
           {t('myCoursesPage.coursesFilter.chooseThe')}
-          <Typography sx={styles.inlineBlock(!!filters.category)}>
+          <Typography
+            component={'span'}
+            sx={styles.inlineBlock(!!filters.category)}
+          >
             {t('myCoursesPage.coursesFilter.subject')}:
           </Typography>
         </Typography>
-        <AppSelect
+        <AsyncAutocomplete
           disabled={!filters.category}
-          fields={fields}
-          fullWidth
-          label={t('myCoursesPage.coursesFilter.subjectLabel')}
-          setValue={(value) => handleFilterChange('subject', value)}
-          size={SizeEnum.Small}
+          labelField='name'
+          onChange={onSubjectChange}
+          service={getSubjectsNames}
+          textFieldProps={{
+            label: t('myCoursesPage.coursesFilter.subjectLabel')
+          }}
           value={filters.subject}
+          valueField='_id'
         />
       </Box>
 
       <Box sx={styles.checkboxContainer}>
         <Typography sx={styles.checkboxTitleMargin}>
           {t('myCoursesPage.coursesFilter.choose')}
-          <Typography sx={styles.boldText}>
+          <Typography component={'span'} sx={styles.boldText}>
             {t('myCoursesPage.coursesFilter.levels')}:
           </Typography>
         </Typography>
         <CheckboxList
           items={levelOptions}
-          onChange={(value) => handleFilterChange('proficiencyLevel', value)}
+          onChange={updateFilterByKey('proficiencyLevel')}
           value={filters.proficiencyLevel}
         />
       </Box>
@@ -117,20 +156,24 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
         {t('myCoursesPage.coursesFilter.search')}:
       </Typography>
       <FilterInput
-        onChange={(value) => handleFilterChange('title', value)}
+        onChange={updateFilterByKey('title')}
         placeholder={t('common.search')}
         value={filters.title}
       />
 
       <Button
-        onClick={() => handleReset()}
+        onClick={resetFilters}
         size={SizeEnum.ExtraLarge}
         sx={styles.clearButtonMb}
         variant={ButtonVariantEnum.Tonal}
       >
         {t('button.clearFilters')}
       </Button>
-      <Button size={SizeEnum.ExtraLarge} variant={ButtonVariantEnum.Contained}>
+      <Button
+        onClick={handleApplyFilters}
+        size={SizeEnum.ExtraLarge}
+        variant={ButtonVariantEnum.Contained}
+      >
         {t('button.applyFilters')}
       </Button>
     </AppDrawer>

--- a/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
+++ b/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useCallback } from 'react'
+import { FC, ReactNode, useCallback, SyntheticEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import FilterListIcon from '@mui/icons-material/FilterList'
 import Typography from '@mui/material/Typography'
@@ -17,8 +17,9 @@ import { styles } from '~/containers/my-courses/courses-filters-drawer/CoursesFi
 import {
   ButtonVariantEnum,
   CategoryNameInterface,
+  ComponentEnum,
   CourseFilters,
-  CourseFiltersActions,
+  FiltersActions,
   PositionEnum,
   ProficiencyLevelEnum,
   SizeEnum,
@@ -27,7 +28,7 @@ import {
 
 interface CoursesFiltersDrawerProps {
   additionalParams: Record<string, number | string | undefined>
-  filterActions: CourseFiltersActions<CourseFilters>
+  filterActions: FiltersActions<CourseFilters>
   filters: CourseFilters
   onClose: () => void
   isOpen: boolean
@@ -52,7 +53,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
   )
 
   const onCategoryChange = (
-    _: React.SyntheticEvent,
+    _: SyntheticEvent,
     value: CategoryNameInterface | null
   ) => {
     updateFiltersInQuery({
@@ -63,7 +64,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
   }
 
   const onSubjectChange = (
-    _: React.SyntheticEvent,
+    _: SyntheticEvent,
     value: SubjectNameInterface | null
   ) => {
     updateFiltersInQuery({ ...additionalParams, subject: value?._id ?? '' })
@@ -93,7 +94,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
       <Box sx={styles.categorySelect}>
         <Typography sx={styles.titleMargin}>
           {t('myCoursesPage.coursesFilter.chooseThe')}
-          <Typography component={'span'} sx={styles.boldText}>
+          <Typography component={ComponentEnum.Span} sx={styles.boldText}>
             {t('myCoursesPage.coursesFilter.category')}:
           </Typography>
         </Typography>
@@ -119,7 +120,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
         >
           {t('myCoursesPage.coursesFilter.chooseThe')}
           <Typography
-            component={'span'}
+            component={ComponentEnum.Span}
             sx={styles.inlineBlock(!!filters.category)}
           >
             {t('myCoursesPage.coursesFilter.subject')}:
@@ -141,7 +142,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
       <Box sx={styles.checkboxContainer}>
         <Typography sx={styles.checkboxTitleMargin}>
           {t('myCoursesPage.coursesFilter.choose')}
-          <Typography component={'span'} sx={styles.boldText}>
+          <Typography component={ComponentEnum.Span} sx={styles.boldText}>
             {t('myCoursesPage.coursesFilter.levels')}:
           </Typography>
         </Typography>

--- a/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
+++ b/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
@@ -26,7 +26,7 @@ import {
 } from '~/types'
 
 interface CoursesFiltersDrawerProps {
-  additionalParams: Record<string, unknown>
+  additionalParams: Record<string, number | string | undefined>
   filterActions: CourseFiltersActions<CourseFilters>
   filters: CourseFilters
   onClose: () => void

--- a/src/hooks/use-filter-query.tsx
+++ b/src/hooks/use-filter-query.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { FindOffersFiltersActions, UpdateFiltersInQuery } from '~/types'
+import { FiltersActions, UpdateFiltersInQuery } from '~/types'
 import { parseQueryParams } from '~/utils/helper-functions'
 
 interface UseFilterQueryOptions<T> {
@@ -13,7 +13,7 @@ interface UseFilterQueryOptions<T> {
 
 interface FilterQueryHook<T> {
   filters: T
-  filterQueryActions: FindOffersFiltersActions<T>
+  filterQueryActions: FiltersActions<T>
   searchParams: URLSearchParams
   activeFilterCount?: number
 }

--- a/src/pages/my-courses/MyCourses.constants.tsx
+++ b/src/pages/my-courses/MyCourses.constants.tsx
@@ -1,17 +1,7 @@
-import { CourseFilters } from '~/types'
-
 export const defaultResponse = { items: [], count: 0 }
 
 export const courseItemsLoadLimit = {
   tablet: 6,
   mobile: 6,
   default: 6
-}
-
-export const defaultFilters: CourseFilters = {
-  title: '',
-  category: '',
-  subject: '',
-  proficiencyLevel: [],
-  page: 1
 }

--- a/src/pages/my-courses/MyCourses.constants.tsx
+++ b/src/pages/my-courses/MyCourses.constants.tsx
@@ -1,7 +1,17 @@
+import { CourseFilters } from '~/types'
+
 export const defaultResponse = { items: [], count: 0 }
 
 export const courseItemsLoadLimit = {
   tablet: 6,
   mobile: 6,
   default: 6
+}
+
+export const defaultFilters: CourseFilters = {
+  title: '',
+  category: '',
+  subject: '',
+  proficiencyLevel: [],
+  page: 1
 }

--- a/src/pages/my-courses/MyCourses.tsx
+++ b/src/pages/my-courses/MyCourses.tsx
@@ -29,10 +29,10 @@ import {
 } from '~/types'
 import { initialSort } from '~/containers/find-course/courses-filter-bar/CorseFilterBar.constants'
 import {
-  defaultFilters,
   defaultResponse,
   courseItemsLoadLimit
 } from '~/pages/my-courses/MyCourses.constants'
+import { coursesDefaultFilters } from '~/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.constants'
 import { snackbarVariants } from '~/constants'
 
 import { styles } from '~/pages/my-courses/MyCourses.styles'
@@ -47,7 +47,7 @@ const MyCourses = () => {
 
   const { filters, activeFilterCount, searchParams, filterQueryActions } =
     useFilterQuery({
-      defaultFilters: defaultFilters,
+      defaultFilters: coursesDefaultFilters,
       countActiveFilters: countActiveCourseFilters
     })
 
@@ -155,7 +155,7 @@ const MyCourses = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fetchData, searchString, sort])
 
-  const defaultParams = { page: defaultFilters.page }
+  const defaultParams = { page: coursesDefaultFilters.page }
 
   const { items: coursesItems, count: coursesCount } = coursesResponse
 

--- a/src/pages/my-courses/MyCourses.tsx
+++ b/src/pages/my-courses/MyCourses.tsx
@@ -193,7 +193,6 @@ const MyCourses = () => {
       <AddCourseWithInput
         additionalParams={defaultParams}
         chosenFiltersQty={activeFilterCount}
-        fetchData={fetchData}
         filterActions={filterQueryActions}
         filters={filters}
         setSort={onRequestSort}

--- a/src/types/common/interfaces/common.interfaces.ts
+++ b/src/types/common/interfaces/common.interfaces.ts
@@ -3,6 +3,7 @@ import {
   CourseSection,
   FormInputValueChange,
   Offer,
+  UpdateFiltersInQuery,
   UserResponse,
   UserGeneralInfo,
   UserRoleEnum
@@ -120,4 +121,10 @@ export interface StepData {
   photo: string[]
   subjects: SubjectInterface[]
   language: UserResponse['nativeLanguage']
+}
+
+export interface FiltersActions<T> {
+  updateFiltersInQuery: UpdateFiltersInQuery<T>
+  resetFilters: () => void
+  updateQueryParams: () => void
 }

--- a/src/types/course/interfaces/course.interface.ts
+++ b/src/types/course/interfaces/course.interface.ts
@@ -4,7 +4,6 @@ import {
   CategoryInterface,
   SubjectNameInterface,
   ProficiencyLevelEnum,
-  UpdateFiltersInQuery,
   UserResponse,
   Quiz,
   Attachment,
@@ -47,12 +46,6 @@ export interface CourseFilters extends Pick<Course, 'proficiencyLevel'> {
   subject: string
   title: string
   page?: string | number
-}
-
-export interface CourseFiltersActions<T> {
-  updateFiltersInQuery: UpdateFiltersInQuery<T>
-  resetFilters: () => void
-  updateQueryParams: () => void
 }
 
 export interface GetCoursesParams extends Partial<RequestParams> {

--- a/src/types/course/interfaces/course.interface.ts
+++ b/src/types/course/interfaces/course.interface.ts
@@ -4,6 +4,7 @@ import {
   CategoryInterface,
   SubjectNameInterface,
   ProficiencyLevelEnum,
+  UpdateFiltersInQuery,
   UserResponse,
   Quiz,
   Attachment,
@@ -45,6 +46,13 @@ export interface CourseFilters extends Pick<Course, 'proficiencyLevel'> {
   category: string
   subject: string
   title: string
+  page?: string | number
+}
+
+export interface CourseFiltersActions<T> {
+  updateFiltersInQuery: UpdateFiltersInQuery<T>
+  resetFilters: () => void
+  updateQueryParams: () => void
 }
 
 export interface GetCoursesParams extends Partial<RequestParams> {

--- a/src/types/findOffers/interfaces/findOffers.interfaces.ts
+++ b/src/types/findOffers/interfaces/findOffers.interfaces.ts
@@ -1,13 +1,13 @@
 import {
   CategoryInterface,
   CategoryNameInterface,
+  FiltersActions,
   LanguageFilter,
   Offer,
   ProficiencyLevelEnum,
   RangeArray,
   RequestParams,
   SubjectNameInterface,
-  UpdateFiltersInQuery,
   UserRole
 } from '~/types'
 
@@ -25,12 +25,6 @@ export interface FindOffersFilters {
   page: string | number
 }
 
-export interface FindOffersFiltersActions<T> {
-  updateFiltersInQuery: UpdateFiltersInQuery<T>
-  resetFilters: () => void
-  updateQueryParams: () => void
-}
-
 export interface CreateOfferBlockProps<T> {
   data: T
   errors: Record<keyof T, string>
@@ -46,7 +40,7 @@ export interface CreateOfferBlockProps<T> {
 export interface FilterQueryHook<T> {
   filters: FindOffersFilters
   countActiveFilters: number
-  filterQueryActions: FindOffersFiltersActions<T>
+  filterQueryActions: FiltersActions<T>
 }
 
 export interface GetOffersParams

--- a/src/utils/count-active-filters.tsx
+++ b/src/utils/count-active-filters.tsx
@@ -1,31 +1,51 @@
 import { parseQueryParams } from '~/utils/helper-functions'
 import { isDefaultPrice, isEmptyArray } from '~/utils/range-filter'
-import { FindOffersFilters } from '~/types'
+import { FindOffersFilters, CourseFilters } from '~/types'
 
-export const countActiveOfferFilters = (
+const countActiveFilters = (
   searchParams: URLSearchParams,
-  defaultFilters: FindOffersFilters
+  defaultFilters: FindOffersFilters | CourseFilters,
+  ignoredFields: string[]
 ) => {
   const filtersFromQuery = parseQueryParams(searchParams, defaultFilters) ?? {}
-  const ignoredFields = [
-    'sort',
-    'authorRole',
-    'categoryId',
-    'subjectId',
-    'page'
-  ]
+
   return Object.entries(filtersFromQuery).reduce((count, [key, value]) => {
     if (ignoredFields.includes(key)) {
       return count
     }
-    if (key === 'price' && isDefaultPrice(value, defaultFilters.price)) {
+    if (
+      'price' in defaultFilters &&
+      key === 'price' &&
+      isDefaultPrice(value, defaultFilters.price)
+    ) {
       return count
     }
     if (isEmptyArray(value)) {
       return count
     }
     return (
-      count + (value !== defaultFilters[key as keyof FindOffersFilters] ? 1 : 0)
+      count +
+      (value !==
+      defaultFilters[key as keyof (FindOffersFilters | CourseFilters)]
+        ? 1
+        : 0)
     )
   }, 0)
 }
+
+export const countActiveOfferFilters = (
+  searchParams: URLSearchParams,
+  defaultFilters: FindOffersFilters
+) =>
+  countActiveFilters(searchParams, defaultFilters, [
+    'sort',
+    'authorRole',
+    'categoryId',
+    'subjectId',
+    'page'
+  ])
+
+export const countActiveCourseFilters = (
+  searchParams: URLSearchParams,
+  defaultFilters: CourseFilters
+) => countActiveFilters(searchParams, defaultFilters, ['sort', 'page'])

--- a/src/utils/count-active-filters.tsx
+++ b/src/utils/count-active-filters.tsx
@@ -10,17 +10,13 @@ const countActiveFilters = (
   const filtersFromQuery = parseQueryParams(searchParams, defaultFilters) ?? {}
 
   return Object.entries(filtersFromQuery).reduce((count, [key, value]) => {
-    if (ignoredFields.includes(key)) {
-      return count
-    }
     if (
-      'price' in defaultFilters &&
-      key === 'price' &&
-      isDefaultPrice(value, defaultFilters.price)
+      ignoredFields.includes(key) ||
+      ('price' in defaultFilters &&
+        key === 'price' &&
+        isDefaultPrice(value, defaultFilters.price)) ||
+      isEmptyArray(value)
     ) {
-      return count
-    }
-    if (isEmptyArray(value)) {
       return count
     }
     return (

--- a/tests/unit/containers/my-courses/add-course-with-input/AddCourseWithInput.spec.jsx
+++ b/tests/unit/containers/my-courses/add-course-with-input/AddCourseWithInput.spec.jsx
@@ -7,7 +7,7 @@ const mockedFilterActions = {
 }
 
 const mockedFilters = {
-  title: ''
+  title: 'value'
 }
 
 describe('AddCourseWithInput test', () => {
@@ -26,13 +26,28 @@ describe('AddCourseWithInput test', () => {
     expect(addBtn).toBeInTheDocument()
   })
 
-  it('should change input value', async () => {
+  it('should change and clear input value', () => {
     const input = screen.getByRole('textbox')
 
-    expect(input.value).toBe('')
+    expect(input.value).toBe('value')
 
     fireEvent.change(input, { target: { value: 'new value' } })
 
     expect(mockedFilterActions.updateFiltersInQuery).toHaveBeenCalled()
+
+    const clearButton = screen.getByTestId('ClearRoundedIcon')
+
+    fireEvent.click(clearButton)
+
+    expect(mockedFilterActions.updateFiltersInQuery).toHaveBeenCalled()
+  })
+
+  it('should render filters', () => {
+    const filters = screen.getByText('filters.filtersListTitle')
+
+    expect(filters).toBeInTheDocument()
+    fireEvent.click(filters)
+    const filtersModal = screen.getByRole('presentation')
+    expect(filtersModal).toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/my-courses/add-course-with-input/AddCourseWithInput.spec.jsx
+++ b/tests/unit/containers/my-courses/add-course-with-input/AddCourseWithInput.spec.jsx
@@ -2,9 +2,22 @@ import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '~tests/test-utils'
 import AddCourseWithInput from '~/containers/my-courses/add-course-with-input/AddCourseWithInput'
 
+const mockedFilterActions = {
+  updateFiltersInQuery: vi.fn()
+}
+
+const mockedFilters = {
+  title: ''
+}
+
 describe('AddCourseWithInput test', () => {
   beforeEach(() => {
-    renderWithProviders(<AddCourseWithInput />)
+    renderWithProviders(
+      <AddCourseWithInput
+        filterActions={mockedFilterActions}
+        filters={mockedFilters}
+      />
+    )
   })
 
   it('should render "New course" button', () => {
@@ -20,6 +33,6 @@ describe('AddCourseWithInput test', () => {
 
     fireEvent.change(input, { target: { value: 'new value' } })
 
-    expect(input.value).toBe('new value')
+    expect(mockedFilterActions.updateFiltersInQuery).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- Implemented functionality of Courses Filters Drawer (for fetching courses with category, subject, and proficiency level filters, changes in the backend part are necessary - created issue [#772](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/issues/772) for this)
- `countActiveCourseFilters` function was created, existing `countActiveOfferFilters` was splited into `countActiveFilters` function and `countActiveOfferFilters`;
- fixed test for `AddCourseWithInput`.

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/104922087/bcf9e280-05e9-487b-a39f-d179bce2cb44

**Note:** This filter works as expected only together with PR [#773](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/pull/773).

