### PR TITLE
Add user photo instead of user menu icon/1823

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",
-        "@dnd-kit/core": "^6.1.0",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@emotion/react": "^11.11.1",
@@ -2439,55 +2436,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
-      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.0",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@emoji-mart/data": {

--- a/src/containers/edit-profile/profile-tab/profile-tab-inner-container/ProfileTabInnerContainer.tsx
+++ b/src/containers/edit-profile/profile-tab/profile-tab-inner-container/ProfileTabInnerContainer.tsx
@@ -20,11 +20,6 @@ const ProfileTabInnerContainer: FC<ProfileTabProps> = ({ user }) => {
     profileData.generalData.errors &&
     Object.values(profileData.generalData.errors).some((error) => error)
 
-  const handleUpdateProfile = () => {
-    handleSubmit(profileData.generalData.data)
-    window.location.reload()
-  }
-
   return (
     <Box sx={styles.profileInnerContainer}>
       <Box sx={styles.root}>
@@ -39,7 +34,7 @@ const ProfileTabInnerContainer: FC<ProfileTabProps> = ({ user }) => {
       <AppButton
         disabled={hasError}
         loading={loading}
-        onClick={handleUpdateProfile}
+        onClick={() => handleSubmit(profileData.generalData.data)}
         size={SizeEnum.ExtraLarge}
         sx={styles.updateProfileBtn}
         variant={ButtonVariantEnum.Contained}

--- a/src/containers/edit-profile/profile-tab/profile-tab-inner-container/ProfileTabInnerContainer.tsx
+++ b/src/containers/edit-profile/profile-tab/profile-tab-inner-container/ProfileTabInnerContainer.tsx
@@ -20,6 +20,11 @@ const ProfileTabInnerContainer: FC<ProfileTabProps> = ({ user }) => {
     profileData.generalData.errors &&
     Object.values(profileData.generalData.errors).some((error) => error)
 
+  const handleUpdateProfile = () => {
+    handleSubmit(profileData.generalData.data)
+    window.location.reload()
+  }
+
   return (
     <Box sx={styles.profileInnerContainer}>
       <Box sx={styles.root}>
@@ -34,7 +39,7 @@ const ProfileTabInnerContainer: FC<ProfileTabProps> = ({ user }) => {
       <AppButton
         disabled={hasError}
         loading={loading}
-        onClick={() => handleSubmit(profileData.generalData.data)}
+        onClick={handleUpdateProfile}
         size={SizeEnum.ExtraLarge}
         sx={styles.updateProfileBtn}
         variant={ButtonVariantEnum.Contained}

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -27,31 +27,38 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
     [userId, userRole]
   )
 
-  const { loading, response } = useAxios<UserResponse>({
+  const {
+    loading,
+    response: { photo, firstName, lastName }
+  } = useAxios<UserResponse>({
     service: getUserData,
     fetchOnMount: true,
     defaultResponse: defaultResponses.object as UserResponse
   })
 
-  const photoUrl =
-    response.photo &&
-    `${import.meta.env.VITE_APP_IMG_USER_URL}${response.photo}`
+  if (loading) {
+    return <Avatar sx={styles.accountIcon} />
+  }
 
-  const userNameForAvatar = loading
-    ? ''
-    : `${response.firstName?.slice(0, 1) || ''}${
-        response.lastName?.slice(0, 1) || ''
-      }`
+  let userPhoto = ''
+  if (!loading && photo) {
+    userPhoto = `${import.meta.env.VITE_APP_IMG_USER_URL}${photo}`
+  }
+
+  let userNameInitials = ''
+  if (!loading && firstName && lastName) {
+    userNameInitials = `${firstName[0] || ''}${lastName[0] || ''}`
+  }
 
   return (
     <Tooltip title={t('iconsTooltip.account')}>
       <Avatar
         alt='User'
         onClick={openMenu}
-        src={photoUrl}
+        src={userPhoto}
         sx={styles.accountIcon}
       >
-        {userNameForAvatar}
+        {userNameInitials}
       </Avatar>
     </Tooltip>
   )

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -1,4 +1,4 @@
-import { useCallback, FC } from 'react'
+import { useCallback, FC, MouseEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppSelector } from '~/hooks/use-redux'
 import { AxiosResponse } from 'axios'
@@ -15,7 +15,7 @@ import { styles } from '~/containers/navigation-icons/NavigationIcons.styles'
 import { UserResponse, UserRole } from '~/types'
 
 interface AccountIconProps {
-  openMenu: () => void
+  openMenu: (event: MouseEvent) => void
 }
 
 const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -39,7 +39,7 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
 
   const userNameForAvatar = loading
     ? ''
-    : response.firstName.charAt(0) + '' + response.lastName.charAt(0)
+    : `${response.firstName.slice(0, 1)}${response.lastName.slice(0, 1)}`
 
   return (
     <Tooltip title={t('iconsTooltip.account')}>

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -39,7 +39,9 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
 
   const userNameForAvatar = loading
     ? ''
-    : `${response.firstName.slice(0, 1)}${response.lastName.slice(0, 1)}`
+    : `${response.firstName?.slice(0, 1) || ''}${
+        response.lastName?.slice(0, 1) || ''
+      }`
 
   return (
     <Tooltip title={t('iconsTooltip.account')}>

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -20,7 +20,6 @@ interface AccountIconProps {
 
 const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
   const { t } = useTranslation()
-
   const { userId, userRole } = useAppSelector((state) => state.appMain)
 
   const getUserData: () => Promise<AxiosResponse<UserResponse>> = useCallback(
@@ -34,6 +33,10 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
     defaultResponse: defaultResponses.object as UserResponse
   })
 
+  const photoUrl =
+    response.photo &&
+    `${import.meta.env.VITE_APP_IMG_USER_URL}${response.photo}`
+
   const userNameForAvatar = loading
     ? ''
     : response.firstName.charAt(0) + '' + response.lastName.charAt(0)
@@ -43,11 +46,8 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
       <Avatar
         alt='User'
         onClick={openMenu}
-        src={
-          response.photo &&
-          `${import.meta.env.VITE_APP_IMG_USER_URL}${response.photo}`
-        }
-        sx={styles.studentIcons}
+        src={photoUrl}
+        sx={styles.accountIcon}
       >
         {userNameForAvatar}
       </Avatar>

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -1,0 +1,61 @@
+import { useCallback, useMemo, FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useAppSelector } from '~/hooks/use-redux'
+import { AxiosResponse } from 'axios'
+
+import Avatar from '@mui/material/Avatar'
+import Tooltip from '@mui/material/Tooltip'
+
+import { userService } from '~/services/user-service'
+import useAxios from '~/hooks/use-axios'
+import { defaultResponses } from '~/constants'
+
+import { styles } from '~/containers/navigation-icons/NavigationIcons.styles'
+
+import { UserResponse, UserRole } from '~/types'
+
+interface AccountIconProps {
+  openMenu: () => void
+}
+
+const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
+  const { t } = useTranslation()
+
+  const { userId, userRole } = useAppSelector((state) => state.appMain)
+
+  const getUserData: () => Promise<AxiosResponse<UserResponse>> = useCallback(
+    () => userService.getUserById(userId, userRole as UserRole),
+    [userId, userRole]
+  )
+
+  const { response } = useAxios<UserResponse>({
+    service: getUserData,
+    fetchOnMount: true,
+    defaultResponse: defaultResponses.object as UserResponse
+  })
+
+  const userNameForAvatar = useMemo(() => {
+    if (response.firstName && response.lastName) {
+      return response.firstName.charAt(0) + '' + response.lastName.charAt(0)
+    }
+    return ''
+  }, [response.firstName, response.lastName])
+
+  return (
+    <Tooltip title={t('iconsTooltip.account')}>
+      <Avatar
+        alt='User'
+        onClick={openMenu}
+        src={
+          response.photo &&
+          `${import.meta.env.VITE_APP_IMG_USER_URL}${response.photo}`
+        }
+        sx={styles.studentIcons}
+      >
+        {userNameForAvatar}
+      </Avatar>
+    </Tooltip>
+  )
+}
+
+export default AccountIcon

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -51,7 +51,7 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
   }
 
   return (
-    <Tooltip title={t('iconsTooltip.account')}>
+    <Tooltip arrow title={t('iconsTooltip.account')}>
       <Avatar
         alt='User'
         onClick={openMenu}

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, FC } from 'react'
+import { useCallback, FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppSelector } from '~/hooks/use-redux'
 import { AxiosResponse } from 'axios'
@@ -28,18 +28,15 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
     [userId, userRole]
   )
 
-  const { response } = useAxios<UserResponse>({
+  const { loading, response } = useAxios<UserResponse>({
     service: getUserData,
     fetchOnMount: true,
     defaultResponse: defaultResponses.object as UserResponse
   })
 
-  const userNameForAvatar = useMemo(() => {
-    if (response.firstName && response.lastName) {
-      return response.firstName.charAt(0) + '' + response.lastName.charAt(0)
-    }
-    return ''
-  }, [response.firstName, response.lastName])
+  const userNameForAvatar = loading
+    ? ''
+    : response.firstName.charAt(0) + '' + response.lastName.charAt(0)
 
   return (
     <Tooltip title={t('iconsTooltip.account')}>

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -47,7 +47,7 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
 
   let userNameInitials = ''
   if (!loading && firstName && lastName) {
-    userNameInitials = `${firstName[0] || ''}${lastName[0] || ''}`
+    userNameInitials = `${firstName[0]}${lastName[0]}`
   }
 
   return (

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -40,25 +40,15 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
     return <Avatar sx={styles.accountIcon} />
   }
 
-  let userPhoto = ''
-  if (!loading && photo) {
-    userPhoto = `${import.meta.env.VITE_APP_IMG_USER_URL}${photo}`
-  }
-
-  let userNameInitials = ''
-  if (!loading && firstName && lastName) {
-    userNameInitials = `${firstName[0]}${lastName[0]}`
-  }
-
   return (
     <Tooltip arrow title={t('iconsTooltip.account')}>
       <Avatar
         alt='User Avatar'
         onClick={openMenu}
-        src={userPhoto}
+        src={`${import.meta.env.VITE_APP_IMG_USER_URL}${photo}`}
         sx={styles.accountIcon}
       >
-        {userNameInitials}
+        {!loading && firstName && lastName && `${firstName[0]}${lastName[0]}`}
       </Avatar>
     </Tooltip>
   )

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -53,7 +53,7 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
   return (
     <Tooltip arrow title={t('iconsTooltip.account')}>
       <Avatar
-        alt='User'
+        alt='User Avatar'
         onClick={openMenu}
         src={userPhoto}
         sx={styles.accountIcon}

--- a/src/containers/navigation-icons/NavigationIcons.constants.tsx
+++ b/src/containers/navigation-icons/NavigationIcons.constants.tsx
@@ -6,7 +6,7 @@ import LoginIcon from '@mui/icons-material/Login'
 import MessageRoundedIcon from '@mui/icons-material/MessageRounded'
 import BookmarkIcon from '@mui/icons-material/Bookmark'
 import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded'
-import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined'
+
 import { IconButtonProps } from '@mui/material/IconButton'
 
 import { authRoutes } from '~/router/constants/authRoutes'
@@ -85,14 +85,6 @@ export const userIcons: NavigationIconButton[] = [
     icon: <NotificationsRoundedIcon />,
     buttonProps: ({ openNotifications }) => ({
       onClick: openNotifications,
-      sx: styles.studentIcons
-    })
-  },
-  {
-    tooltip: 'iconsTooltip.account',
-    icon: <AccountCircleOutlinedIcon />,
-    buttonProps: ({ openAccountMenu }) => ({
-      onClick: openAccountMenu,
       sx: styles.studentIcons
     })
   },

--- a/src/containers/navigation-icons/NavigationIcons.styles.ts
+++ b/src/containers/navigation-icons/NavigationIcons.styles.ts
@@ -1,4 +1,5 @@
 const hideOnMobile = { display: { xs: 'none', md: 'inherit' } }
+import { TypographyVariantEnum } from '~/types'
 
 export const styles = {
   iconBox: {
@@ -21,6 +22,7 @@ export const styles = {
   accountIcon: {
     ...hideOnMobile,
     color: 'primary.900',
-    ml: { sm: '12px', md: '7px', lg: '12px' }
+    ml: { sm: '12px', md: '7px', lg: '12px' },
+    typography: TypographyVariantEnum.Button
   }
 }

--- a/src/containers/navigation-icons/NavigationIcons.styles.ts
+++ b/src/containers/navigation-icons/NavigationIcons.styles.ts
@@ -14,5 +14,13 @@ export const styles = {
     ...hideOnMobile,
     ml: '12px'
   },
-  studentIcons: { ...hideOnMobile, color: 'primary.900' }
+  studentIcons: {
+    ...hideOnMobile,
+    color: 'primary.900'
+  },
+  accountIcon: {
+    ...hideOnMobile,
+    color: 'primary.900',
+    ml: { sm: '12px', md: '7px', lg: '12px' }
+  }
 }

--- a/src/containers/navigation-icons/NavigationIcons.styles.ts
+++ b/src/containers/navigation-icons/NavigationIcons.styles.ts
@@ -1,4 +1,7 @@
-const hideOnMobile = { display: { xs: 'none', md: 'inherit' } }
+const hideOnMobile = {
+  display: { xs: 'none', md: 'inherit' },
+  color: 'primary.900'
+}
 import { TypographyVariantEnum } from '~/types'
 
 export const styles = {
@@ -16,13 +19,11 @@ export const styles = {
     ml: '12px'
   },
   studentIcons: {
-    ...hideOnMobile,
-    color: 'primary.900'
+    ...hideOnMobile
   },
   accountIcon: {
     ...hideOnMobile,
-    color: 'primary.900',
-    ml: { sm: '12px', md: '7px', lg: '12px' },
+    ml: { sm: '12px', md: '12px', lg: '12px' },
     typography: TypographyVariantEnum.Button
   }
 }

--- a/src/containers/navigation-icons/user-icons/UserIcons.tsx
+++ b/src/containers/navigation-icons/user-icons/UserIcons.tsx
@@ -82,7 +82,7 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
         anchorEl={languageMenuAnchorEl}
         onClose={closeLanguageMenu}
       />
-      <AccountIcon openMenu={openMenu} />
+      <AccountIcon openMenu={openAccountMenu} />
       <AccountMenu anchorEl={accountMenuAnchorEl} onClose={closeAccountMenu} />
       <NotificationsMenu
         anchorEl={notificationsAnchor}

--- a/src/containers/navigation-icons/user-icons/UserIcons.tsx
+++ b/src/containers/navigation-icons/user-icons/UserIcons.tsx
@@ -5,6 +5,7 @@ import Box from '@mui/material/Box'
 
 import useMenu from '~/hooks/use-menu'
 import NavigationIcon from '~/components/navigation-icon/NavigationIcon'
+import AccountIcon from '~/containers/navigation-icons/AccountIcon'
 import {
   mockNotifications,
   userIcons
@@ -81,6 +82,7 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
         anchorEl={languageMenuAnchorEl}
         onClose={closeLanguageMenu}
       />
+      <AccountIcon openMenu={openMenu} />
       <AccountMenu anchorEl={accountMenuAnchorEl} onClose={closeAccountMenu} />
       <NotificationsMenu
         anchorEl={notificationsAnchor}

--- a/src/hooks/use-update-user.tsx
+++ b/src/hooks/use-update-user.tsx
@@ -59,6 +59,13 @@ const useUpdateUser = (userId: string) => {
 
     if (photo !== undefined) updatedData.photo = photo
 
+    if (updatedData.photo) {
+      handleResponse()
+      setTimeout(() => {
+        window.location.reload()
+      }, 2000)
+    }
+
     fetchData(updatedData).catch(console.error)
   }
 

--- a/src/hooks/use-update-user.tsx
+++ b/src/hooks/use-update-user.tsx
@@ -59,7 +59,7 @@ const useUpdateUser = (userId: string) => {
 
     if (photo !== undefined) updatedData.photo = photo
 
-    if (updatedData.photo) {
+    if (updatedData.photo || updatedData.photo === null) {
       handleResponse()
       setTimeout(() => {
         window.location.reload()

--- a/src/hooks/use-update-user.tsx
+++ b/src/hooks/use-update-user.tsx
@@ -18,6 +18,7 @@ const useUpdateUser = (userId: string) => {
       severity: snackbarVariants.success,
       message: 'editProfilePage.profile.successMessage'
     })
+    window.location.reload()
   }
 
   const handleResponseError = (error: ErrorResponse) => {
@@ -58,11 +59,6 @@ const useUpdateUser = (userId: string) => {
     }
 
     if (photo !== undefined) updatedData.photo = photo
-
-    if (updatedData.photo || updatedData.photo === null) {
-      handleResponse()
-      window.location.reload()
-    }
 
     fetchData(updatedData).catch(console.error)
   }

--- a/src/hooks/use-update-user.tsx
+++ b/src/hooks/use-update-user.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { useNavigate } from 'react-router'
 import { snackbarVariants } from '~/constants'
 import { useSnackBarContext } from '~/context/snackbar-context'
 import { userService } from '~/services/user-service'
@@ -7,6 +8,8 @@ import useAxios from './use-axios'
 
 const useUpdateUser = (userId: string) => {
   const { setAlert } = useSnackBarContext()
+
+  const navigate = useNavigate()
 
   const updateUser = useCallback(
     (data: UpdateUserParams) => userService.updateUser(userId, data),
@@ -18,7 +21,7 @@ const useUpdateUser = (userId: string) => {
       severity: snackbarVariants.success,
       message: 'editProfilePage.profile.successMessage'
     })
-    window.location.reload()
+    navigate(0)
   }
 
   const handleResponseError = (error: ErrorResponse) => {

--- a/src/hooks/use-update-user.tsx
+++ b/src/hooks/use-update-user.tsx
@@ -61,9 +61,7 @@ const useUpdateUser = (userId: string) => {
 
     if (updatedData.photo || updatedData.photo === null) {
       handleResponse()
-      setTimeout(() => {
-        window.location.reload()
-      }, 2000)
+      window.location.reload()
     }
 
     fetchData(updatedData).catch(console.error)

--- a/tests/unit/containers/navbar/NavBar.spec.jsx
+++ b/tests/unit/containers/navbar/NavBar.spec.jsx
@@ -15,6 +15,12 @@ vi.mock('~/containers/guest-home-page/google-button/GoogleButton', () => ({
   }
 }))
 
+vi.mock('~/containers/navigation-icons/AccountIcon', () => ({
+  default: function () {
+    return <button>AccountIcon</button>
+  }
+}))
+
 describe('Guest NavBar test', () => {
   const preloadedState = { appMain: { loading: false, userRole: '' } }
   beforeEach(() => {
@@ -63,8 +69,7 @@ describe('Student NavBar test', () => {
     expect(text).toBeInTheDocument()
   })
   it('should render account icon', () => {
-    const icon = screen.getByTestId('AccountCircleOutlinedIcon')
-
-    expect(icon).toBeInTheDocument()
+    const accountIcon = screen.getByText('AccountIcon')
+    expect(accountIcon).toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
+++ b/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
@@ -21,7 +21,7 @@ describe('AccountIcon test with user role', () => {
   })
 
   it('should render click menu icon and open account menu after click on it', async () => {
-    const AccountIconButton = await screen.findByAltText('User')
+    const AccountIconButton = await screen.findByAltText('User Avatar')
     expect(AccountIconButton).toBeInTheDocument()
 
     fireEvent.click(AccountIconButton)

--- a/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
+++ b/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
@@ -1,0 +1,34 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { expect } from 'vitest'
+import AccountIcon from '~/containers/navigation-icons/AccountIcon'
+import { renderWithProviders } from '~tests/test-utils'
+
+const mockOpenMenu = vi.fn()
+
+vi.mock('~/services/user-service', () => ({
+  userService: {
+    getUserById: () => ({
+      data: { firstName: 'John', lastName: 'Doe', photo: 'path-to-photo' }
+    })
+  }
+}))
+
+describe('AccountIcon test with user role', () => {
+  const preloadedState = { appMain: { userRole: 'tutor' } }
+  beforeEach(() => {
+    renderWithProviders(<AccountIcon openMenu={mockOpenMenu} />, {
+      preloadedState
+    })
+  })
+
+  it('should render click menu icon and open account menu after click on it', async () => {
+    const AccountIconButton = await screen.findByAltText('User')
+    expect(AccountIconButton).toBeInTheDocument()
+
+    fireEvent.click(AccountIconButton)
+
+    await waitFor(() => {
+      expect(mockOpenMenu).toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
+++ b/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
@@ -1,5 +1,4 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
-import { expect } from 'vitest'
 import AccountIcon from '~/containers/navigation-icons/AccountIcon'
 import { renderWithProviders } from '~tests/test-utils'
 

--- a/tests/unit/containers/navigation-icons/user-icons/UserIcons.spec.jsx
+++ b/tests/unit/containers/navigation-icons/user-icons/UserIcons.spec.jsx
@@ -6,9 +6,20 @@ import { vi } from 'vitest'
 const openLoginDialog = vi.fn()
 const setIsSidebarOpen = vi.fn()
 
+vi.mock('~/containers/navigation-icons/AccountIcon', () => ({
+  default: function () {
+    return <button>AccountIcon</button>
+  }
+}))
+
 describe('test with user role', () => {
   beforeEach(() => {
-    renderWithProviders(<UserIcons openLoginDialog={ openLoginDialog } setSidebarOpen={ setIsSidebarOpen } />)
+    renderWithProviders(
+      <UserIcons
+        openLoginDialog={openLoginDialog}
+        setSidebarOpen={setIsSidebarOpen}
+      />
+    )
   })
 
   it('should render login icon', () => {
@@ -27,15 +38,15 @@ describe('test with user role', () => {
   it('should render tooltip title', async () => {
     const messageIcon = screen.getByTestId('MessageRoundedIcon')
     fireEvent.mouseOver(messageIcon)
-    const messagesTooltipTitle = await screen.findByText('iconsTooltip.messages')
+    const messagesTooltipTitle = await screen.findByText(
+      'iconsTooltip.messages'
+    )
 
     expect(messagesTooltipTitle).toBeInTheDocument()
   })
-  it('should open account menu', async () => {
-    const accountMenuIcon = screen.getByTestId('AccountCircleOutlinedIcon')
-    fireEvent.click(accountMenuIcon)
-    const accountMenuLogout = await screen.findByText('header.logout')
 
-    expect(accountMenuLogout).toBeInTheDocument()
+  it('should render account menu icon', async () => {
+    const accountMenuIcon = await screen.findByText('AccountIcon')
+    expect(accountMenuIcon).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
In this pull request:
- Created new component AccountIcon (in the folder navigation-icons)(there was no posibility to add this element to exisisting file with NavigationIcons.constants)
- Added tests to this implementation
- Removed previous MUI element from NavigationIcons.constants
- Fixed tests for NavBar and UserIcons component
- Added immediate reload of the page after clicking on 'Update profile' button for changin the Avatar without user intervention

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/4e14b838-fe58-4e34-9da8-a919f0fbd29f)




https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/600bdfde-088c-4d79-a518-7f99c3c1c3a4




