### PR TITLE
Fixed bug when course could not be created

### DIFF
--- a/src/hooks/use-user-categories-and-subjects.tsx
+++ b/src/hooks/use-user-categories-and-subjects.tsx
@@ -19,12 +19,12 @@ const useUserCategoriesAndSubjects = ({
   const { Subjects } = CourseAutocompleteOptionsEnum
 
   const userCategories = useMemo(
-    () => user?.mainSubjects.tutor.map((item) => item.category.name) ?? [],
+    () => user?.mainSubjects.tutor?.map((item) => item.category.name) ?? [],
     [user?.mainSubjects.tutor]
   )
 
   const userSubjects = useMemo(
-    () => user?.mainSubjects.tutor.map((item) => item.name) ?? [],
+    () => user?.mainSubjects.tutor?.map((item) => item.name) ?? [],
     [user?.mainSubjects.tutor]
   )
 


### PR DESCRIPTION
Previously course could not be created if user did not select subjects for tutor role inside stepper. Now it is fixed and default values for create courses are not added if there are not any