### PR TITLE
Fixed course template view

### DIFF
--- a/src/components/course-card/CourseCard.styles.ts
+++ b/src/components/course-card/CourseCard.styles.ts
@@ -25,7 +25,6 @@ export const styles = {
     flexDirection: 'column',
     justifyContent: 'space-between',
     minHeight: '285px',
-    minWidth: '360px',
     height: '100%',
     boxSizing: 'border-box',
     backgroundColor: 'basic.white',

--- a/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.styles.ts
+++ b/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.styles.ts
@@ -39,11 +39,6 @@ export const styles = {
     cursor: 'pointer'
   },
   cardsWrapper: {
-    display: 'grid',
-    gridTemplateColumns: {
-      md: 'repeat(2, minmax(330px, 1fr))',
-      lg: 'repeat(3, minmax(330px, 1fr))'
-    },
     gap: '16px',
     mb: 0
   },
@@ -55,11 +50,7 @@ export const styles = {
   }),
   card: {
     card: {
-      maxWidth: '390px',
-      maxHeight: '245px',
-      width: '100%',
-      height: '100%',
-      boxSizing: 'border-box',
+      minHeight: '245px',
       cursor: 'pointer'
     },
     title: { typography: TypographyVariantEnum.MidTitle },

--- a/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.styles.ts
+++ b/src/containers/cooperation-details/add-course-modal-modal/AddCourseTemplateModal.styles.ts
@@ -4,10 +4,12 @@ import { TypographyVariantEnum } from '~/types'
 export const styles = {
   root: {
     width: { lg: '1130px', md: '786px', xs: '100%' },
-    height: '600px',
+    height: { xs: '100svh', sm: '600px' },
     p: { sm: '40px', xs: '20px' },
     boxSizing: 'border-box',
-    backgroundColor: 'backgroundColor'
+    backgroundColor: 'backgroundColor',
+    display: 'flex',
+    flexDirection: 'column'
   },
   titleWithDescription: {
     title: { typography: TypographyVariantEnum.H5 },
@@ -46,7 +48,8 @@ export const styles = {
     height: isFiltersOpened ? '228px' : '300px',
     margin: '16px 0',
     overflow: 'auto',
-    padding: '10px 20px 10px 10px'
+    padding: '10px 20px 10px 10px',
+    flex: '3 0 auto'
   }),
   card: {
     card: {


### PR DESCRIPTION
Changed some styles so there are no repetitions between styles passed down from `AddCourseTemplateModal` and default styles of `CourseCard` and `MyCorsesCardsList`. Also, made changes in `max-width` and `max-height`, so everything displays correctly.

Also I fixed `AddCourseTemplateModal` for mobiles, as previously its height was hardcoded and it covered only half of a screen. Now it covers all screen height on small devices. (previous behaviour shown on screenshot).

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/8d39dbae-7538-4aa4-8617-3f667341bbd4)

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/45f78087-0987-4d35-af57-213a216a9c1b

