### PR TITLE
Fixed translations on new course and new coopeation activities pages

### DIFF
--- a/src/constants/translations/en/course.json
+++ b/src/constants/translations/en/course.json
@@ -7,8 +7,8 @@
     "section": "section",
     "sections": "sections",
     "courseSection": {
-        "defaultNewTitle": "Section 1",
-        "moduleTitle": "Module 1",
+        "defaultNewTitle": "Section",
+        "moduleTitle": "Module",
         "defaultNewDescription": "Description...",
         "addResourceBtn": "Add Resource",
         "resourcesMenu": {

--- a/src/constants/translations/ua/course.json
+++ b/src/constants/translations/ua/course.json
@@ -7,8 +7,8 @@
     "section": "Розділ",
     "sections": "Розділи",
     "courseSection": {
-        "defaultNewTitle": "Розділ 1",
-        "moduleTitle": "Модуль 1",
+        "defaultNewTitle": "Розділ",
+        "moduleTitle": "Модуль",
         "defaultNewDescription": "Опис...",
         "addResourceBtn": "Додати матеріал",
         "resourcesMenu": {


### PR DESCRIPTION
Fixed translations for better code readability

### 1. Fixed translation from `Section 1` to `Section` on New Course page:

Before:

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/5fc7a11a-d1c0-4280-99fc-9819774e4b45)

After:

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/644cf99f-93a7-41fe-aca3-36458001aea6)

### 2. Fixed translation from `Module 1` to `Module` on new coopeation activities page:

Before:

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/4649bcb6-2fad-41ee-9ded-c91bddd973f2)

After:

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/4439e153-9ce0-438e-8d5b-f272d5fcab00)
