### PR TITLE
Fixed edit profile button

### DIFF
--- a/src/components/app-icon-button/AppIconButton.tsx
+++ b/src/components/app-icon-button/AppIconButton.tsx
@@ -1,0 +1,12 @@
+import { IconButton, IconButtonProps } from '@mui/material'
+import { FC } from 'react'
+import { Link, LinkProps } from 'react-router-dom'
+import { ComponentEnum } from '~/types'
+
+type AppIconButtonProps = IconButtonProps & Partial<LinkProps>
+
+const AppIconButton: FC<AppIconButtonProps> = ({ to, ...props }) => (
+  <IconButton component={to ? Link : ComponentEnum.Button} to={to} {...props} />
+)
+
+export default AppIconButton

--- a/src/containers/tutor-profile/profile-info/ProfileInfo.jsx
+++ b/src/containers/tutor-profile/profile-info/ProfileInfo.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
-import IconButton from '@mui/material/IconButton'
+import AppIconButton from '~/components/app-icon-button/AppIconButton'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
 import CopyRoundedIcon from '@mui/icons-material/ContentCopyRounded'
 
@@ -55,15 +55,15 @@ const ProfileInfo = ({ userData, myRole }) => {
   )
 
   const actionIconBtn = (
-    <IconButton
+    <AppIconButton
       data-testid='icon-btn'
-      href={isMyProfile && authRoutes.editProfile.path}
       onClick={!isMyProfile ? copyProfileLink : undefined}
       size={isLaptopAndAbove ? SizeEnum.Large : SizeEnum.Small}
       sx={styles.iconBtn}
+      to={isMyProfile && authRoutes.editProfile.path}
     >
       {actionIcon}
-    </IconButton>
+    </AppIconButton>
   )
 
   const accountRating = (

--- a/tests/unit/components/app-icon-button/AppIconButton.spec.jsx
+++ b/tests/unit/components/app-icon-button/AppIconButton.spec.jsx
@@ -1,0 +1,15 @@
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '~tests/test-utils'
+import AppIconButton from '~/components/app-icon-button/AppIconButton'
+
+describe('test AppIconButton component', () => {
+  it('Should render a link when url is passed', () => {
+    renderWithProviders(
+      <AppIconButton to='https://example.com'>I</AppIconButton>
+    )
+
+    const iconButtonElement = screen.getByRole('link')
+
+    expect(iconButtonElement).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
I created a new component for this task, so we won't need to pass `component={Link}` or wrap `<IconButton>` in `<Link>` each time we want to make icon button to behave as a link.


https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/4bbe5d56-4dca-4b39-92c5-283be76bc3e8

