### PR TITLE
Hotfix/tooltip for disable button_create or edit quiz container_fix bug

### DIFF
--- a/src/components/app-button/AppButton.tsx
+++ b/src/components/app-button/AppButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ElementType, FC, ReactNode } from 'react'
+import { forwardRef, ElementType, FC, ReactNode, Ref } from 'react'
 import Button, { ButtonProps } from '@mui/material/Button'
 
 import Loader from '~/components/loader/Loader'
@@ -24,7 +24,7 @@ const AppButton: FC<AppButtonProps> = forwardRef(
       size = SizeEnum.Large,
       ...props
     },
-    ref
+    ref: Ref<HTMLButtonElement>
   ) => {
     const loader = <Loader size={20} sx={{ opacity: '0.6' }} />
 

--- a/src/components/app-button/AppButton.tsx
+++ b/src/components/app-button/AppButton.tsx
@@ -1,4 +1,4 @@
-import { ElementType, FC, ReactNode } from 'react'
+import { forwardRef, ElementType, FC, ReactNode } from 'react'
 import Button, { ButtonProps } from '@mui/material/Button'
 
 import Loader from '~/components/loader/Loader'
@@ -14,25 +14,33 @@ interface AppButtonProps extends ButtonProps {
   to?: string
 }
 
-const AppButton: FC<AppButtonProps> = ({
-  children,
-  loading,
-  disabled,
-  variant = ButtonVariantEnum.Contained,
-  size = SizeEnum.Large,
-  ...props
-}) => {
-  const loader = <Loader size={20} sx={{ opacity: '0.6' }} />
+const AppButton: FC<AppButtonProps> = forwardRef(
+  (
+    {
+      children,
+      loading,
+      disabled,
+      variant = ButtonVariantEnum.Contained,
+      size = SizeEnum.Large,
+      ...props
+    },
+    ref
+  ) => {
+    const loader = <Loader size={20} sx={{ opacity: '0.6' }} />
 
-  return (
-    <Button
-      className={`s2s-button s2s-button__${variant} s2s-button__${size}`}
-      disabled={loading || disabled}
-      {...props}
-    >
-      {loading ? loader : children}
-    </Button>
-  )
-}
+    AppButton.displayName = 'AppButton'
+
+    return (
+      <Button
+        className={`s2s-button s2s-button__${variant} s2s-button__${size}`}
+        disabled={loading || disabled}
+        ref={ref}
+        {...props}
+      >
+        {loading ? loader : children}
+      </Button>
+    )
+  }
+)
 
 export default AppButton

--- a/src/components/app-button/AppButton.tsx
+++ b/src/components/app-button/AppButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ElementType, FC, ReactNode, Ref } from 'react'
+import { ElementType, FC, ReactNode } from 'react'
 import Button, { ButtonProps } from '@mui/material/Button'
 
 import Loader from '~/components/loader/Loader'
@@ -14,33 +14,25 @@ interface AppButtonProps extends ButtonProps {
   to?: string
 }
 
-const AppButton: FC<AppButtonProps> = forwardRef(
-  (
-    {
-      children,
-      loading,
-      disabled,
-      variant = ButtonVariantEnum.Contained,
-      size = SizeEnum.Large,
-      ...props
-    },
-    ref: Ref<HTMLButtonElement>
-  ) => {
-    const loader = <Loader size={20} sx={{ opacity: '0.6' }} />
+const AppButton: FC<AppButtonProps> = ({
+  children,
+  loading,
+  disabled,
+  variant = ButtonVariantEnum.Contained,
+  size = SizeEnum.Large,
+  ...props
+}) => {
+  const loader = <Loader size={20} sx={{ opacity: '0.6' }} />
 
-    AppButton.displayName = 'AppButton'
-
-    return (
-      <Button
-        className={`s2s-button s2s-button__${variant} s2s-button__${size}`}
-        disabled={loading || disabled}
-        ref={ref}
-        {...props}
-      >
-        {loading ? loader : children}
-      </Button>
-    )
-  }
-)
+  return (
+    <Button
+      className={`s2s-button s2s-button__${variant} s2s-button__${size}`}
+      disabled={loading || disabled}
+      {...props}
+    >
+      {loading ? loader : children}
+    </Button>
+  )
+}
 
 export default AppButton

--- a/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.styles.ts
+++ b/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.styles.ts
@@ -61,6 +61,9 @@ export const styles = {
     '& button': {
       gap: '12px',
       width: '100%'
+    },
+    '& span': {
+      width: '100%'
     }
   },
 

--- a/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
+++ b/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
@@ -204,7 +204,6 @@ const CreateOrEditQuizContainer = ({
   const CreateQuestionButton = (
     <Tooltip
       arrow
-      disableTouchListener
       placement={PositionEnum.Top}
       title={
         isCreationOpen ? t('myResourcesPage.quizzes.savePreviousQuestion') : ''
@@ -212,6 +211,7 @@ const CreateOrEditQuizContainer = ({
     >
       <span>
         <AppButton
+          disabled={isCreationOpen}
           onClick={onOpenCreateQuestion}
           size={SizeEnum.ExtraLarge}
           variant={ButtonVariantEnum.Tonal}

--- a/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
+++ b/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
@@ -204,19 +204,22 @@ const CreateOrEditQuizContainer = ({
   const CreateQuestionButton = (
     <Tooltip
       arrow
+      disableTouchListener
       placement={PositionEnum.Top}
       title={
         isCreationOpen ? t('myResourcesPage.quizzes.savePreviousQuestion') : ''
       }
     >
-      <AppButton
-        onClick={onOpenCreateQuestion}
-        size={SizeEnum.ExtraLarge}
-        variant={ButtonVariantEnum.Tonal}
-      >
-        {t('myResourcesPage.quizzes.createNewQuestion')}
-        <EditIcon fontSize={SizeEnum.Small} />
-      </AppButton>
+      <span>
+        <AppButton
+          onClick={onOpenCreateQuestion}
+          size={SizeEnum.ExtraLarge}
+          variant={ButtonVariantEnum.Tonal}
+        >
+          {t('myResourcesPage.quizzes.createNewQuestion')}
+          <EditIcon fontSize={SizeEnum.Small} />
+        </AppButton>
+      </span>
     </Tooltip>
   )
 

--- a/src/containers/navigation-icons/NavigationIcons.styles.ts
+++ b/src/containers/navigation-icons/NavigationIcons.styles.ts
@@ -24,6 +24,7 @@ export const styles = {
   accountIcon: {
     ...hideOnMobile,
     ml: { sm: '12px', md: '12px', lg: '12px' },
-    typography: TypographyVariantEnum.Button
+    typography: TypographyVariantEnum.Button,
+    cursor: 'pointer'
   }
 }


### PR DESCRIPTION
After edit tooltip to the button 'Create new question' it doesn't work correct, because MUI component Tooltip, doesn't pass ref to the castom components like AppButton.
Because of that, was added <span> wrapper to AppButton component that helps to show disable button with tooltip without errors
From ofаicial MUI documentation
![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/5ba37457-1906-4990-9ddf-ee3ccdb85ec4)
Link
https://mui.com/material-ui/react-tooltip/
How it works now

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/6d4a57e8-b50b-47ff-8e20-29e2f5190ea6

Also I've add corsor: 'pointer' to the User Avatar in this hotfix PR as I forgot about it before(