### PR TITLE
Check the logic of checkboxes in project

### DIFF
--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -51,7 +51,7 @@ function SubjectGroup({
         />
       </Box>
       <ProficiencyLevelSelect
-        fillRange
+        // fillRange
         fullWidth
         label={t('editProfilePage.profile.professionalTab.proficiencyLevels')}
         onChange={(value) => proficiencyLevels.handleChange(value)}

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -51,7 +51,7 @@ function SubjectGroup({
         />
       </Box>
       <ProficiencyLevelSelect
-        // fillRange
+        fillRange
         fullWidth
         label={t('editProfilePage.profile.professionalTab.proficiencyLevels')}
         onChange={(value) => proficiencyLevels.handleChange(value)}

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -54,7 +54,7 @@ function SubjectGroup({
         fillRange
         fullWidth
         label={t('editProfilePage.profile.professionalTab.proficiencyLevels')}
-        onChange={(value) => proficiencyLevels.handleChange(value)}
+        onChange={proficiencyLevels.handleChange}
         value={proficiencyLevels.value}
       />
     </Box>

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -54,11 +54,7 @@ function SubjectGroup({
         fillRange
         fullWidth
         label={t('editProfilePage.profile.professionalTab.proficiencyLevels')}
-        onChange={(event) =>
-          proficiencyLevels.handleChange(
-            event.target.value as ProficiencyLevelEnum[]
-          )
-        }
+        onChange={(value) => proficiencyLevels.handleChange(value)}
         value={proficiencyLevels.value}
       />
     </Box>

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -51,6 +51,7 @@ function SubjectGroup({
         />
       </Box>
       <ProficiencyLevelSelect
+        fillRange
         fullWidth
         label={t('editProfilePage.profile.professionalTab.proficiencyLevels')}
         onChange={(event) =>

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -7,6 +7,7 @@ import AppRange from '~/components/app-range/AppRange'
 import CheckboxList from '~/components/checkbox-list/CheckboxList'
 import FilterInput from '~/components/filter-input/FilterInput'
 import RadioButtonInputs from '~/components/radio-button-inputs/RadioButtonInputs'
+import { useAppSelector } from '~/hooks/use-redux'
 
 import {
   languageValues,
@@ -20,7 +21,8 @@ import {
   PriceRange,
   ProficiencyLevelEnum,
   UpdateFiltersInQuery,
-  UpdateOfferFilterByKey
+  UpdateOfferFilterByKey,
+  UserRoleEnum
 } from '~/types'
 
 interface OfferFilterListProps {
@@ -37,6 +39,7 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
   price
 }) => {
   const { t } = useTranslation()
+  const { userRole } = useAppSelector((state) => state.appMain)
   const levelOptions = Object.values(ProficiencyLevelEnum)
 
   const radioOptions = radioButtonsTranslationKeys.map(({ title, value }) => ({
@@ -80,10 +83,16 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
     <Typography sx={styles.title}>{title}</Typography>
   )
 
+  const checkboxListProps =
+    userRole === UserRoleEnum.Tutor
+      ? { fillRange: true }
+      : { singleSelect: true }
+
   return (
     <>
       {filterTitle(t('findOffers.filterTitles.level'))}
       <CheckboxList
+        {...checkboxListProps}
         items={levelOptions}
         onChange={updateFilterByKey('proficiencyLevel')}
         value={filters.proficiencyLevel}

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
@@ -39,7 +39,7 @@ export const styles = {
     ...commonStyle
   },
   levelSelect: {
-    width: '100%'
+    width: { md: '370px', xs: '100%' }
   },
   otherToolbar: {
     borderRadius: '10px',

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
@@ -39,7 +39,7 @@ export const styles = {
     ...commonStyle
   },
   levelSelect: {
-    width: { md: '370px', xs: '100%' }
+    width: '100%'
   },
   otherToolbar: {
     borderRadius: '10px',

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
@@ -124,6 +124,7 @@ const CourseToolbar = ({
       />
       <ProficiencyLevelSelect
         errorMessage={errors.proficiencyLevel}
+        fillRange
         label={t('breadCrumbs.level')}
         onBlur={handleBlur('proficiencyLevel')}
         onChange={onLevelChange}

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
@@ -2,7 +2,6 @@ import { useCallback, SyntheticEvent, ChangeEvent, FocusEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import { SelectChangeEvent } from '@mui/material/Select'
 
 import { subjectService } from '~/services/subject-service'
 import { categoryService } from '~/services/category-service'
@@ -74,8 +73,12 @@ const CourseToolbar = ({
     handleNonInputValueChange('subject', value?._id ?? null)
   }
 
-  const onLevelChange = (event: SelectChangeEvent<ProficiencyLevelEnum[]>) => {
-    handleNonInputValueChange('proficiencyLevel', event.target.value)
+  // const onLevelChange = (event: SelectChangeEvent<ProficiencyLevelEnum[]>) => {
+  //   handleNonInputValueChange('proficiencyLevel', event.target.value)
+  // }
+
+  const onLevelChange = (value: ProficiencyLevelEnum[]) => {
+    handleNonInputValueChange('proficiencyLevel', value)
   }
 
   const AppAutoCompleteList = (

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
@@ -73,10 +73,6 @@ const CourseToolbar = ({
     handleNonInputValueChange('subject', value?._id ?? null)
   }
 
-  // const onLevelChange = (event: SelectChangeEvent<ProficiencyLevelEnum[]>) => {
-  //   handleNonInputValueChange('proficiencyLevel', event.target.value)
-  // }
-
   const onLevelChange = (value: ProficiencyLevelEnum[]) => {
     handleNonInputValueChange('proficiencyLevel', value)
   }

--- a/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
+++ b/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
@@ -147,6 +147,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
           </Typography>
         </Typography>
         <CheckboxList
+          fillRange
           items={levelOptions}
           onChange={updateFilterByKey('proficiencyLevel')}
           value={filters.proficiencyLevel}

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -11,12 +11,15 @@ import { FC, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ProficiencyLevelEnum } from '~/types'
 import { styles } from './ProficiencyLevelSelect.styles'
+// import { updateCheckBoxState } from '~/utils/checkbox-list'
 
 interface ProficiencyLevelSelectProps
   extends Omit<SelectProps<ProficiencyLevelEnum[]>, 'sx'> {
   value: ProficiencyLevelEnum[]
   label?: string
   errorMessage?: string
+  // fillRange?: boolean
+  // singleSelect?: boolean
   sx?: {
     select: SxProps
   }
@@ -27,6 +30,8 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
   label,
   errorMessage,
   sx,
+  // fillRange = false,
+  // singleSelect = false,
   ...props
 }) => {
   const { t } = useTranslation()
@@ -62,7 +67,13 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
         input={<OutlinedInput label={label} />}
         labelId={`${id}-multiple-checkbox-label`}
         multiple
+        // onChange={() => handleCheckbox(checkbox)}
         renderValue={(selected) => selected.join(', ')}
+        // renderValue={(selected) =>
+        //   fillRange
+        //     ? `${selected[0]} - ${selected[selected.length - 1]}`
+        //     : selected.join(', ')
+        // }
         sx={sx?.select}
         value={value}
         {...props}

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -6,40 +6,60 @@ import ListItemText from '@mui/material/ListItemText'
 import MenuItem from '@mui/material/MenuItem'
 import OutlinedInput from '@mui/material/OutlinedInput'
 import Select from '@mui/material/Select'
+// import { SelectChangeEvent } from '@mui/material/Select'
 import { SelectProps, SxProps } from '@mui/material'
 import { FC, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ProficiencyLevelEnum } from '~/types'
 import { styles } from './ProficiencyLevelSelect.styles'
-// import { updateCheckBoxState } from '~/utils/checkbox-list'
+import { updateCheckBoxState } from '~/utils/checkbox-list'
 
 interface ProficiencyLevelSelectProps
   extends Omit<SelectProps<ProficiencyLevelEnum[]>, 'sx'> {
   value: ProficiencyLevelEnum[]
   label?: string
   errorMessage?: string
-  // fillRange?: boolean
-  // singleSelect?: boolean
+  fillRange?: boolean
+  singleSelect?: boolean
   sx?: {
     select: SxProps
   }
+  // onChange: (event) => void
 }
 
 const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
-  value,
+  value = [],
   label,
-  errorMessage,
+  errorMessage = '',
   sx,
-  // fillRange = false,
-  // singleSelect = false,
+  fillRange = false,
+  singleSelect = false,
+  // onChange,
   ...props
 }) => {
   const { t } = useTranslation()
   const id = useId()
 
+  console.log(value)
+
+  const handleCheckbox = (item: ProficiencyLevelEnum) => {
+    const updatedCheckboxes = updateCheckBoxState(
+      Object.values(ProficiencyLevelEnum),
+      value,
+      item,
+      fillRange,
+      singleSelect
+    )
+
+    return updatedCheckboxes
+  }
+
   const menuItems = Object.values(ProficiencyLevelEnum).map((item) => (
     <MenuItem key={item} value={item}>
-      <Checkbox checked={value.indexOf(item) > -1} />
+      <Checkbox
+        checked={value.indexOf(item) > -1}
+        onChange={() => handleCheckbox(item)}
+      />
       <ListItemText primary={item} />
     </MenuItem>
   ))
@@ -67,13 +87,12 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
         input={<OutlinedInput label={label} />}
         labelId={`${id}-multiple-checkbox-label`}
         multiple
-        // onChange={() => handleCheckbox(checkbox)}
-        renderValue={(selected) => selected.join(', ')}
-        // renderValue={(selected) =>
-        //   fillRange
-        //     ? `${selected[0]} - ${selected[selected.length - 1]}`
-        //     : selected.join(', ')
-        // }
+        // onChange={onChange}
+        renderValue={(selected) =>
+          fillRange
+            ? `${selected[0]} - ${selected[selected.length - 1]}`
+            : selected.join(', ')
+        }
         sx={sx?.select}
         value={value}
         {...props}

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -6,7 +6,6 @@ import ListItemText from '@mui/material/ListItemText'
 import MenuItem from '@mui/material/MenuItem'
 import OutlinedInput from '@mui/material/OutlinedInput'
 import Select from '@mui/material/Select'
-// import { SelectChangeEvent } from '@mui/material/Select'
 import { SelectProps, SxProps } from '@mui/material'
 import { FC, useId } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -15,16 +14,15 @@ import { styles } from './ProficiencyLevelSelect.styles'
 import { updateCheckBoxState } from '~/utils/checkbox-list'
 
 interface ProficiencyLevelSelectProps
-  extends Omit<SelectProps<ProficiencyLevelEnum[]>, 'sx'> {
+  extends Omit<SelectProps<ProficiencyLevelEnum[]>, 'sx' | 'onChange'> {
   value: ProficiencyLevelEnum[]
   label?: string
   errorMessage?: string
   fillRange?: boolean
-  singleSelect?: boolean
   sx?: {
     select: SxProps
   }
-  // onChange: (event) => void
+  onChange: (event: ProficiencyLevelEnum[]) => void
 }
 
 const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
@@ -33,34 +31,32 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
   errorMessage = '',
   sx,
   fillRange = false,
-  singleSelect = false,
-  // onChange,
+  onChange,
   ...props
 }) => {
   const { t } = useTranslation()
   const id = useId()
 
-  console.log(value)
+  const proficiencyLevelItems = Object.values(ProficiencyLevelEnum)
 
-  const handleCheckbox = (item: ProficiencyLevelEnum) => {
+  const handleCheckbox = (checkbox: ProficiencyLevelEnum) => {
     const updatedCheckboxes = updateCheckBoxState(
-      Object.values(ProficiencyLevelEnum),
+      proficiencyLevelItems,
       value,
-      item,
-      fillRange,
-      singleSelect
+      checkbox,
+      fillRange
     )
 
-    return updatedCheckboxes
+    onChange(updatedCheckboxes)
   }
 
-  const menuItems = Object.values(ProficiencyLevelEnum).map((item) => (
-    <MenuItem key={item} value={item}>
+  const menuItems = proficiencyLevelItems.map((checkbox) => (
+    <MenuItem key={checkbox} value={checkbox}>
       <Checkbox
-        checked={value.indexOf(item) > -1}
-        onChange={() => handleCheckbox(item)}
+        checked={value.indexOf(checkbox) > -1}
+        onChange={() => handleCheckbox(checkbox)}
       />
-      <ListItemText primary={item} />
+      <ListItemText primary={checkbox} />
     </MenuItem>
   ))
 
@@ -71,6 +67,12 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
       {t('common.errorMessages.proficiencyLevel')}
     </FormHelperText>
   )
+
+  const renderSelectedValue = (selected: ProficiencyLevelEnum[]) => {
+    return fillRange && selected.length > 1
+      ? `${selected[0]} - ${selected[selected.length - 1]}`
+      : selected.join(', ')
+  }
 
   return (
     <FormControl error={hasError}>
@@ -87,12 +89,7 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
         input={<OutlinedInput label={label} />}
         labelId={`${id}-multiple-checkbox-label`}
         multiple
-        // onChange={onChange}
-        renderValue={(selected) =>
-          fillRange
-            ? `${selected[0]} - ${selected[selected.length - 1]}`
-            : selected.join(', ')
-        }
+        renderValue={(selected) => renderSelectedValue(selected)}
         sx={sx?.select}
         value={value}
         {...props}

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -36,7 +36,6 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
 }) => {
   const { t } = useTranslation()
   const id = useId()
-
   const proficiencyLevelItems = Object.values(ProficiencyLevelEnum)
 
   const handleCheckbox = (checkbox: ProficiencyLevelEnum) => {
@@ -51,11 +50,12 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
   }
 
   const menuItems = proficiencyLevelItems.map((checkbox) => (
-    <MenuItem key={checkbox} value={checkbox}>
-      <Checkbox
-        checked={value.indexOf(checkbox) > -1}
-        onChange={() => handleCheckbox(checkbox)}
-      />
+    <MenuItem
+      key={checkbox}
+      onClick={() => handleCheckbox(checkbox)}
+      value={checkbox}
+    >
+      <Checkbox checked={value.indexOf(checkbox) > -1} />
       <ListItemText primary={checkbox} />
     </MenuItem>
   ))

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -10,7 +10,7 @@ import { SelectProps, SxProps } from '@mui/material'
 import { FC, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ProficiencyLevelEnum } from '~/types'
-import { styles } from './ProficiencyLevelSelect.styles'
+import { styles } from '~/containers/proficiency-level-select/ProficiencyLevelSelect.styles'
 import { updateCheckBoxState } from '~/utils/checkbox-list'
 
 interface ProficiencyLevelSelectProps

--- a/tests/unit/containers/find-offer/offer-filter-block/OfferFilterBlock.spec.jsx
+++ b/tests/unit/containers/find-offer/offer-filter-block/OfferFilterBlock.spec.jsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import { beforeEach } from 'vitest'
 
 import OfferFilterBlock from '~/containers/find-offer/offer-filter-block/OfferFilterBlock'
 import { defaultFilters } from '~/pages/find-offers/FindOffers.constants'
+import { renderWithProviders } from '~tests/test-utils'
 import useBreakpoints from '~/hooks/use-breakpoints'
 
 vi.mock('~/hooks/use-breakpoints')
@@ -24,7 +25,7 @@ useBreakpoints.mockImplementation(() => ({ isMobile: true }))
 describe('OfferFilterBlock', () => {
   beforeEach(async () => {
     await waitFor(() => {
-      render(
+      renderWithProviders(
         <OfferFilterBlock
           activeFilterCount={activeFilterCount}
           additionalParams={additionalParams}

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -121,11 +121,10 @@ describe('ProfileInfo test in my profile on laptop', () => {
     expect(sendMessageBtn).toBeInTheDocument()
   })
 
-  it('should click on `tutor offers` button', async () => {
-    const tutorOffersBtn = await screen.findByText(
+  it('should click on `tutor offers` button', () => {
+    const tutorOffersBtn = screen.getByText(
       /tutorProfilePage.profileInfo.tutorOffers/i
     )
-
     fireEvent.click(tutorOffersBtn)
     waitFor(() => {
       expect(mockNavigate).toHaveBeenCalled()

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -121,14 +121,15 @@ describe('ProfileInfo test in my profile on laptop', () => {
     expect(sendMessageBtn).toBeInTheDocument()
   })
 
-  it('should click on `tutor offers` button', () => {
-    const tutorOffersBtn = screen.getByText(
+  it('should click on `tutor offers` button', async () => {
+    const tutorOffersBtn = await screen.findByText(
       /tutorProfilePage.profileInfo.tutorOffers/i
     )
 
     fireEvent.click(tutorOffersBtn)
-
-    waitFor(() => expect(mockNavigate).toHaveBeenCalled())
+    waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled()
+    })
   })
 })
 

--- a/tests/unit/pages/offer-details/OfferDetails.spec.jsx
+++ b/tests/unit/pages/offer-details/OfferDetails.spec.jsx
@@ -73,9 +73,7 @@ describe('OfferDetails on desktop', () => {
 
     const draft = await screen.findByText('common.labels.moveToDraft')
 
-    waitFor(() => {
-      fireEvent.click(draft)
-    })
+    fireEvent.click(draft)
 
     const active = await screen.findByText('common.labels.makeActive')
 

--- a/tests/unit/pages/offer-details/OfferDetails.spec.jsx
+++ b/tests/unit/pages/offer-details/OfferDetails.spec.jsx
@@ -73,8 +73,9 @@ describe('OfferDetails on desktop', () => {
 
     const draft = await screen.findByText('common.labels.moveToDraft')
 
-    fireEvent.click(draft)
-
+    waitFor(() => {
+      fireEvent.click(draft)
+    })
     const active = await screen.findByText('common.labels.makeActive')
 
     expect(active).toBeInTheDocument()


### PR DESCRIPTION
- In offerFilterList add possibility to filtering offers dependent of user role - if userRol = 'tutor' user can create range filter by Proficiency Level, if userRole 'student' - only single select
- In CoursesFiltersDrawer and CourseToolbar added restriction to choose only one checkbox or range of checkboxes (for courses, created by tutor)
- In AddProfessionalCategoryModal added restriction to choose only one checkbox or range of checkboxes (for subjects studied by tutor)

Tests for AddProfessionalCategoryModal added in PR #1893 and will be fixing according of changes in this PR, later
For adding test files to anothet components, already created an issue #1898




https://github.com/ita-social-projects/SpaceToStudy-Client/assets/127191734/a43857ea-7801-45d0-9966-12c580b862be

