### PR TITLE
Added tests for professional tab after ui changes

### DIFF
--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -6,6 +6,7 @@ import AppButton from '~/components/app-button/AppButton'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import { styles } from '~/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.styles'
 import {
+  ButtonTypeEnum,
   ButtonVariantEnum,
   ComponentEnum,
   ProfessionalCategory,
@@ -176,7 +177,10 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
         </Box>
       </Box>
       <Box sx={styles.buttonGroup}>
-        <AppButton type='submit' variant={ButtonVariantEnum.Contained}>
+        <AppButton
+          type={ButtonTypeEnum.Submit}
+          variant={ButtonVariantEnum.Contained}
+        >
           {t(
             'editProfilePage.profile.professionalTab.addCategoryModal.submitBtn'
           )}

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
@@ -133,6 +133,7 @@ const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
       <Box sx={styles.toolbar.root}>
         <Box sx={styles.toolbar.buttonGroup}>{ToolbarButtons}</Box>
         <IconButton
+          data-testid='delete-professional-category-button'
           onClick={handleDeleteButtonClick}
           sx={styles.toolbar.deleteButton}
         >

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -60,6 +60,7 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
         MenuProps={styles.menuProps}
         error={hasError}
         input={<OutlinedInput label={label} />}
+        inputProps={{ 'data-testid': 'proficiency-levels' }}
         labelId={`${id}-multiple-checkbox-label`}
         multiple
         renderValue={(selected) => selected.join(', ')}

--- a/tests/test-utils.jsx
+++ b/tests/test-utils.jsx
@@ -8,7 +8,6 @@ import { theme } from '~/styles/app-theme/custom-mui.styles'
 import PopupsProvider from '~/PopupsProvider'
 import cooperationsReducer from '~/redux/features/cooperationsSlice'
 
-import { vi } from 'vitest'
 import MockAdapter from 'axios-mock-adapter'
 import { axiosClient } from '~/plugins/axiosClient'
 

--- a/tests/test-utils.jsx
+++ b/tests/test-utils.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux'
 import { configureStore } from '@reduxjs/toolkit'
 import reducer from '~/redux/reducer'
 import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles'
-import { render, waitFor } from '@testing-library/react'
+import { screen, render, waitFor, fireEvent, act } from '@testing-library/react'
 import { theme } from '~/styles/app-theme/custom-mui.styles'
 import PopupsProvider from '~/PopupsProvider'
 import cooperationsReducer from '~/redux/features/cooperationsSlice'
@@ -48,4 +48,18 @@ export const mockAxiosClient = new MockAdapter(axiosClient)
 export const waitForTimeout = (callback, options) => {
   const mergedOptions = { timeout: 5000, ...options }
   return waitFor(callback, mergedOptions)
+}
+
+export const selectOption = async (selectLike, option) => {
+  await act(async () => {
+    fireEvent.click(selectLike)
+    fireEvent.change(selectLike, { target: { value: option } })
+  })
+
+  const selectedOption = screen.getByText(option)
+  await act(async () => {
+    fireEvent.click(selectedOption)
+  })
+
+  expect(selectLike.value).toBe(option)
 }

--- a/tests/unit/components/location-selection-inputs/LocationSelectionInputs.spec.jsx
+++ b/tests/unit/components/location-selection-inputs/LocationSelectionInputs.spec.jsx
@@ -1,9 +1,8 @@
-import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
-import { vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
 import LocationSelectionInputs from '~/components/location-selection-inputs/LocationSelectionInputs'
-
 import { mockAxiosClient } from '~tests/test-utils'
 import { URLs } from '~/constants/request'
+import { selectOption } from '~tests/test-utils'
 
 const onDataChangeMock = vi.fn()
 
@@ -14,20 +13,6 @@ const mockCountries = [
   { name: 'Country3', iso2: 'C3' }
 ]
 const initialData = { country: 'Country3', city: 'City3' }
-
-const selectOption = async (label, option) => {
-  const autocomplete = screen.getByLabelText(label)
-  expect(autocomplete).toBeInTheDocument()
-  await act(async () => {
-    fireEvent.click(autocomplete)
-    fireEvent.change(autocomplete, { target: { value: option } })
-  })
-  const selectedOption = screen.getByText(option)
-  await act(async () => {
-    fireEvent.click(selectedOption)
-  })
-  expect(autocomplete.value).toBe(option)
-}
 
 describe('LocationSelectionInputs', () => {
   beforeEach(async () => {
@@ -52,12 +37,18 @@ describe('LocationSelectionInputs', () => {
   })
   it('changes the value of the country input when a country is selected', async () => {
     const newCountry = mockCountries[0].name
-    await selectOption('common.labels.country', newCountry)
+
+    const option = screen.getByLabelText('common.labels.country')
+    await selectOption(option, newCountry)
   })
   it('changes the value of the city input when a city is selected after a country is selected', async () => {
     const newCountry = mockCountries[0].name
     const newCity = mockCities[0]
-    await selectOption('common.labels.country', newCountry)
-    await selectOption('common.labels.city', newCity)
+
+    const countryOption = screen.getByLabelText('common.labels.country')
+    await selectOption(countryOption, newCountry)
+
+    const cityOption = screen.getByLabelText('common.labels.city')
+    await selectOption(cityOption, newCity)
   })
 })

--- a/tests/unit/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.spec.jsx
@@ -1,0 +1,43 @@
+import ProfessionalInfoTab from '~/containers/edit-profile/professional-info-tab/ProfessionalInfoTab'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '~tests/test-utils'
+
+const mockOpenModal = vi.fn()
+
+vi.mock('~/context/modal-context', async () => {
+  const actual = await vi.importActual('~/context/modal-context')
+  return {
+    ...actual,
+    useModalContext: () => ({
+      openModal: mockOpenModal
+    })
+  }
+})
+
+describe('ProfessionalInfoTab', () => {
+  beforeEach(() => {
+    renderWithProviders(<ProfessionalInfoTab />)
+  })
+
+  it('should render title and description', () => {
+    const title = screen.getByText(
+      'editProfilePage.profile.professionalTab.mainTitle'
+    )
+    expect(title).toBeInTheDocument()
+
+    const description = screen.getByText(
+      'editProfilePage.profile.professionalTab.mainDescription'
+    )
+    expect(description).toBeInTheDocument()
+  })
+
+  it('should open create category modal when "add category" button is clicked', () => {
+    const addCategoryButton = screen.getByText(
+      'editProfilePage.profile.professionalTab.addCategoryBtn'
+    )
+
+    fireEvent.click(addCategoryButton)
+
+    expect(mockOpenModal).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/containers/edit-profile/professional-info-tab/about-tutor-accordion/AboutTutorAccordion.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/about-tutor-accordion/AboutTutorAccordion.spec.jsx
@@ -1,0 +1,29 @@
+import AboutTutorAccordion from '~/containers/edit-profile/professional-info-tab/about-tutor-accordion/AboutTutorAccordion'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '~tests/test-utils'
+
+describe('AboutTutorAccordion', () => {
+  beforeEach(() => {
+    renderWithProviders(<AboutTutorAccordion />)
+  })
+
+  it('should open first accordion by default', () => {
+    const textareas = screen.getAllByLabelText(
+      'editProfilePage.profile.professionalTab.accordion.textareaLabel'
+    )
+
+    expect(textareas).toHaveLength(4)
+    expect(screen.getByTestId('0-true')).toBeInTheDocument()
+    expect(screen.getByTestId('1-false')).toBeInTheDocument()
+  })
+
+  it('should open corresponding accordion content', () => {
+    const secondItemTitle = screen.getByText(
+      'editProfilePage.profile.professionalTab.accordion.workExperience'
+    )
+    fireEvent.click(secondItemTitle)
+
+    expect(screen.getByTestId('0-false')).toBeInTheDocument()
+    expect(screen.getByTestId('1-true')).toBeInTheDocument()
+  })
+})

--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -1,0 +1,132 @@
+import AddProfessionalCategoryModal from '~/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal'
+import { renderWithProviders, selectOption } from '~tests/test-utils'
+import { fireEvent, screen } from '@testing-library/react'
+import { professionalSubjectTemplate } from '~/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.constants'
+import { ProficiencyLevelEnum } from '~/types'
+
+const mockCloseModal = vi.fn()
+
+const initialValues = {
+  _id: '1',
+  name: 'Computer science',
+  subjects: [
+    {
+      _id: '1',
+      name: 'PHP',
+      proficiencyLevels: [
+        ProficiencyLevelEnum.Beginner,
+        ProficiencyLevelEnum.Intermediate,
+        ProficiencyLevelEnum.Advanced
+      ]
+    },
+    {
+      _id: '2',
+      name: 'Java',
+      proficiencyLevels: [ProficiencyLevelEnum.Beginner]
+    }
+  ]
+}
+
+const renderProfessionalCategoryModalWithInitialValues = (initialValues) => {
+  renderWithProviders(
+    <AddProfessionalCategoryModal
+      closeModal={mockCloseModal}
+      initialValues={initialValues}
+    />
+  )
+}
+
+describe('AddProfessionalCategoryModal without initial value', () => {
+  beforeEach(() => {
+    renderProfessionalCategoryModalWithInitialValues()
+  })
+
+  it('should render SubjectGroup using template in (modal create mode)', async () => {
+    const professionalSubject = screen.getByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+    expect(professionalSubject).toHaveValue(professionalSubjectTemplate.name)
+  })
+
+  it('should add one more subject group if "Add one more subject" button in clicked', () => {
+    const button = screen.getByText(
+      /editProfilePage.profile.professionalTab.addCategoryModal.addSubjectBtn/
+    )
+
+    expect(button).toBeInTheDocument()
+
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    const professionalSubjects = screen.getAllByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+    expect(professionalSubjects).toHaveLength(3)
+  })
+
+  it('should update subject name when other option is selected', async () => {
+    const autocomplete = screen.getByLabelText(
+      /editProfilePage.profile.professionalTab.mainStudyCategory/
+    )
+    await selectOption(autocomplete, 'Language1')
+  })
+
+  it('should update professional subject value in autocomplete', async () => {
+    const autocomplete = screen.getByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+    await selectOption(autocomplete, 'Subject1')
+  })
+
+  it('should update proficiency level select value correctly', () => {
+    const select = screen.getByTestId('proficiency-levels')
+    expect(select).toHaveValue('')
+
+    fireEvent.select(select, {
+      target: {
+        value: [ProficiencyLevelEnum.Beginner, ProficiencyLevelEnum.Advanced]
+      }
+    })
+    expect(select).toHaveValue(
+      [ProficiencyLevelEnum.Beginner, ProficiencyLevelEnum.Advanced].join(',')
+    )
+  })
+
+  it('should close modal when form is submitted', () => {
+    const submitButton = screen.getByText(
+      /editProfilePage.profile.professionalTab.addCategoryModal.submitBtn/
+    )
+    fireEvent.click(submitButton)
+
+    expect(mockCloseModal).toHaveBeenCalled()
+  })
+})
+
+describe('AddProfessionalCategoryModal with initial value', () => {
+  beforeEach(() => {
+    renderProfessionalCategoryModalWithInitialValues(initialValues)
+  })
+
+  it('should create SubjectGroup list according to passed initial values (modal edit mode)', () => {
+    const professionalSubjects = screen.getAllByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+    expect(professionalSubjects).toHaveLength(2)
+
+    expect(professionalSubjects[0]).toHaveValue(initialValues.subjects[0].name)
+    expect(professionalSubjects[1]).not.toHaveValue(
+      initialValues.subjects[0].name
+    )
+
+    const professionalProficiencyLevelSelects =
+      screen.getAllByTestId('proficiency-levels')
+    expect(professionalProficiencyLevelSelects).toHaveLength(2)
+
+    const secondProficiencyLevelSelect = professionalProficiencyLevelSelects[1]
+    const selectedProficiencyLevels =
+      initialValues.subjects[1].proficiencyLevels
+    expect(secondProficiencyLevelSelect).toHaveValue(
+      selectedProficiencyLevels.join(', ')
+    )
+  })
+})

--- a/tests/unit/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.spec.jsx
@@ -1,0 +1,96 @@
+import ProfessionalCategory from '~/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '~tests/test-utils'
+import { ProficiencyLevelEnum } from '~/types'
+
+const mockOpenProfessionalCategoryModal = vi.fn()
+
+const activatedCategory = {
+  _id: '1',
+  name: 'Computer science',
+  isActivated: true,
+  isActivationBlocked: false,
+  subjects: []
+}
+
+const categoryWithSubjects = {
+  ...activatedCategory,
+  subjects: [
+    {
+      _id: '1',
+      name: 'PHP',
+      proficiencyLevels: [
+        ProficiencyLevelEnum.Beginner,
+        ProficiencyLevelEnum.Intermediate,
+        ProficiencyLevelEnum.Advanced
+      ]
+    },
+    {
+      _id: '2',
+      name: 'Java',
+      proficiencyLevels: [ProficiencyLevelEnum.Beginner]
+    }
+  ]
+}
+
+const deactivatedCategory = { ...activatedCategory, isActivated: false }
+
+const renderProfessionalCategoryWithItem = (item) => {
+  renderWithProviders(
+    <ProfessionalCategory
+      item={item}
+      openProfessionalCategoryModal={mockOpenProfessionalCategoryModal}
+    />
+  )
+}
+
+describe('ProfessionalCategory', () => {
+  it('should render deactivate button when isActivated is true', () => {
+    renderProfessionalCategoryWithItem(activatedCategory)
+
+    const deactivateCategoryButton = screen.getByText(
+      /editProfilePage.profile.professionalTab.deactivateCategoryBtn/
+    )
+
+    expect(deactivateCategoryButton).toBeInTheDocument()
+  })
+
+  it('should render activate button when isActivated is false', () => {
+    renderProfessionalCategoryWithItem(deactivatedCategory)
+
+    const activateCategoryButton = screen.getByText(
+      /editProfilePage.profile.professionalTab.activateCategoryBtn/
+    )
+
+    expect(activateCategoryButton).toBeInTheDocument()
+  })
+
+  it('should open modal when Delete button is clicked', () => {
+    renderProfessionalCategoryWithItem(categoryWithSubjects)
+
+    const deleteCategoryButton = screen.getByTestId(
+      'delete-professional-category-button'
+    )
+    fireEvent.click(deleteCategoryButton)
+
+    const deleteCategoryModalTitle = screen.getByText(
+      /editProfilePage.profile.professionalTab.deleteCategoryModal.title/
+    )
+
+    expect(deleteCategoryModalTitle).toBeInTheDocument()
+  })
+
+  it('should render subjects correctly', () => {
+    renderProfessionalCategoryWithItem(categoryWithSubjects)
+
+    const firstSubjectName = categoryWithSubjects.subjects[0].name
+    const firstSubjectNameElement = screen.getByText(firstSubjectName)
+    expect(firstSubjectNameElement).toBeInTheDocument()
+
+    const subjectLabels = screen.getAllByText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+
+    expect(subjectLabels).toHaveLength(categoryWithSubjects.subjects.length)
+  })
+})


### PR DESCRIPTION
Wrote tests to Improve coverage as much as possible for `professional-info-tab`

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/f953e903-887c-4d8d-8b4f-ace388e60ee1)

When speaking about `AddProfessionalCategoryModal.tsx`, following lines could not be tested in any way, so I kept it as it is because coverage is decent enough 

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/f0269c8a-bc65-4af0-a486-d3d92f3f5b39)

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/c42d565c-7856-4040-91a6-3314f498dda7)


As for `ProfessionalCategory.tsx`, uncoreved lines contain `TODO`s, so i can't test them now. These lines should be tested when actual logic with backend is added:

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/8c08497b-dde4-4166-846c-5a2ed3da0fd0)

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/109922101/82cab3a7-1444-4938-b9b9-f12d2170ad89)

