### PR TITLE
Feature/1818/translation fuctionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",
+        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@emotion/react": "^11.11.1",
@@ -2436,6 +2439,55 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
+      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emoji-mart/data": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "dependencies": {
     "@date-io/date-fns": "^2.17.0",
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@emotion/react": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "dependencies": {
     "@date-io/date-fns": "^2.17.0",
-    "@dnd-kit/core": "^6.1.0",
-    "@dnd-kit/sortable": "^8.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
     "@emotion/react": "^11.11.1",

--- a/src/components/popular-categories/PopularCategories.tsx
+++ b/src/components/popular-categories/PopularCategories.tsx
@@ -86,7 +86,7 @@ const PopularCategories: FC<PopularCategoriesProps> = ({
         <Loader />
       ) : (
         <CardsList
-          btnText={t('common.goToName', { name: 'categories' })}
+          btnText={t('common.goToCategories')}
           cards={cards}
           onClick={onClickButton}
         />

--- a/src/constants/translations/en/common.json
+++ b/src/constants/translations/en/common.json
@@ -23,6 +23,7 @@
   "uahSlashHour": "UAH/hour",
   "beginner": "Beginner",
   "offers": "offers",
+  "goToCategories": "Go to categories",
   "popularCategories": "Popular Categories",
   "aboutOffer": "About Offer",
   "goToName": "Go to {{name}}",

--- a/src/constants/translations/ua/common.json
+++ b/src/constants/translations/ua/common.json
@@ -23,6 +23,7 @@
   "uahSlashHour": "ГРН/годину",
   "beginner": "Початковий",
   "offers": "Пропозиції",
+  "goToCategories": "Перейти до категорій",
   "popularCategories": "Популярні категорії",
   "aboutOffer": "Про пропозицію",
   "goToName": "Перейти до {{name}}",

--- a/src/containers/layout/account-menu/AccountMenu.tsx
+++ b/src/containers/layout/account-menu/AccountMenu.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
 import MenuItem from '@mui/material/MenuItem'
+import { MenuProps } from '@mui/material'
 
 import AppMenu from '~/components/app-menu/AppMenu'
 import { authRoutes } from '~/router/constants/authRoutes'
@@ -10,7 +11,7 @@ import { authRoutes } from '~/router/constants/authRoutes'
 import { styles } from '~/containers/layout/account-menu/AccountMenu.styles'
 
 interface AccountMenuProps {
-  anchorEl: Element | null
+  anchorEl: MenuProps['anchorEl']
   onClose: () => void
 }
 

--- a/src/containers/layout/language-menu/LanguageMenu.constants.ts
+++ b/src/containers/layout/language-menu/LanguageMenu.constants.ts
@@ -1,0 +1,10 @@
+export const languageMenuConstants = [
+  {
+    languageCode: 'en',
+    language: 'English'
+  },
+  {
+    languageCode: 'ua',
+    language: 'Українська'
+  }
+]

--- a/src/containers/layout/language-menu/LanguageMenu.constants.ts
+++ b/src/containers/layout/language-menu/LanguageMenu.constants.ts
@@ -1,10 +1,10 @@
 export const languageMenuConstants = [
   {
-    languageCode: 'en',
-    language: 'English'
+    value: 'en',
+    label: 'English'
   },
   {
-    languageCode: 'ua',
-    language: 'Українська'
+    value: 'ua',
+    label: 'Українська'
   }
 ]

--- a/src/containers/layout/language-menu/LanguageMenu.styles.tsx
+++ b/src/containers/layout/language-menu/LanguageMenu.styles.tsx
@@ -1,0 +1,5 @@
+export const styles = {
+  active: {
+    backgroundColor: 'primary.100'
+  }
+}

--- a/src/containers/layout/language-menu/LanguageMenu.tsx
+++ b/src/containers/layout/language-menu/LanguageMenu.tsx
@@ -35,13 +35,14 @@ const LanguageMenu: FC<LanguageMenuProps> = ({ anchorEl, onClose }) => {
   }
 
   const menuItems = languageMenuConstants.map(({ language, languageCode }) => {
-    const sx = i18n.language === languageCode ? styles.active : undefined
+    const menuItemStyles =
+      i18n.language === languageCode ? styles.active : undefined
 
     return (
       <MenuItem
         key={languageCode}
         onClick={() => handleLanguageChange(languageCode)}
-        sx={sx}
+        sx={menuItemStyles}
       >
         {language}
       </MenuItem>

--- a/src/containers/layout/language-menu/LanguageMenu.tsx
+++ b/src/containers/layout/language-menu/LanguageMenu.tsx
@@ -1,11 +1,14 @@
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
+
 import MenuItem from '@mui/material/MenuItem'
 import Menu, { MenuProps } from '@mui/material/Menu'
-import { styles } from '~/containers/layout/language-menu/LanguageMenu.styles'
+
 import { languageMenuConstants } from '~/containers/layout/language-menu/LanguageMenu.constants'
 import { setToLocalStorage } from '~/services/local-storage-service'
 import { useSnackBarContext } from '~/context/snackbar-context'
+
+import { styles } from '~/containers/layout/language-menu/LanguageMenu.styles'
 
 interface LanguageMenuProps {
   anchorEl: MenuProps['anchorEl']
@@ -32,11 +35,13 @@ const LanguageMenu: FC<LanguageMenuProps> = ({ anchorEl, onClose }) => {
   }
 
   const menuItems = languageMenuConstants.map(({ language, languageCode }) => {
+    const sx = i18n.language === languageCode ? styles.active : undefined
+
     return (
       <MenuItem
         key={languageCode}
         onClick={() => handleLanguageChange(languageCode)}
-        sx={i18n.language === languageCode ? styles.active : {}}
+        sx={sx}
       >
         {language}
       </MenuItem>

--- a/src/containers/layout/language-menu/LanguageMenu.tsx
+++ b/src/containers/layout/language-menu/LanguageMenu.tsx
@@ -1,0 +1,53 @@
+import { FC } from 'react'
+import { useTranslation } from 'react-i18next'
+import MenuItem from '@mui/material/MenuItem'
+import Menu, { MenuProps } from '@mui/material/Menu'
+import { styles } from '~/containers/layout/language-menu/LanguageMenu.styles'
+import { languageMenuConstants } from '~/containers/layout/language-menu/LanguageMenu.constants'
+import { setToLocalStorage } from '~/services/local-storage-service'
+import { useSnackBarContext } from '~/context/snackbar-context'
+
+interface LanguageMenuProps {
+  anchorEl: MenuProps['anchorEl']
+  onClose: () => void
+}
+const LanguageMenu: FC<LanguageMenuProps> = ({ anchorEl, onClose }) => {
+  const { i18n } = useTranslation()
+  const { setAlert } = useSnackBarContext()
+
+  const handleLanguageChange = (language: string) => {
+    i18n
+      .changeLanguage(language)
+      .then(() => {
+        setToLocalStorage('language', language)
+        onClose()
+      })
+      .catch(() => {
+        setAlert({
+          message: 'Failed to change language',
+          severity: 'error',
+          duration: 1000
+        })
+      })
+  }
+
+  const menuItems = languageMenuConstants.map(({ language, languageCode }) => {
+    return (
+      <MenuItem
+        key={languageCode}
+        onClick={() => handleLanguageChange(languageCode)}
+        sx={i18n.language === languageCode ? styles.active : {}}
+      >
+        {language}
+      </MenuItem>
+    )
+  })
+
+  return (
+    <Menu anchorEl={anchorEl} onClose={onClose} open={Boolean(anchorEl)}>
+      {menuItems}
+    </Menu>
+  )
+}
+
+export default LanguageMenu

--- a/src/containers/layout/language-menu/LanguageMenu.tsx
+++ b/src/containers/layout/language-menu/LanguageMenu.tsx
@@ -34,17 +34,16 @@ const LanguageMenu: FC<LanguageMenuProps> = ({ anchorEl, onClose }) => {
       })
   }
 
-  const menuItems = languageMenuConstants.map(({ language, languageCode }) => {
-    const menuItemStyles =
-      i18n.language === languageCode ? styles.active : undefined
+  const menuItems = languageMenuConstants.map(({ value, label }) => {
+    const menuItemStyles = i18n.language === value ? styles.active : undefined
 
     return (
       <MenuItem
-        key={languageCode}
-        onClick={() => handleLanguageChange(languageCode)}
+        key={value}
+        onClick={() => handleLanguageChange(value)}
         sx={menuItemStyles}
       >
-        {language}
+        {label}
       </MenuItem>
     )
   })

--- a/src/containers/layout/notifications-menu/NotificationsMenu.tsx
+++ b/src/containers/layout/notifications-menu/NotificationsMenu.tsx
@@ -6,6 +6,7 @@ import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 import Link from '@mui/material/Link'
+import { MenuProps } from '@mui/material'
 
 import AppMenu from '~/components/app-menu/AppMenu'
 import AppButton from '~/components/app-button/AppButton'
@@ -13,15 +14,15 @@ import { ButtonVariantEnum, Notification, SizeEnum } from '~/types'
 import { styles } from '~/containers/layout/notifications-menu/NotificationsMenu.styles'
 import { liksByType } from '~/containers/layout/notifications-menu/NotificationsMenu.constants'
 
-interface NotificationsMenuuProps {
-  anchorEl: Element | null
+interface NotificationsMenuProps {
+  anchorEl: MenuProps['anchorEl']
   onClose: () => void
   items: Notification[]
   onDelete: (item: Notification) => void
   onClear: () => void
 }
 
-const NotificationsMenu: FC<NotificationsMenuuProps> = ({
+const NotificationsMenu: FC<NotificationsMenuProps> = ({
   anchorEl,
   items,
   onClear,

--- a/src/containers/navigation-icons/NavigationIcons.constants.tsx
+++ b/src/containers/navigation-icons/NavigationIcons.constants.tsx
@@ -15,9 +15,10 @@ import { styles } from '~/containers/navigation-icons/NavigationIcons.styles'
 
 type ButtonProps = (props: {
   openLoginDialog?: () => void
-  openMenu?: () => void
+  openAccountMenu?: (event: React.MouseEvent<HTMLButtonElement>) => void
   setSidebarOpen?: () => void
-  openNotifications?: () => void
+  openNotifications?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  openLanguageMenu?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }) => IconButtonProps
 
 type BadgeContent = (props: { notifications: number }) => number
@@ -30,11 +31,13 @@ interface NavigationIconButton {
   badgeContent?: BadgeContent
 }
 
-const languageIcon = {
-  disabled: true,
+const languageIcon: NavigationIconButton = {
   tooltip: 'iconsTooltip.language',
-  icon: <LanguageIcon color='disabled' />,
-  buttonProps: () => ({ sx: styles.studentIcons })
+  icon: <LanguageIcon />,
+  buttonProps: ({ openLanguageMenu }) => ({
+    onClick: openLanguageMenu,
+    sx: styles.studentIcons
+  })
 }
 
 const menuIcon: NavigationIconButton = {
@@ -88,8 +91,8 @@ export const userIcons: NavigationIconButton[] = [
   {
     tooltip: 'iconsTooltip.account',
     icon: <AccountCircleOutlinedIcon />,
-    buttonProps: ({ openMenu }) => ({
-      onClick: openMenu,
+    buttonProps: ({ openAccountMenu }) => ({
+      onClick: openAccountMenu,
       sx: styles.studentIcons
     })
   },

--- a/src/containers/navigation-icons/user-icons/UserIcons.tsx
+++ b/src/containers/navigation-icons/user-icons/UserIcons.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
 
+import useMenu from '~/hooks/use-menu'
 import NavigationIcon from '~/components/navigation-icon/NavigationIcon'
 import {
   mockNotifications,
@@ -12,6 +13,7 @@ import {
 import { styles } from '~/containers/navigation-icons/NavigationIcons.styles'
 import AccountMenu from '~/containers/layout/account-menu/AccountMenu'
 import NotificationsMenu from '~/containers/layout/notifications-menu/NotificationsMenu'
+import LanguageMenu from '~/containers/layout/language-menu/LanguageMenu'
 import { Notification } from '~/types'
 
 interface UserIconsProps {
@@ -21,16 +23,25 @@ interface UserIconsProps {
 const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
   const [notificationItems, setNotificationItems] =
     useState<Notification[]>(mockNotifications)
-  const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null)
-  const [notificationsAnchor, setNotificationsAnchor] =
-    useState<HTMLElement | null>(null)
-  const anchorRef = useRef<HTMLDivElement | null>(null)
+  const {
+    anchorEl: accountenuAnchorEl,
+    openMenu: openAccountMenu,
+    closeMenu: closeAccountMenu
+  } = useMenu()
+  const {
+    anchorEl: notificationsAnchor,
+    openMenu: openNotifications,
+    closeMenu: closeNotifications
+  } = useMenu()
+  const {
+    anchorEl: languageMenuAnchorEl,
+    openMenu: openLanguageMenu,
+    closeMenu: closeLanguageMenu
+  } = useMenu()
+
   const { t } = useTranslation()
 
-  const openMenu = () => setMenuAnchorEl(anchorRef.current)
-  const closeMenu = () => setMenuAnchorEl(null)
-  const openNotifications = () => setNotificationsAnchor(anchorRef.current)
-  const closeNotifications = () => setNotificationsAnchor(null)
+  const anchorRef = useRef<HTMLDivElement | null>(null)
 
   const icons = userIcons.map(
     (item) =>
@@ -40,9 +51,10 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
             notifications: notificationItems.length
           })}
           buttonProps={item.buttonProps({
-            openMenu,
+            openAccountMenu,
             openNotifications,
-            setSidebarOpen
+            setSidebarOpen,
+            openLanguageMenu
           })}
           icon={item.icon}
           key={item.tooltip}
@@ -65,7 +77,11 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
   return (
     <Box ref={anchorRef} sx={styles.iconBox}>
       {icons}
-      <AccountMenu anchorEl={menuAnchorEl} onClose={closeMenu} />
+      <LanguageMenu
+        anchorEl={languageMenuAnchorEl}
+        onClose={closeLanguageMenu}
+      />
+      <AccountMenu anchorEl={accountenuAnchorEl} onClose={closeAccountMenu} />
       <NotificationsMenu
         anchorEl={notificationsAnchor}
         items={notificationItems}

--- a/src/containers/navigation-icons/user-icons/UserIcons.tsx
+++ b/src/containers/navigation-icons/user-icons/UserIcons.tsx
@@ -24,7 +24,7 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
   const [notificationItems, setNotificationItems] =
     useState<Notification[]>(mockNotifications)
   const {
-    anchorEl: accountenuAnchorEl,
+    anchorEl: accountMenuAnchorEl,
     openMenu: openAccountMenu,
     closeMenu: closeAccountMenu
   } = useMenu()
@@ -81,7 +81,7 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
         anchorEl={languageMenuAnchorEl}
         onClose={closeLanguageMenu}
       />
-      <AccountMenu anchorEl={accountenuAnchorEl} onClose={closeAccountMenu} />
+      <AccountMenu anchorEl={accountMenuAnchorEl} onClose={closeAccountMenu} />
       <NotificationsMenu
         anchorEl={notificationsAnchor}
         items={notificationItems}

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -1,10 +1,13 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import resources from '~/constants/translations'
+import { getFromLocalStorage } from '~/services/local-storage-service'
+
+const initialLanguage = getFromLocalStorage('language') || 'en'
 
 void i18n.use(initReactI18next).init({
   resources,
-  lng: 'en',
+  lng: initialLanguage,
   ns: ['translations']
 })
 

--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -1,9 +1,19 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import resources from '~/constants/translations'
-import { getFromLocalStorage } from '~/services/local-storage-service'
+import {
+  getFromLocalStorage,
+  setToLocalStorage
+} from '~/services/local-storage-service'
 
-const initialLanguage = getFromLocalStorage('language') || 'en'
+let initialLanguage = getFromLocalStorage('language')
+
+if (!initialLanguage) {
+  const browserLanguage = navigator.language.split('-')[0]
+  initialLanguage = browserLanguage === 'uk' ? 'ua' : 'en'
+
+  setToLocalStorage('language', initialLanguage)
+}
 
 void i18n.use(initReactI18next).init({
   resources,

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -13,6 +13,7 @@ import {
 
 export interface LocalStorage {
   'emoji-mart.last'?: string
+  language?: string
 }
 
 export interface GetUsersParams extends RequestParams {

--- a/tests/setup-tests.js
+++ b/tests/setup-tests.js
@@ -2,9 +2,8 @@ import '@testing-library/jest-dom'
 import { vi } from 'vitest'
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => {
-    return {
-      t: (str) => str
-    }
-  }
+  useTranslation: () => ({
+    i18n: { language: 'en' },
+    t: (str) => str
+  })
 }))


### PR DESCRIPTION
Added translation functionality
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/118522791/304dd3be-13a8-4293-bcad-b5137423a53e)
Video how it works. (After deleting the language from localStorage, the language will be selected from the object navigator (preferences browser language) on the next launch of the site)


https://github.com/ita-social-projects/SpaceToStudy-Client/assets/118522791/25c5ca6d-ca0a-45bd-bca6-e38dae65d749


- I added language additions to local storage.
- I found several bugs with layout and translations, which I will divide into other issues in the future. 
- Also fixed some tests that were failing
- Added an error message if the language cannot be changed

