### PR TITLE
Fix the behavior of the TitleWithDescription component tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@date-io/date-fns": "^2.17.0",
-        "@dnd-kit/core": "^6.1.0",
-        "@dnd-kit/sortable": "^8.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
         "@emotion/react": "^11.11.1",
@@ -2439,55 +2436,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.0.tgz",
-      "integrity": "sha512-ea7IkhKvlJUv9iSHJOnxinBcoOI3ppGnnL+VDJ75O45Nss6HtZd8IdN8touXPDtASfeI2T2LImb8VOZcL47wjQ==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-J3cQBClB4TVxwGo3KEjssGEXNJqGVWx17aRTZ1ob0FliR5IjYgTxl5YJbKTzA6IzrtelotH19v6y7uoIRUZPSg==",
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.0",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@emoji-mart/data": {

--- a/src/components/img-title-description/ImgTitleDescription.tsx
+++ b/src/components/img-title-description/ImgTitleDescription.tsx
@@ -25,7 +25,7 @@ const ImgTitleDescription: FC<ImgTitleDescriptionProps> = ({
 
       <TitleWithDescription
         description={description}
-        style={style.titleWithDescription}
+        style={styles.titleWithDescription}
         title={title}
       />
     </Box>

--- a/src/components/img-title-description/ImgTitleDescription.tsx
+++ b/src/components/img-title-description/ImgTitleDescription.tsx
@@ -10,7 +10,15 @@ interface ImgTitleDescriptionProps {
   img?: string
   title?: string
   description?: ReactNode
-  style?: Record<string, SxProps>
+  style?: {
+    root?: SxProps
+    img?: SxProps
+    titleWithDescription?: {
+      wrapper?: SxProps
+      title?: SxProps
+      description?: SxProps
+    }
+  }
 }
 
 const ImgTitleDescription: FC<ImgTitleDescriptionProps> = ({
@@ -25,7 +33,7 @@ const ImgTitleDescription: FC<ImgTitleDescriptionProps> = ({
 
       <TitleWithDescription
         description={description}
-        style={styles.titleWithDescription}
+        style={style.titleWithDescription}
         title={title}
       />
     </Box>

--- a/src/components/title-with-description/TitleWithDescription.tsx
+++ b/src/components/title-with-description/TitleWithDescription.tsx
@@ -14,6 +14,7 @@ interface TitleWithDescriptionProps {
     title?: SxProps
     description?: SxProps
   }
+
   isDescriptionTooltip?: boolean
 }
 
@@ -27,6 +28,7 @@ const TitleWithDescription = ({
     <Box sx={style.wrapper}>
       {title && <Typography sx={style.title}>{title}</Typography>}
       <Tooltip
+        arrow
         placement='bottom'
         title={isDescriptionTooltip ? description : ''}
       >

--- a/src/components/title-with-description/TitleWithDescription.tsx
+++ b/src/components/title-with-description/TitleWithDescription.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, ReactNode, useState } from 'react'
+import { ReactElement, ReactNode } from 'react'
 import { SxProps } from '@mui/material'
 import Tooltip from '@mui/material/Tooltip'
 import Box from '@mui/material/Box'
@@ -23,24 +23,15 @@ const TitleWithDescription = ({
   style = styles,
   isDescriptionTooltip = false
 }: TitleWithDescriptionProps) => {
-  const [tooltipVisible, setTooltipVisible] = useState<boolean>(false)
-
-  const handleTooltip = () => setTooltipVisible((prevState) => !prevState)
-
   return (
     <Box sx={style.wrapper}>
       {title && <Typography sx={style.title}>{title}</Typography>}
-      {isDescriptionTooltip ? (
-        <Tooltip open={tooltipVisible} placement='bottom' title={description}>
-          <Typography onClick={handleTooltip} sx={style.description}>
-            {description}
-          </Typography>
-        </Tooltip>
-      ) : (
-        <Typography onClick={handleTooltip} sx={style.description}>
-          {description}
-        </Typography>
-      )}
+      <Tooltip
+        placement='bottom'
+        title={isDescriptionTooltip ? description : ''}
+      >
+        <Typography sx={style.description}>{description}</Typography>
+      </Tooltip>
     </Box>
   )
 }

--- a/src/containers/my-offers/my-offers-card/MyOffersCard.tsx
+++ b/src/containers/my-offers/my-offers-card/MyOffersCard.tsx
@@ -6,7 +6,7 @@ import Typography from '@mui/material/Typography'
 import Divider from '@mui/material/Divider'
 
 import AppButton from '~/components/app-button/AppButton'
-import TitleWithDescripiton from '~/components/title-with-description/TitleWithDescription'
+import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import StatusChip from '~/components/status-chip/StatusChip'
 import SubjectLevelWithLabels from '~/components/subject-level-with-labels/SubjectLevelWithLabels'
 
@@ -48,7 +48,7 @@ const MyOffersCard: FC<OfferCardSquareProps> = ({ buttonActions, offer }) => {
         subject={subject.name}
       />
       <Box sx={styles.priceContainer}>
-        <TitleWithDescripiton
+        <TitleWithDescription
           description={`/ ${t('common.hour')}`}
           style={styles.titleWithDescription}
           title={`${price} ${t('common.uah')}`}

--- a/tests/unit/components/title-with-description/TitleWithDescription.spec.jsx
+++ b/tests/unit/components/title-with-description/TitleWithDescription.spec.jsx
@@ -1,4 +1,4 @@
-import { screen, render } from '@testing-library/react'
+import { screen, render, fireEvent, waitFor } from '@testing-library/react'
 
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 
@@ -22,5 +22,25 @@ describe('title-with-description component', () => {
     const description = screen.getByText(props.description)
 
     expect(description).toBeInTheDocument()
+  })
+})
+
+describe('title-with-description component with tooltip', () => {
+  const props = {
+    title: 'Title for test case',
+    description: 'Description for test case'
+  }
+  it('should show tooltip when isDescriptionTooltip is true', () => {
+    render(<TitleWithDescription {...props} isDescriptionTooltip />)
+
+    const descriptionElement = screen.getByText(props.description)
+
+    fireEvent.mouseOver(descriptionElement)
+
+    waitFor(() => {
+      const tooltipContent = screen.getByRole('tooltip')
+      expect(tooltipContent).toBeInTheDocument()
+      expect(tooltipContent).toHaveTextContent(props.description)
+    })
   })
 })


### PR DESCRIPTION
Chacked components that use TitleWithDescription component and as a result - only IconExtensionWithTitle.tsx use isDescriptionTooltip(true)
Refactored TitleWithDescription component for conditional rendering of tooltip title without state and handler
Added test for checking tooltip display

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/819defad-0e3a-4b28-8bda-63f624c1b516)


