### PR TITLE
Fixed page scroll on new lesson page

### DIFF
--- a/src/components/file-editor/FileEditor.constants.ts
+++ b/src/components/file-editor/FileEditor.constants.ts
@@ -1,3 +1,5 @@
+import { IAllProps } from '@tinymce/tinymce-react'
+
 const fonts = {
   'Andale Mono': 'andale mono,times',
   Arial: 'arial,helvetica,sans-serif',
@@ -57,8 +59,22 @@ const toolbar = [
   'removeformat'
 ]
 
-export const fileEditorConfig = {
-  fonts,
-  plugins,
-  toolbar
+const initOptions: IAllProps['init'] = {
+  height: 400,
+  menubar: true,
+  plugins: plugins.join(' '),
+  toolbar: toolbar.join(' | '),
+  content_style:
+    '@import url("https://fonts.googleapis.com/css2?family=Rubik:wght@400;600;800&display=swap"); body { font-family:Rubik; font-size:14px }',
+  font_family_formats: Object.entries(fonts)
+    .map((entry) => entry.join('='))
+    .join('; '),
+  ui_mode: 'split'
 }
+
+export const getEditorInitOptions = (
+  extraOptions: Partial<IAllProps['init']>
+) => ({
+  ...initOptions,
+  ...extraOptions
+})

--- a/src/components/file-editor/FileEditor.tsx
+++ b/src/components/file-editor/FileEditor.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { Editor } from '@tinymce/tinymce-react'
-import { fileEditorConfig } from './FileEditor.constants'
+import { getEditorInitOptions } from './FileEditor.constants'
 import { useTranslation } from 'react-i18next'
 
 interface FileEditorProps {
@@ -11,22 +11,15 @@ interface FileEditorProps {
 const FileEditor: FC<FileEditorProps> = ({ onEdit, value }) => {
   const { t } = useTranslation()
 
+  const initOptions = getEditorInitOptions({
+    placeholder: t('lesson.fileEditorPlaceholder')
+  })
+
   return (
     <Editor
       apiKey={import.meta.env.VITE_APP_TINY_MCE_API_KEY}
       data-testid='editor'
-      init={{
-        height: 400,
-        menubar: true,
-        placeholder: t('lesson.fileEditorPlaceholder'),
-        plugins: fileEditorConfig.plugins.join(' '),
-        toolbar: fileEditorConfig.toolbar.join(' | '),
-        content_style:
-          '@import url("https://fonts.googleapis.com/css2?family=Rubik:wght@400;600;800&display=swap"); body { font-family:Rubik; font-size:14px }',
-        font_family_formats: Object.entries(fileEditorConfig.fonts)
-          .map((entry) => entry.join('='))
-          .join('; ')
-      }}
+      init={initOptions}
       onEditorChange={onEdit}
       value={value}
     />

--- a/src/components/file-editor/FileEditor.tsx
+++ b/src/components/file-editor/FileEditor.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { Editor } from '@tinymce/tinymce-react'
-import { getEditorInitOptions } from './FileEditor.constants'
+import { getEditorInitOptions } from '~/components/file-editor/FileEditor.constants'
 import { useTranslation } from 'react-i18next'
 
 interface FileEditorProps {

--- a/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.tsx
+++ b/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.tsx
@@ -33,7 +33,6 @@ import { imageResize } from '~/utils/image-resize'
 import { styles } from '~/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.styles'
 import { openAlert } from '~/redux/features/snackbarSlice'
 
-
 export interface ProfileTabFormProps {
   data: EditProfileForm
   errors: UseFormErrors<EditProfileForm>

--- a/src/containers/tutor-profile/profile-info/ProfileInfo.jsx
+++ b/src/containers/tutor-profile/profile-info/ProfileInfo.jsx
@@ -17,10 +17,8 @@ import ProfileContainerMobile from '~/containers/tutor-profile/profile-info/Prof
 import { styles } from '~/containers/tutor-profile/profile-info/ProfileInfo.styles'
 
 import { authRoutes } from '~/router/constants/authRoutes'
-import { styles } from '~/containers/tutor-profile/profile-info/ProfileInfo.styles'
 import { snackbarVariants } from '~/constants'
 
-import { useSnackBarContext } from '~/context/snackbar-context'
 import { SizeEnum, UserRoleEnum, ButtonVariantEnum } from '~/types'
 import { createUrlPath, getDifferenceDates } from '~/utils/helper-functions'
 import { useAppDispatch } from '~/hooks/use-redux'

--- a/tests/unit/components/file-editor/FileEditor.spec.jsx
+++ b/tests/unit/components/file-editor/FileEditor.spec.jsx
@@ -1,0 +1,14 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import FileEditor from '~/components/file-editor/FileEditor.tsx'
+
+describe('Test file editor', () => {
+  render(<FileEditor />)
+
+  it('should render file editor', async () => {
+    const editorElement = screen.queryAllByTestId('editor')
+
+    waitFor(() => {
+      expect(editorElement).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
- Basically, I only added `ui_mode: 'split'` to init options. All the other changes are refactoring, I moved static init options to constants file and made a function to add other dynamic options.

- Library we use for text redactor recalculated menu position on document `scroll` event. I guess the problem was that in our application such event was not dispatched as scroll occurred not in `body` but in `main` element (even scrollbar indicates that scrollable part is not entire page). Developers of the library recommend to use `ui_mode: 'split'` when redactor is in scrollable element. 

- As you can see, menus appear below header, I don't think it can be changed with this library and with scroll fix.

Before and after changes demonstrations are below.

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/42154d81-d779-426b-814d-aca90dc3a5ff

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/62070431/90bd8907-4095-4ca3-83dd-14d8b5394d21

