### PR TITLE
Refactor FileUploader to emit action when the same file is added twice in a row

### DIFF
--- a/src/components/file-uploader/FileUploader.tsx
+++ b/src/components/file-uploader/FileUploader.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react'
+import { FC, ReactElement, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
@@ -51,11 +51,19 @@ const FileUploader: FC<FileUploaderProps> = ({
 }) => {
   const { t } = useTranslation()
 
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
   const { addFiles, deleteFile } = useUpload({
     files: initialState,
     emitter: emitter,
     validationData
   })
+
+  const handleClick = () => {
+    if (inputRef.current) {
+      inputRef.current.value = ''
+    }
+  }
 
   const filesList = initialState.map((item: File) => (
     <ListItem key={`${item.name}-${item.lastModified}`} sx={styles.listItem}>
@@ -73,7 +81,12 @@ const FileUploader: FC<FileUploaderProps> = ({
   const acceptableFileTypes = validationData.filesTypes.join(', ')
 
   const uploadButton = (
-    <Button component={ComponentEnum.Label} sx={sx.button} variant={variant}>
+    <Button
+      component={ComponentEnum.Label}
+      onClick={handleClick}
+      sx={sx.button}
+      variant={variant}
+    >
       {isImages && <CloudUploadIcon sx={styles.icon} />}
       {buttonText}
       {icon}
@@ -82,6 +95,7 @@ const FileUploader: FC<FileUploaderProps> = ({
         hidden
         multiple
         onChange={addFiles}
+        ref={inputRef}
         type={InputEnum.File}
       />
     </Button>

--- a/src/hooks/use-upload.tsx
+++ b/src/hooks/use-upload.tsx
@@ -37,6 +37,7 @@ const useUpload = ({ files, validationData, emitter }: UseUpload) => {
     const error = filesValidation(newFiles, validationData) ?? ''
     const filesForEmitter = error ? files : newFiles
     emitter({ files: filesForEmitter, error })
+    event.target.value = ''
   }
 
   const deleteFile = (file: File) => {

--- a/src/hooks/use-upload.tsx
+++ b/src/hooks/use-upload.tsx
@@ -37,7 +37,6 @@ const useUpload = ({ files, validationData, emitter }: UseUpload) => {
     const error = filesValidation(newFiles, validationData) ?? ''
     const filesForEmitter = error ? files : newFiles
     emitter({ files: filesForEmitter, error })
-    event.target.value = ''
   }
 
   const deleteFile = (file: File) => {


### PR DESCRIPTION
The `onChange` event for an input of type file doesn't trigger when the same file is selected twice in a row because the value of the input doesn't actually change. The browser doesn't consider selecting the same file again as a change in value, so it doesn't trigger the `onChange` event.

So i considered to reset `event.target.value` after we adding a file to resolve this problem

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/118522791/c5b3dea1-aabf-439f-986e-349e23a54843

