### PR TITLE
Feature/1894/professional block categories

### DIFF
--- a/src/constants/translations/en/edit-profile.json
+++ b/src/constants/translations/en/edit-profile.json
@@ -45,10 +45,7 @@
       "subject": "Subject",
       "proficiencyLevels": "Proficiency Levels",
       "editCategoryBtn": "Edit category",
-      "activateCategoryBtn": "Activate",
-      "deactivateCategoryBtn": "Deactivate",
-      "deactivateCategoryBtnEnabledTooltip": "This category will be hidden on your profile.\nYou can activate it anytime.",
-      "deactivateCategoryBtnDisabledTooltip": "You have opened cooperation(s) with this category.\nPlease close it before deactivation",
+      "deleteCategoryBtnDisabledTooltip": "You have opened cooperation(s)/offers with this category.\nPlease close it before deactivation",
       "aboutTheTutorTitle": "About the tutor",
       "aboutTheTutorDescription": "Describe your professional experience. This information will be displayed on your public profile.",
       "accordion": {

--- a/src/constants/translations/ua/edit-profile.json
+++ b/src/constants/translations/ua/edit-profile.json
@@ -45,10 +45,7 @@
       "subject": "Предмет",
       "proficiencyLevels": "Рівні кваліфікації",
       "editCategoryBtn": "Редагувати",
-      "activateCategoryBtn": "Активувати",
-      "deactivateCategoryBtn": "Деактивувати",
-      "deactivateCategoryBtnEnabledTooltip": "Стає невидимою у вашому профілі.\nВи можете активувати її у будь-який час.",
-      "deactivateCategoryBtnDisabledTooltip": "Ви розпочали співпрацю(і) з цією категорією.\nБудь ласка, закрийте її перед деактивацією",
+      "deleteCategoryBtnDisabledTooltip": "Ви розпочали співпрацю(і)/пропозицію. з цією категорією.\nБудь ласка, закрийте її перед деактивацією",
       "aboutTheTutorTitle": "Про викладача",
       "aboutTheTutorDescription": "Опишіть ваш професійний досвід. Ця інформація буде відображена у вашому публічному профілі.",
       "accordion": {

--- a/src/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.tsx
+++ b/src/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.tsx
@@ -12,10 +12,8 @@ import {
   ComponentEnum,
   OpenProfessionalCategoryModalHandler,
   ProfessionalBlock,
-  ProfessionalCategoryWithActivationControls,
-  ProficiencyLevelEnum,
   SizeEnum,
-  SubjectInterface,
+  UserMainSubject,
   UserRoleEnum
 } from '~/types'
 
@@ -115,25 +113,36 @@ const mockCategoriesData: ProfessionalCategoryWithActivationControls[] = [
 
 interface ProfessionalInfoTabProps {
   professionalBlock?: ProfessionalBlock
-  categories: SubjectInterface[]
+  categories: UserMainSubject[]
   userId: string
 }
 
 const ProfessionalInfoTab: FC<ProfessionalInfoTabProps> = ({
   professionalBlock,
-  userId
+  userId,
+  categories
 }) => {
   const { t } = useTranslation()
 
-  const { openModal, closeModal } = useModalContext()
-
   const { userRole } = useAppSelector((state) => state.appMain)
+
+  const { openModal, closeModal } = useModalContext()
 
   const { handleSubmit, loading } = useUpdateUser(userId)
 
   const { data, handleInputChange } = useForm<ProfessionalBlock>({
     initialValues: professionalBlock || initialFormValues
   })
+
+  const handleDeleteCategory = (mainSubjectId: string) => {
+    handleSubmit({
+      mainSubjects: {
+        _id: mainSubjectId,
+        category: { _id: '', name: '' },
+        subjects: []
+      }
+    })
+  }
 
   const handleUpdateInfo = () => {
     handleSubmit({ professionalBlock: data })
@@ -145,8 +154,7 @@ const ProfessionalInfoTab: FC<ProfessionalInfoTabProps> = ({
     openModal({
       component: (
         <AddProfessionalCategoryModal
-          closeModal={closeModal}
-          initialValues={initialValues}
+          {...{ handleSubmit, loading, initialValues, closeModal }}
         />
       ),
       paperProps: {
@@ -214,7 +222,8 @@ const ProfessionalInfoTab: FC<ProfessionalInfoTabProps> = ({
           </AppButton>
         </Box>
         <ProfessionalCategoryList
-          items={mockCategoriesData}
+          handleDeleteCategory={handleDeleteCategory}
+          items={categories}
           openProfessionalCategoryModal={openProfessionalCategoryModal}
         />
       </Box>

--- a/src/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.tsx
+++ b/src/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.tsx
@@ -51,11 +51,13 @@ const ProfessionalInfoTab: FC<ProfessionalInfoTabProps> = ({
   })
 
   const handleDeleteCategory = (mainSubjectId: string, categoryId: string) => {
+    const deletedMainSubject = {
+      _id: mainSubjectId,
+      category: { _id: categoryId, name: '' }
+    }
+
     handleSubmit({
-      mainSubjects: {
-        _id: mainSubjectId,
-        category: { _id: categoryId, name: '' }
-      }
+      mainSubjects: deletedMainSubject
     })
   }
 
@@ -71,6 +73,7 @@ const ProfessionalInfoTab: FC<ProfessionalInfoTabProps> = ({
         <AddProfessionalCategoryModal
           {...{ handleSubmit, loading, initialValues, closeModal }}
           blockedCategoriesOptions={categories}
+          isDeletionBlocked={initialValues?.isDeletionBlocked}
         />
       ),
       paperProps: {

--- a/src/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.tsx
+++ b/src/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.tsx
@@ -29,117 +29,32 @@ import AppButton from '~/components/app-button/AppButton'
 
 import { styles } from '~/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.styles'
 
-// @TODO: replace mock data to real data
-const mockCategoriesData: ProfessionalCategoryWithActivationControls[] = [
-  {
-    _id: crypto.randomUUID(),
-    name: 'Languages',
-    isActivated: true,
-    isActivationBlocked: true,
-    subjects: [
-      {
-        _id: crypto.randomUUID(),
-        name: 'English',
-        proficiencyLevels: [
-          ProficiencyLevelEnum.Beginner,
-          ProficiencyLevelEnum.Intermediate,
-          ProficiencyLevelEnum.Advanced,
-          ProficiencyLevelEnum.Professional,
-          ProficiencyLevelEnum.TestPreparation
-        ]
-      },
-      {
-        _id: crypto.randomUUID(),
-        name: 'English',
-        proficiencyLevels: [
-          ProficiencyLevelEnum.Beginner,
-          ProficiencyLevelEnum.Intermediate,
-          ProficiencyLevelEnum.Advanced
-        ]
-      }
-    ]
-  },
-  {
-    _id: crypto.randomUUID(),
-    name: 'Languages',
-    isActivated: true,
-    isActivationBlocked: false,
-    subjects: [
-      {
-        _id: crypto.randomUUID(),
-        name: 'English',
-        proficiencyLevels: [
-          ProficiencyLevelEnum.Beginner,
-          ProficiencyLevelEnum.Intermediate,
-          ProficiencyLevelEnum.Advanced,
-          ProficiencyLevelEnum.Professional,
-          ProficiencyLevelEnum.TestPreparation
-        ]
-      },
-      {
-        _id: crypto.randomUUID(),
-        name: 'English',
-        proficiencyLevels: [
-          ProficiencyLevelEnum.Beginner,
-          ProficiencyLevelEnum.Intermediate,
-          ProficiencyLevelEnum.Advanced
-        ]
-      }
-    ]
-  },
-  {
-    _id: crypto.randomUUID(),
-    name: 'Computer science',
-    isActivated: false,
-    isActivationBlocked: false,
-    subjects: [
-      {
-        _id: crypto.randomUUID(),
-        name: 'PHP',
-        proficiencyLevels: [
-          ProficiencyLevelEnum.Beginner,
-          ProficiencyLevelEnum.Intermediate,
-          ProficiencyLevelEnum.Advanced
-        ]
-      },
-      {
-        _id: crypto.randomUUID(),
-        name: 'Java',
-        proficiencyLevels: [ProficiencyLevelEnum.Beginner]
-      }
-    ]
-  }
-]
-
 interface ProfessionalInfoTabProps {
   professionalBlock?: ProfessionalBlock
   categories: UserMainSubject[]
-  userId: string
 }
 
 const ProfessionalInfoTab: FC<ProfessionalInfoTabProps> = ({
   professionalBlock,
-  userId,
-  categories
+  categories = []
 }) => {
   const { t } = useTranslation()
 
-  const { userRole } = useAppSelector((state) => state.appMain)
+  const { userId, userRole } = useAppSelector((state) => state.appMain)
 
   const { openModal, closeModal } = useModalContext()
 
-  const { handleSubmit, loading } = useUpdateUser(userId)
+  const { handleSubmit, loading } = useUpdateUser(userId, true)
 
   const { data, handleInputChange } = useForm<ProfessionalBlock>({
     initialValues: professionalBlock || initialFormValues
   })
 
-  const handleDeleteCategory = (mainSubjectId: string) => {
+  const handleDeleteCategory = (mainSubjectId: string, categoryId: string) => {
     handleSubmit({
       mainSubjects: {
         _id: mainSubjectId,
-        category: { _id: '', name: '' },
-        subjects: []
+        category: { _id: categoryId, name: '' }
       }
     })
   }
@@ -155,6 +70,7 @@ const ProfessionalInfoTab: FC<ProfessionalInfoTabProps> = ({
       component: (
         <AddProfessionalCategoryModal
           {...{ handleSubmit, loading, initialValues, closeModal }}
+          blockedCategoriesOptions={categories}
         />
       ),
       paperProps: {

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.constants.ts
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.constants.ts
@@ -1,6 +1,11 @@
-import { ProfessionalSubject } from '~/types'
+import { ProfessionalCategory, SubjectNameInterface } from '~/types'
 
-export const professionalSubjectTemplate: Omit<ProfessionalSubject, '_id'> = {
-  name: '',
-  proficiencyLevels: []
+export const professionalSubjectTemplate: SubjectNameInterface = {
+  _id: '',
+  name: ''
+}
+
+export const userMainSubjectTemplate: ProfessionalCategory = {
+  category: { _id: '', name: '' },
+  subjects: [professionalSubjectTemplate]
 }

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.styles.ts
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.styles.ts
@@ -28,15 +28,10 @@ export const styles = {
   addOneMoreSubjectButton: {
     marginLeft: '58px'
   },
-  checkbox: {
-    padding: '12px',
-    '&.Mui-disabled': {
-      color: palette.primary[100]
-    }
-  },
   checkboxGroup: {
     display: 'flex',
-    gap: '10px'
+    gap: '10px',
+    marginLeft: '58px'
   },
   buttonGroup: {
     display: 'flex',

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.styles.ts
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.styles.ts
@@ -30,8 +30,13 @@ export const styles = {
   },
   checkboxGroup: {
     display: 'flex',
-    gap: '10px',
-    marginLeft: '58px'
+    gap: '10px'
+  },
+  deleteBtn: {
+    padding: '12px',
+    svg: {
+      fill: palette.primary[700]
+    }
   },
   buttonGroup: {
     display: 'flex',

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -61,10 +61,15 @@ function SubjectGroup({
   return (
     <Box sx={styles.item}>
       <Box sx={styles.checkboxGroup}>
-        <IconButton onClick={handleSubjectDelete} sx={styles.deleteBtn}>
+        <IconButton
+          data-testid='deleteBtn'
+          onClick={handleSubjectDelete}
+          sx={styles.deleteBtn}
+        >
           <DeleteIcon />
         </IconButton>
         <AsyncAutocomplete
+          data-testid='subjectField'
           disabled={!selectedCategory}
           fullWidth
           getOptionDisabled={handleDisableOptions}
@@ -118,7 +123,6 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
     initialValues: initialFormValues,
     onSubmit: formSubmission
   })
-
   const handleMainStudyCategoryChange = (
     _: SyntheticEvent,
     value: CategoryNameInterface | null

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -55,7 +55,7 @@ function SubjectGroup({
   )
 
   const handleDisableOptions = (option: SubjectInterface) => {
-    return disableOptions.some((subj) => subj._id === option._id)
+    return disableOptions.some((subject) => subject._id === option._id)
   }
 
   return (
@@ -93,6 +93,7 @@ interface AddProfessionalCategoryModalProps {
   initialValues?: ProfessionalCategory
   handleSubmit: (data: UpdateUserParams) => void
   loading: boolean
+  isDeletionBlocked?: boolean
 }
 
 const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
@@ -100,7 +101,8 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
   closeModal,
   initialValues: initialValuesFromProps,
   handleSubmit,
-  loading
+  loading,
+  isDeletionBlocked = false
 }) => {
   const { t } = useTranslation()
 
@@ -145,24 +147,37 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
     }
 
   const handleSubjectAdd = () => {
+    const newSubjects = [...data.subjects, professionalSubjectTemplate]
     handleDataChange({
-      subjects: [...data.subjects, professionalSubjectTemplate]
+      subjects: newSubjects
     })
   }
 
   const handleSubjectDelete = (id: string) => {
+    const updatedSubjects = data.subjects.filter((el) => el._id !== id)
     handleDataChange({
-      subjects: data.subjects.filter((el) => el._id !== id)
+      subjects: updatedSubjects
     })
   }
 
   const handleBlockOption = (option: CategoryNameInterface) => {
-    return (
-      blockedCategoriesOptions.some(
-        (mainSubject) => mainSubject.category._id === option._id
-      ) && option._id !== data.category._id
+    const isCurrent = option._id !== data.category._id
+    const isBlocked = blockedCategoriesOptions.some(
+      (mainSubject) => mainSubject.category._id === option._id
     )
+    return isBlocked && isCurrent
   }
+
+  const SubjectsGroup = data.subjects.map((subject, index) => (
+    <SubjectGroup
+      disableOptions={data.subjects}
+      handleChange={handleProfessionalSubjectChange(index)}
+      handleSubjectDelete={() => handleSubjectDelete(subject._id)}
+      key={index}
+      selectedCategory={data.category._id}
+      subject={{ name: subject.name, _id: subject._id }}
+    />
+  ))
 
   return (
     <Box component={ComponentEnum.Form} onSubmit={submitForm} sx={styles.root}>
@@ -177,6 +192,7 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
       />
       <Box sx={styles.formWrapper}>
         <AsyncAutocomplete
+          disabled={isDeletionBlocked}
           fullWidth
           getOptionDisabled={handleBlockOption}
           labelField='name'
@@ -192,16 +208,7 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
           value={data.category._id}
           valueField='_id'
         />
-        {data.subjects.map((subject, index) => (
-          <SubjectGroup
-            disableOptions={data.subjects}
-            handleChange={handleProfessionalSubjectChange(index)}
-            handleSubjectDelete={() => handleSubjectDelete(subject._id)}
-            key={index}
-            selectedCategory={data.category._id}
-            subject={{ name: subject.name, _id: subject._id }}
-          />
-        ))}
+        {SubjectsGroup}
         <Box sx={styles.addOneMoreSubjectButton}>
           <AppButton
             loading={loading}

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -9,7 +9,8 @@ import {
   ProfessionalCategory,
   SubjectInterface,
   SubjectNameInterface,
-  UpdateUserParams
+  UpdateUserParams,
+  UserMainSubject
 } from '~/types'
 
 import { subjectService } from '~/services/subject-service'
@@ -18,7 +19,10 @@ import useForm from '~/hooks/use-form'
 
 import Box from '@mui/material/Box'
 import AddIcon from '@mui/icons-material/Add'
+import DeleteIcon from '@mui/icons-material/Delete'
+import IconButton from '@mui/material/IconButton'
 import AppButton from '~/components/app-button/AppButton'
+
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
 
@@ -33,13 +37,15 @@ interface SubjectGroupProps {
   selectedCategory: string
   handleChange: (value: Partial<SubjectNameInterface>) => void
   disableOptions: Array<SubjectNameInterface>
+  handleSubjectDelete: () => void
 }
 
 function SubjectGroup({
   handleChange,
   subject,
   selectedCategory,
-  disableOptions
+  disableOptions,
+  handleSubjectDelete
 }: SubjectGroupProps) {
   const { t } = useTranslation()
 
@@ -55,6 +61,9 @@ function SubjectGroup({
   return (
     <Box sx={styles.item}>
       <Box sx={styles.checkboxGroup}>
+        <IconButton onClick={handleSubjectDelete} sx={styles.deleteBtn}>
+          <DeleteIcon />
+        </IconButton>
         <AsyncAutocomplete
           disabled={!selectedCategory}
           fullWidth
@@ -74,13 +83,15 @@ function SubjectGroup({
 }
 
 interface AddProfessionalCategoryModalProps {
+  blockedCategoriesOptions?: UserMainSubject[]
   closeModal: () => void
   initialValues?: ProfessionalCategory
-  handleSubmit: (data: UpdateUserParams) => Promise<void>
+  handleSubmit: (data: UpdateUserParams) => void
   loading: boolean
 }
 
 const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
+  blockedCategoriesOptions = [],
   closeModal,
   initialValues: initialValuesFromProps,
   handleSubmit,
@@ -90,8 +101,8 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
 
   const initialFormValues = initialValuesFromProps || userMainSubjectTemplate
 
-  const formSubmission = async () => {
-    await handleSubmit({
+  const formSubmission = () => {
+    handleSubmit({
       mainSubjects: data
     })
 
@@ -135,6 +146,20 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
     })
   }
 
+  const handleSubjectDelete = (id: string) => {
+    handleDataChange({
+      subjects: data.subjects.filter((el) => el._id !== id)
+    })
+  }
+
+  const handleBlockOption = (option: CategoryNameInterface) => {
+    return (
+      blockedCategoriesOptions.some(
+        (mainSubject) => mainSubject.category._id === option._id
+      ) && option._id !== data.category._id
+    )
+  }
+
   return (
     <Box component={ComponentEnum.Form} onSubmit={submitForm} sx={styles.root}>
       <TitleWithDescription
@@ -149,6 +174,7 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
       <Box sx={styles.formWrapper}>
         <AsyncAutocomplete
           fullWidth
+          getOptionDisabled={handleBlockOption}
           labelField='name'
           onChange={handleMainStudyCategoryChange}
           service={categoryService.getCategoriesNames}
@@ -166,6 +192,7 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
           <SubjectGroup
             disableOptions={data.subjects}
             handleChange={handleProfessionalSubjectChange(index)}
+            handleSubjectDelete={() => handleSubjectDelete(subject._id)}
             key={index}
             selectedCategory={data.category._id}
             subject={{ name: subject.name, _id: subject._id }}

--- a/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
+++ b/src/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.tsx
@@ -1,63 +1,74 @@
-import Checkbox from '@mui/material/Checkbox'
-import Box from '@mui/material/Box'
-import { FC, SyntheticEvent } from 'react'
+import { FC, SyntheticEvent, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import AppButton from '~/components/app-button/AppButton'
-import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
-import { styles } from '~/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.styles'
+
 import {
   ButtonTypeEnum,
   ButtonVariantEnum,
+  CategoryNameInterface,
   ComponentEnum,
   ProfessionalCategory,
-  ProfessionalSubject,
-  ProficiencyLevelEnum
+  SubjectInterface,
+  SubjectNameInterface,
+  UpdateUserParams
 } from '~/types'
-import useForm from '~/hooks/use-form'
-import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
-import AddIcon from '@mui/icons-material/Add'
-import { professionalSubjectTemplate } from '~/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.constants'
-import ProficiencyLevelSelect from '~/containers/proficiency-level-select/ProficiencyLevelSelect'
 
-interface ValueWithHandler<T> {
-  value: T
-  handleChange: (value: T) => void
-}
+import { subjectService } from '~/services/subject-service'
+import { categoryService } from '~/services/category-service'
+import useForm from '~/hooks/use-form'
+
+import Box from '@mui/material/Box'
+import AddIcon from '@mui/icons-material/Add'
+import AppButton from '~/components/app-button/AppButton'
+import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
+import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
+
+import {
+  professionalSubjectTemplate,
+  userMainSubjectTemplate
+} from '~/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.constants'
+import { styles } from '~/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.styles'
 
 interface SubjectGroupProps {
-  isCategoryDisabled: boolean
-  subjectName: ValueWithHandler<string | null>
-  proficiencyLevels: ValueWithHandler<ProficiencyLevelEnum[]>
+  subject: SubjectNameInterface
+  selectedCategory: string
+  handleChange: (value: Partial<SubjectNameInterface>) => void
+  disableOptions: Array<SubjectNameInterface>
 }
 
 function SubjectGroup({
-  isCategoryDisabled,
-  subjectName,
-  proficiencyLevels
+  handleChange,
+  subject,
+  selectedCategory,
+  disableOptions
 }: SubjectGroupProps) {
   const { t } = useTranslation()
+
+  const getSubjectsNames = useCallback(
+    () => subjectService.getSubjectsNames(selectedCategory),
+    [selectedCategory]
+  )
+
+  const handleDisableOptions = (option: SubjectInterface) => {
+    return disableOptions.some((subj) => subj._id === option._id)
+  }
 
   return (
     <Box sx={styles.item}>
       <Box sx={styles.checkboxGroup}>
-        <Checkbox checked disabled={isCategoryDisabled} sx={styles.checkbox} />
-        <AppAutoComplete
+        <AsyncAutocomplete
+          disabled={!selectedCategory}
           fullWidth
-          onChange={(_, value) => subjectName.handleChange(value)}
-          options={['Subject1', 'Subject2', 'Subject3']} // @TODO: replace with actual subjects from backend
+          getOptionDisabled={handleDisableOptions}
+          labelField='name'
+          onChange={(_, value) => handleChange(value!)}
+          service={getSubjectsNames}
           textFieldProps={{
             label: `${t('editProfilePage.profile.professionalTab.subject')}*`
           }}
-          value={subjectName.value}
+          value={subject._id}
+          valueField='_id'
         />
       </Box>
-      <ProficiencyLevelSelect
-        fillRange
-        fullWidth
-        label={t('editProfilePage.profile.professionalTab.proficiencyLevels')}
-        onChange={proficiencyLevels.handleChange}
-        value={proficiencyLevels.value}
-      />
     </Box>
   )
 }
@@ -65,42 +76,51 @@ function SubjectGroup({
 interface AddProfessionalCategoryModalProps {
   closeModal: () => void
   initialValues?: ProfessionalCategory
+  handleSubmit: (data: UpdateUserParams) => Promise<void>
+  loading: boolean
 }
 
 const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
   closeModal,
-  initialValues: initialValuesFromProps
+  initialValues: initialValuesFromProps,
+  handleSubmit,
+  loading
 }) => {
   const { t } = useTranslation()
 
-  const initialFormValues = {
-    mainStudyCategory: initialValuesFromProps?.name ?? '',
-    subjects: initialValuesFromProps?.subjects ?? [professionalSubjectTemplate]
+  const initialFormValues = initialValuesFromProps || userMainSubjectTemplate
+
+  const formSubmission = async () => {
+    await handleSubmit({
+      mainSubjects: data
+    })
+
+    closeModal()
   }
 
-  // @TODO: add more validations if needed
-  const { data, errors, handleDataChange, handleSubmit } = useForm({
+  const {
+    data,
+    errors,
+    handleDataChange,
+    handleSubmit: submitForm
+  } = useForm({
     initialValues: initialFormValues,
-    // eslint-disable-next-line
-    onSubmit: async () => {
-      // @TODO: handle data save
-      void closeModal()
-    }
+    onSubmit: formSubmission
   })
 
   const handleMainStudyCategoryChange = (
     _: SyntheticEvent,
-    value: string | null
+    value: CategoryNameInterface | null
   ) => {
-    handleDataChange({ mainStudyCategory: value })
+    handleDataChange({ category: value })
   }
 
   const handleProfessionalSubjectChange =
-    (index: number, key: keyof ProfessionalSubject) =>
+    (index: number) =>
     <Value,>(value: Value) => {
       const transformedSubjects = data.subjects.map((subject, i) => {
         if (index === i) {
-          return { ...subject, [key]: value }
+          return { ...subject, ...value }
         }
 
         return subject
@@ -116,11 +136,7 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
   }
 
   return (
-    <Box
-      component={ComponentEnum.Form}
-      onSubmit={handleSubmit}
-      sx={styles.root}
-    >
+    <Box component={ComponentEnum.Form} onSubmit={submitForm} sx={styles.root}>
       <TitleWithDescription
         description={t(
           'editProfilePage.profile.professionalTab.addCategoryModal.description'
@@ -131,38 +147,33 @@ const AddProfessionalCategoryModal: FC<AddProfessionalCategoryModalProps> = ({
         )}
       />
       <Box sx={styles.formWrapper}>
-        <AppAutoComplete
+        <AsyncAutocomplete
           fullWidth
+          labelField='name'
           onChange={handleMainStudyCategoryChange}
-          options={['Language1', 'Language2', 'Language3']} // @TODO: replace with actual languages from backend
+          service={categoryService.getCategoriesNames}
           textFieldProps={{
             label: `${t(
               'editProfilePage.profile.professionalTab.mainStudyCategory'
             )}*`,
-            error: Boolean(errors.mainStudyCategory),
-            helperText: errors.mainStudyCategory
+            error: Boolean(errors.category),
+            helperText: errors.category
           }}
-          value={data.mainStudyCategory}
+          value={data.category._id}
+          valueField='_id'
         />
         {data.subjects.map((subject, index) => (
           <SubjectGroup
-            isCategoryDisabled // @TODO: handle checkbox
+            disableOptions={data.subjects}
+            handleChange={handleProfessionalSubjectChange(index)}
             key={index}
-            proficiencyLevels={{
-              value: subject.proficiencyLevels,
-              handleChange: handleProfessionalSubjectChange(
-                index,
-                'proficiencyLevels'
-              )
-            }}
-            subjectName={{
-              value: subject.name,
-              handleChange: handleProfessionalSubjectChange(index, 'name')
-            }}
+            selectedCategory={data.category._id}
+            subject={{ name: subject.name, _id: subject._id }}
           />
         ))}
         <Box sx={styles.addOneMoreSubjectButton}>
           <AppButton
+            loading={loading}
             onClick={handleSubjectAdd}
             startIcon={<AddIcon />}
             variant={ButtonVariantEnum.ContainedLight}

--- a/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
@@ -2,22 +2,22 @@ import Box from '@mui/material/Box'
 import { FC } from 'react'
 import ProfessionalCategory from '~/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory'
 import { styles } from '~/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.styles'
-import {
-  OpenProfessionalCategoryModalHandler,
-  ProfessionalCategoryWithActivationControls
-} from '~/types'
+import { OpenProfessionalCategoryModalHandler, UserMainSubject } from '~/types'
 
 interface ProfessionalCategoryListProps {
-  items: ProfessionalCategoryWithActivationControls[]
+  items: UserMainSubject[]
   openProfessionalCategoryModal: OpenProfessionalCategoryModalHandler
+  handleDeleteCategory: (id: string) => void
 }
 
 const ProfessionalCategoryList: FC<ProfessionalCategoryListProps> = ({
   items,
-  openProfessionalCategoryModal
+  openProfessionalCategoryModal,
+  handleDeleteCategory
 }) => {
   const professionalCategoryItems = items.map((item) => (
     <ProfessionalCategory
+      handleDelete={() => handleDeleteCategory(item._id)}
       item={item}
       key={item._id}
       openProfessionalCategoryModal={openProfessionalCategoryModal}

--- a/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
@@ -15,14 +15,17 @@ const ProfessionalCategoryList: FC<ProfessionalCategoryListProps> = ({
   openProfessionalCategoryModal,
   handleDeleteCategory
 }) => {
-  const professionalCategoryItems = items.map((item) => (
-    <ProfessionalCategory
-      handleDelete={() => handleDeleteCategory(item._id, item.category._id)}
-      item={item}
-      key={item._id}
-      openProfessionalCategoryModal={openProfessionalCategoryModal}
-    />
-  ))
+  const professionalCategoryItems = items.map((item) => {
+    const handleDelete = () => handleDeleteCategory(item._id, item.category._id)
+    return (
+      <ProfessionalCategory
+        handleDelete={handleDelete}
+        item={item}
+        key={item._id}
+        openProfessionalCategoryModal={openProfessionalCategoryModal}
+      />
+    )
+  })
 
   return <Box sx={styles.cards}>{professionalCategoryItems}</Box>
 }

--- a/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
@@ -7,7 +7,7 @@ import { OpenProfessionalCategoryModalHandler, UserMainSubject } from '~/types'
 interface ProfessionalCategoryListProps {
   items: UserMainSubject[]
   openProfessionalCategoryModal: OpenProfessionalCategoryModalHandler
-  handleDeleteCategory: (id: string) => void
+  handleDeleteCategory: (id: string, categoryId: string) => void
 }
 
 const ProfessionalCategoryList: FC<ProfessionalCategoryListProps> = ({
@@ -17,7 +17,7 @@ const ProfessionalCategoryList: FC<ProfessionalCategoryListProps> = ({
 }) => {
   const professionalCategoryItems = items.map((item) => (
     <ProfessionalCategory
-      handleDelete={() => handleDeleteCategory(item._id)}
+      handleDelete={() => handleDeleteCategory(item._id, item.category._id)}
       item={item}
       key={item._id}
       openProfessionalCategoryModal={openProfessionalCategoryModal}

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.styles.ts
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.styles.ts
@@ -4,17 +4,15 @@ import palette from '~/styles/app-theme/app.pallete'
 const { Body2, Overline, Caption } = TypographyVariantEnum
 
 export const styles = {
-  root: (isActivated: boolean) => ({
-    border: `1px solid ${
-      isActivated ? palette.primary[300] : palette.primary[100]
-    }`,
+  root: {
+    border: `1px solid ${palette.primary[300]}`,
     display: 'flex',
     flexDirection: 'column',
     gap: 2,
     borderRadius: 1,
     px: 2,
     py: 4
-  }),
+  },
   createBtnContainer: {
     my: 3
   },
@@ -62,10 +60,9 @@ export const styles = {
     }
   },
   card: {
-    root: (isActivated: boolean) => ({
-      m: 0,
-      ...(!isActivated && { color: palette.primary[200] })
-    }),
+    root: {
+      m: 0
+    },
     item: {
       display: 'flex',
       flexDirection: { xs: 'column', md: 'row' },

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.styles.ts
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.styles.ts
@@ -8,7 +8,7 @@ export const styles = {
     border: `1px solid ${palette.primary[300]}`,
     display: 'flex',
     flexDirection: 'column',
-    gap: 2,
+    gap: 3,
     borderRadius: 1,
     px: 2,
     py: 4
@@ -34,7 +34,8 @@ export const styles = {
     deleteButton: {
       svg: {
         fill: palette.primary[700]
-      }
+      },
+      '&:disabled': { svg: { fill: palette.primary[200] } }
     }
   },
   cards: {
@@ -50,7 +51,7 @@ export const styles = {
       display: 'flex',
       flexDirection: 'column',
       columnGap: 3,
-      rowGap: 5
+      rowGap: 2
     },
     item: {
       display: 'flex',

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
@@ -6,34 +6,30 @@ import Tooltip from '@mui/material/Tooltip'
 import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import AppButton from '~/components/app-button/AppButton'
-import { ButtonVariantEnum, ComponentEnum, PositionEnum } from '~/types'
+import {
+  ButtonVariantEnum,
+  ComponentEnum,
+  PositionEnum,
+  UserMainSubject
+} from '~/types'
 import DeleteIcon from '@mui/icons-material/Delete'
 import useConfirm from '~/hooks/use-confirm'
 import { styles } from '~/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.styles'
-import {
-  OpenProfessionalCategoryModalHandler,
-  ProfessionalCategoryWithActivationControls
-} from '~/types'
+import { OpenProfessionalCategoryModalHandler } from '~/types'
 
 interface ProfessionalCategoryProps {
-  item: ProfessionalCategoryWithActivationControls
+  item: UserMainSubject
   openProfessionalCategoryModal: OpenProfessionalCategoryModalHandler
+  handleDelete: () => void
 }
 
 const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
   item,
-  openProfessionalCategoryModal
+  openProfessionalCategoryModal,
+  handleDelete
 }) => {
   const { t } = useTranslation()
   const { openDialog } = useConfirm()
-
-  const handleActivateButtonClick = () => {
-    // @TODO: handle activation logic
-  }
-
-  const handleDeactivateButtonClick = () => {
-    // @TODO: handle deactivation logic
-  }
 
   const handleDeleteButtonClick = () => {
     openDialog({
@@ -50,7 +46,7 @@ const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
         'editProfilePage.profile.professionalTab.deleteCategoryModal.submitBtn'
       ),
       sendConfirm: () => {
-        // @TODO: handle deleting category
+        handleDelete()
       }
     })
   }
@@ -74,77 +70,52 @@ const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
     )
   }
 
-  const ToolbarButtons = item.isActivated ? (
-    <>
-      <AppButton
-        onClick={() => openProfessionalCategoryModal(item)}
-        variant={ButtonVariantEnum.ContainedLight}
-      >
-        {t('editProfilePage.profile.professionalTab.editCategoryBtn')}
-      </AppButton>
-      <Tooltip
-        arrow
-        placement={PositionEnum.Right}
-        title={
-          <Typography sx={styles.toolbar.deactivateButtonTooltip}>
-            {t(
-              `editProfilePage.profile.professionalTab.deactivateCategoryBtn${
-                !item.isActivationBlocked ? 'Enabled' : 'Disabled'
-              }Tooltip`
-            )}
-          </Typography>
-        }
-      >
-        <Box>
-          <AppButton
-            disabled={item.isActivationBlocked}
-            onClick={handleDeactivateButtonClick}
-            variant={ButtonVariantEnum.Tonal}
-          >
-            {t('editProfilePage.profile.professionalTab.deactivateCategoryBtn')}
-          </AppButton>
-        </Box>
-      </Tooltip>
-    </>
-  ) : (
-    <AppButton
-      onClick={handleActivateButtonClick}
-      variant={ButtonVariantEnum.Tonal}
-    >
-      {t('editProfilePage.profile.professionalTab.activateCategoryBtn')}
-    </AppButton>
-  )
-
   const Subjects = item.subjects.map((subject) => (
     <Box key={subject._id} sx={styles.subjects.item}>
       <CardItem label={t('editProfilePage.profile.professionalTab.subject')}>
         {subject.name}
       </CardItem>
-      <CardItem
-        label={t('editProfilePage.profile.professionalTab.proficiencyLevels')}
-      >
-        {subject.proficiencyLevels.join(', ')}
-      </CardItem>
     </Box>
   ))
 
   return (
-    <Box sx={styles.root(item.isActivated)}>
+    <Box sx={styles.root}>
       <Box sx={styles.toolbar.root}>
-        <Box sx={styles.toolbar.buttonGroup}>{ToolbarButtons}</Box>
-        <IconButton
-          data-testid='delete-professional-category-button'
-          onClick={handleDeleteButtonClick}
-          sx={styles.toolbar.deleteButton}
+        <Box sx={styles.toolbar.buttonGroup}>
+          <AppButton
+            onClick={() => openProfessionalCategoryModal(item)}
+            variant={ButtonVariantEnum.ContainedLight}
+          >
+            {t('editProfilePage.profile.professionalTab.editCategoryBtn')}
+          </AppButton>
+        </Box>
+        <Tooltip
+          arrow
+          placement={PositionEnum.Right}
+          title={
+            <Typography sx={styles.toolbar.deactivateButtonTooltip}>
+              {item.isDeletionBlocked
+                ? t(
+                    'editProfilePage.profile.professionalTab.deleteCategoryBtnDisabledTooltip'
+                  )
+                : ''}
+            </Typography>
+          }
         >
-          <DeleteIcon />
-        </IconButton>
+          <IconButton
+            disabled={item.isDeletionBlocked}
+            onClick={handleDeleteButtonClick}
+            sx={styles.toolbar.deleteButton}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </Tooltip>
       </Box>
-      <Box component={ComponentEnum.Dl} sx={styles.card.root(item.isActivated)}>
+      <Box component={ComponentEnum.Dl} sx={styles.card.root}>
         <CardItem
           label={t('editProfilePage.profile.professionalTab.mainStudyCategory')}
         >
-          {item.name}
+          {item.category.name}
         </CardItem>
         <Divider sx={styles.divider} />
         <Box sx={styles.subjects.root}>{Subjects}</Box>

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
@@ -103,6 +103,7 @@ const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
         >
           <span>
             <IconButton
+              data-testid='delete-professional-category-button'
               disabled={item.isDeletionBlocked}
               onClick={handleDeleteButtonClick}
               sx={styles.toolbar.deleteButton}

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
@@ -10,12 +10,12 @@ import {
   ButtonVariantEnum,
   ComponentEnum,
   PositionEnum,
-  UserMainSubject
+  UserMainSubject,
+  OpenProfessionalCategoryModalHandler
 } from '~/types'
 import DeleteIcon from '@mui/icons-material/Delete'
 import useConfirm from '~/hooks/use-confirm'
 import { styles } from '~/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.styles'
-import { OpenProfessionalCategoryModalHandler } from '~/types'
 
 interface ProfessionalCategoryProps {
   item: UserMainSubject
@@ -94,11 +94,10 @@ const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
           placement={PositionEnum.Right}
           sx={styles.toolbar.deactivateButtonTooltip}
           title={
-            item.isDeletionBlocked
-              ? t(
-                  'editProfilePage.profile.professionalTab.deleteCategoryBtnDisabledTooltip'
-                )
-              : ''
+            item.isDeletionBlocked &&
+            t(
+              'editProfilePage.profile.professionalTab.deleteCategoryBtnDisabledTooltip'
+            )
           }
         >
           <span>

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
@@ -92,23 +92,24 @@ const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
         <Tooltip
           arrow
           placement={PositionEnum.Right}
+          sx={styles.toolbar.deactivateButtonTooltip}
           title={
-            <Typography sx={styles.toolbar.deactivateButtonTooltip}>
-              {item.isDeletionBlocked
-                ? t(
-                    'editProfilePage.profile.professionalTab.deleteCategoryBtnDisabledTooltip'
-                  )
-                : ''}
-            </Typography>
+            item.isDeletionBlocked
+              ? t(
+                  'editProfilePage.profile.professionalTab.deleteCategoryBtnDisabledTooltip'
+                )
+              : ''
           }
         >
-          <IconButton
-            disabled={item.isDeletionBlocked}
-            onClick={handleDeleteButtonClick}
-            sx={styles.toolbar.deleteButton}
-          >
-            <DeleteIcon />
-          </IconButton>
+          <span>
+            <IconButton
+              disabled={item.isDeletionBlocked}
+              onClick={handleDeleteButtonClick}
+              sx={styles.toolbar.deleteButton}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </span>
         </Tooltip>
       </Box>
       <Box component={ComponentEnum.Dl} sx={styles.card.root}>

--- a/src/containers/edit-profile/profile-tab/ProfileTab.tsx
+++ b/src/containers/edit-profile/profile-tab/ProfileTab.tsx
@@ -73,7 +73,7 @@ const ProfileTab: FC<ProfileTabProps> = ({ user }) => {
   }, [setNeedConfirmation, isDirty])
 
   const handleUpdateData = () => {
-    const updatedData = getUserUpdatedData(user, data)
+    const updatedData = getUserUpdatedData(data)
     handleSubmit(updatedData)
   }
 

--- a/src/containers/user-profile/profile-info/ProfileInfo.jsx
+++ b/src/containers/user-profile/profile-info/ProfileInfo.jsx
@@ -142,9 +142,10 @@ const ProfileInfo = ({ userData, myRole }) => {
   )
 
   const subjectData =
-    userData.mainSubjects.tutor?.flatMap((item) =>
-      item.subjects.map((subject) => subject.name)
-    ) || []
+    userData.mainSubjects.tutor?.flatMap((item) => {
+      const subjectNames = item.subjects.map((subject) => subject.name)
+      return subjectNames.length ? subjectNames : [item.category.name]
+    }) || []
 
   return !isMobile ? (
     <ProfileContainerDesktop

--- a/src/containers/user-profile/profile-info/ProfileInfo.jsx
+++ b/src/containers/user-profile/profile-info/ProfileInfo.jsx
@@ -142,7 +142,9 @@ const ProfileInfo = ({ userData, myRole }) => {
   )
 
   const subjectData =
-    userData.mainSubjects.tutor?.map((item) => item.name) || []
+    userData.mainSubjects.tutor?.flatMap((item) =>
+      item.subjects.map((subject) => subject.name)
+    ) || []
 
   return !isMobile ? (
     <ProfileContainerDesktop

--- a/src/hooks/use-form.tsx
+++ b/src/hooks/use-form.tsx
@@ -12,7 +12,7 @@ interface UseFormProps<T> {
   initialValues: T
   initialErrors?: UseFormErrors<T>
   validations?: Partial<UseFormValidations<T>>
-  onSubmit?: (data?: T) => Promise<void>
+  onSubmit?: (data?: T) => Promise<void> | void
   submitWithData?: boolean
 }
 

--- a/src/pages/edit-profile/EditProfile.constants.tsx
+++ b/src/pages/edit-profile/EditProfile.constants.tsx
@@ -32,7 +32,6 @@ export const tabsData: UserProfileProps = {
       <ProfessionalInfoTab
         categories={response.mainSubjects[userRole]}
         professionalBlock={response.professionalBlock}
-        userId={response._id}
       />
     )
   },

--- a/src/pages/edit-profile/EditProfile.constants.tsx
+++ b/src/pages/edit-profile/EditProfile.constants.tsx
@@ -4,7 +4,7 @@ import SchoolIcon from '@mui/icons-material/School'
 import NotificationsIcon from '@mui/icons-material/Notifications'
 import GppGoodIcon from '@mui/icons-material/GppGood'
 
-import { UserProfileTabsEnum, UserResponse } from '~/types'
+import { UserProfileTabsEnum, UserResponse, MainUserRole } from '~/types'
 import ProfileTab from '~/containers/edit-profile/profile-tab/ProfileTab'
 import ProfessionalInfoTab from '~/containers/edit-profile/professional-info-tab/ProfessionalInfoTab'
 import NotificationTab from '~/containers/edit-profile/notification-tab/NotificationTab'
@@ -14,7 +14,7 @@ export type UserProfileProps = Record<
   UserProfileTabsEnum,
   {
     title: string
-    content: (response: UserResponse) => ReactElement
+    content: (response: UserResponse, userRole: MainUserRole) => ReactElement
     icon?: ReactElement
   }
 >
@@ -28,9 +28,9 @@ export const tabsData: UserProfileProps = {
   [UserProfileTabsEnum.ProfessionalInfo]: {
     icon: <SchoolIcon />,
     title: 'editProfilePage.profile.professionalTab.tabTitle',
-    content: (response) => (
+    content: (response, userRole) => (
       <ProfessionalInfoTab
-        categories={response.mainSubjects.tutor}
+        categories={response.mainSubjects[userRole]}
         professionalBlock={response.professionalBlock}
         userId={response._id}
       />

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -18,6 +18,7 @@ import AppButton from '~/components/app-button/AppButton'
 import SidebarMenu from '~/components/sidebar-menu/SidebarMenu'
 import {
   ButtonVariantEnum,
+  MainUserRole,
   SizeEnum,
   UserProfileTabsEnum,
   UserResponse,
@@ -68,7 +69,8 @@ const EditProfile = () => {
   }
 
   const cooperationContent =
-    activeTab && tabsData[activeTab]?.content?.(response)
+    activeTab &&
+    tabsData[activeTab]?.content?.(response, userRole as MainUserRole)
 
   return (
     <PageWrapper>

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -54,7 +54,7 @@ const EditProfile = () => {
   const { userId, userRole } = useAppSelector((state) => state.appMain)
 
   const getUserData = useCallback(
-    () => userService.getUserById(userId, userRole as UserRole),
+    () => userService.getUserById(userId, userRole as UserRole, true),
     [userId, userRole]
   )
   const { checkConfirmation } = useConfirm()

--- a/src/services/user-service.tsx
+++ b/src/services/user-service.tsx
@@ -17,10 +17,11 @@ export const userService = {
   },
   getUserById: (
     userId: string,
-    userRole: UserRole
+    userRole: UserRole,
+    isEdit?: boolean
   ): Promise<AxiosResponse<UserResponse>> => {
     return axiosClient.get(
-      createUrlPath(URLs.users.get, userId, { role: userRole })
+      createUrlPath(URLs.users.get, userId, { role: userRole, isEdit })
     )
   },
   updateUser: (

--- a/src/types/edit-profile/interfaces/editProfile.interfaces.ts
+++ b/src/types/edit-profile/interfaces/editProfile.interfaces.ts
@@ -1,4 +1,8 @@
-import { ProficiencyLevelEnum, UpdatedPhoto } from '~/types/common/common.index'
+import {
+  CategoryNameInterface,
+  SubjectNameInterface,
+  UpdatedPhoto
+} from '~/types/common/common.index'
 import { UserResponse } from '~/types/user/user.index'
 
 export interface EditProfileForm
@@ -11,20 +15,12 @@ export interface EditProfileForm
   photo: string | UpdatedPhoto | null
 }
 
-export interface ProfessionalSubject {
-  _id: string
-  name: string
-  proficiencyLevels: ProficiencyLevelEnum[]
-}
-
 export interface ProfessionalCategory {
-  _id: string
-  name: string
-  subjects: ProfessionalSubject[]
+  category: CategoryNameInterface
+  subjects: SubjectNameInterface[]
 }
 
-export interface ProfessionalCategoryWithActivationControls
-  extends ProfessionalCategory {
-  isActivated: boolean
-  isActivationBlocked: boolean
+export interface UserMainSubject extends ProfessionalCategory {
+  isDeletionBlocked: boolean
+  _id: string
 }

--- a/src/types/edit-profile/types/editProfile.types.ts
+++ b/src/types/edit-profile/types/editProfile.types.ts
@@ -1,5 +1,5 @@
-import { ProfessionalCategory } from '~/types'
+import { UserMainSubject } from '~/types'
 
 export type OpenProfessionalCategoryModalHandler = (
-  initialValues?: ProfessionalCategory
+  initialValues?: UserMainSubject
 ) => void

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -4,13 +4,13 @@ import {
   Address,
   UserRole,
   RequestParams,
-  SubjectInterface,
-  SubjectNameInterface,
   Faq,
   DataByRole,
   UpdatedPhoto,
   UpdateFields,
-  UserStatusEnum
+  UserStatusEnum,
+  UserMainSubject,
+  ProfessionalCategory
 } from '~/types'
 
 export interface LocalStorage {
@@ -34,7 +34,7 @@ export interface UserResponse {
   firstName: string
   lastName: string
   email: string
-  mainSubjects: DataByRole<SubjectInterface[]>
+  mainSubjects: DataByRole<UserMainSubject[]>
   totalReviews: DataByRole<number>
   averageRating: DataByRole<number>
   nativeLanguage: string | null
@@ -65,7 +65,7 @@ export interface UserGeneralInfo
 
 export interface UpdateUserParams
   extends Partial<Pick<UserResponse, UpdateFields>> {
-  mainSubjects?: SubjectNameInterface[]
+  mainSubjects?: ProfessionalCategory & { _id?: string }
   videoLink?: string
   photo?: UpdatedPhoto | null
 }

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -9,8 +9,7 @@ import {
   UpdatedPhoto,
   UpdateFields,
   UserStatusEnum,
-  UserMainSubject,
-  ProfessionalCategory
+  UserMainSubject
 } from '~/types'
 
 export interface LocalStorage {
@@ -65,7 +64,7 @@ export interface UserGeneralInfo
 
 export interface UpdateUserParams
   extends Partial<Pick<UserResponse, UpdateFields>> {
-  mainSubjects?: ProfessionalCategory & { _id?: string }
+  mainSubjects?: Partial<UserMainSubject>
   videoLink?: string
   photo?: UpdatedPhoto | null
 }

--- a/src/types/user/user-types/user.types.ts
+++ b/src/types/user/user-types/user.types.ts
@@ -12,3 +12,5 @@ export type UpdateFields =
   | 'professionalSummary'
   | 'nativeLanguage'
   | 'professionalBlock'
+
+export type MainUserRole = UserRoleEnum.Tutor | UserRoleEnum.Student

--- a/src/utils/get-profile-values.ts
+++ b/src/utils/get-profile-values.ts
@@ -20,15 +20,10 @@ export const getProfileInitialValues = (user: UserResponse) => ({
     user.role[0] !== UserRoleEnum.Admin
       ? user.videoLink?.[user.role[0]] || ''
       : '',
-  mainSubjects:
-    user.role[0] !== UserRoleEnum.Admin ? user.mainSubjects[user.role[0]] : [],
   photo: user.photo || { src: '', name: '' }
 })
 
-export const getUserUpdatedData = (
-  user: UserResponse,
-  data: EditProfileForm
-) => {
+export const getUserUpdatedData = (data: EditProfileForm) => {
   const updatedData: UpdateUserParams = {
     firstName: data.firstName,
     lastName: data.lastName,
@@ -37,10 +32,6 @@ export const getUserUpdatedData = (
       city: data.city ?? ''
     },
     professionalSummary: data.professionalSummary,
-    mainSubjects:
-      user.role[0] !== UserRoleEnum.Admin
-        ? user.mainSubjects[user.role[0]]
-        : [],
     nativeLanguage: data.nativeLanguage ?? null,
     videoLink: data.videoLink
   }

--- a/src/utils/helper-functions.tsx
+++ b/src/utils/helper-functions.tsx
@@ -192,7 +192,9 @@ const createQueryParamsString = (query: { [key: string]: string }) => {
   const queryParams = new URLSearchParams()
 
   Object.entries(query).forEach(([key, value]) => {
-    queryParams.append(key, value)
+    if (value) {
+      queryParams.append(key, value)
+    }
   })
 
   return queryParams.toString()

--- a/tests/test-utils.jsx
+++ b/tests/test-utils.jsx
@@ -62,13 +62,17 @@ export const TestSnackbar = ({ children }) => (
   </>
 )
 
-export const selectOption = async (selectLike, option) => {
+export const selectOption = async (
+  selectLike,
+  option,
+  selectionFn = 'getByText'
+) => {
   await act(async () => {
     fireEvent.click(selectLike)
     fireEvent.change(selectLike, { target: { value: option } })
   })
 
-  const selectedOption = screen.getByText(option)
+  const selectedOption = screen[selectionFn](option)
   await act(async () => {
     fireEvent.click(selectedOption)
   })

--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -77,10 +77,7 @@ describe('AddProfessionalCategoryModal without initial value', () => {
     )
     await selectOption(categoryAutocomplete, 'Cooking', 'getByDisplayValue')
 
-    // const subjectAutoComplete = screen.getByLabelText(
-    //   /editProfilePage.profile.professionalTab.subject/
-    // )
-    // await selectOption(subjectAutoComplete, 'Gastronomy')
+    // TODO: Implement test case for subjects
   })
 
   it('should close modal when form is submitted', async () => {
@@ -95,11 +92,7 @@ describe('AddProfessionalCategoryModal without initial value', () => {
   })
 
   it('should be disabled if category is disabled', () => {
-    const categoryAutocomplete = screen.getByLabelText(
-      /editProfilePage.profile.professionalTab.mainStudyCategory/
-    )
-    fireEvent.mouseDown(categoryAutocomplete)
-    // const disabledOption = screen.getByText('Music')
+    // TODO: Implement test case
   })
 })
 
@@ -119,12 +112,7 @@ describe('AddProfessionalCategoryModal with initial value', () => {
   )
 
   it('should create SubjectGroup list according to passed initial values (modal edit mode)', async () => {
-    // const professionalSubjects = screen.getAllByTestId('subjectField')
-    // expect(professionalSubjects).toHaveLength(2)
-    // expect(professionalSubjects[0]).toHaveValue(initialValues.subjects[0]._id)
-    // expect(professionalSubjects[1]).not.toHaveValue(
-    //   initialValues.subjects[0]._id
-    // )
+    // TODO: Implement test case
   })
 
   it('should delete subject from the list', async () => {

--- a/tests/unit/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.spec.jsx
@@ -1,43 +1,28 @@
 import ProfessionalCategory from '~/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory'
 import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '~tests/test-utils'
-import { ProficiencyLevelEnum } from '~/types'
 
 const mockOpenProfessionalCategoryModal = vi.fn()
-
-const activatedCategory = {
-  _id: '1',
-  name: 'Computer science',
-  isActivated: true,
-  isActivationBlocked: false,
-  subjects: []
-}
+const mockedHandleDelete = vi.fn()
 
 const categoryWithSubjects = {
-  ...activatedCategory,
-  subjects: [
-    {
-      _id: '1',
-      name: 'PHP',
-      proficiencyLevels: [
-        ProficiencyLevelEnum.Beginner,
-        ProficiencyLevelEnum.Intermediate,
-        ProficiencyLevelEnum.Advanced
-      ]
-    },
-    {
-      _id: '2',
-      name: 'Java',
-      proficiencyLevels: [ProficiencyLevelEnum.Beginner]
-    }
-  ]
+  _id: '648850c4fdc2d1a130c24aea',
+  category: { _id: '64884f21fdc2d1a130c24ac0', name: 'Music' },
+  subjects: [{ _id: '64885108fdc2d1a130c24af9', name: 'Guitar' }],
+  isDeletionBlocked: false
 }
 
-const deactivatedCategory = { ...activatedCategory, isActivated: false }
+const blockedCategory = {
+  _id: '648850c4fdc2d1a130c24aea',
+  category: { _id: '64884f21fdc2d1a130c24ac0', name: 'Music' },
+  subjects: [{ _id: '64885108fdc2d1a130c24af9', name: 'Guitar' }],
+  isDeletionBlocked: true
+}
 
 const renderProfessionalCategoryWithItem = (item) => {
   renderWithProviders(
     <ProfessionalCategory
+      handleDelete={mockedHandleDelete}
       item={item}
       openProfessionalCategoryModal={mockOpenProfessionalCategoryModal}
     />
@@ -45,26 +30,6 @@ const renderProfessionalCategoryWithItem = (item) => {
 }
 
 describe('ProfessionalCategory', () => {
-  it('should render deactivate button when isActivated is true', () => {
-    renderProfessionalCategoryWithItem(activatedCategory)
-
-    const deactivateCategoryButton = screen.getByText(
-      /editProfilePage.profile.professionalTab.deactivateCategoryBtn/
-    )
-
-    expect(deactivateCategoryButton).toBeInTheDocument()
-  })
-
-  it('should render activate button when isActivated is false', () => {
-    renderProfessionalCategoryWithItem(deactivatedCategory)
-
-    const activateCategoryButton = screen.getByText(
-      /editProfilePage.profile.professionalTab.activateCategoryBtn/
-    )
-
-    expect(activateCategoryButton).toBeInTheDocument()
-  })
-
   it('should open modal when Delete button is clicked', () => {
     renderProfessionalCategoryWithItem(categoryWithSubjects)
 
@@ -76,8 +41,24 @@ describe('ProfessionalCategory', () => {
     const deleteCategoryModalTitle = screen.getByText(
       /editProfilePage.profile.professionalTab.deleteCategoryModal.title/
     )
-
     expect(deleteCategoryModalTitle).toBeInTheDocument()
+
+    const confirmBtn = screen.getByText(
+      /editProfilePage.profile.professionalTab.deleteCategoryModal.submitBtn/
+    )
+
+    fireEvent.click(confirmBtn)
+
+    expect(mockedHandleDelete).toHaveBeenCalled()
+  })
+
+  it('should disable delete button if deletion blocked', () => {
+    renderProfessionalCategoryWithItem(blockedCategory)
+    const deleteCategoryButton = screen.getByTestId(
+      'delete-professional-category-button'
+    )
+
+    expect(deleteCategoryButton).toBeDisabled()
   })
 
   it('should render subjects correctly', () => {
@@ -92,5 +73,18 @@ describe('ProfessionalCategory', () => {
     )
 
     expect(subjectLabels).toHaveLength(categoryWithSubjects.subjects.length)
+  })
+
+  it('should open edit subject modal correctly', () => {
+    renderProfessionalCategoryWithItem(categoryWithSubjects)
+
+    const editBtn = screen.getByText(
+      /editProfilePage.profile.professionalTab.editCategoryBtn/
+    )
+    expect(editBtn).toBeInTheDocument()
+
+    fireEvent.click(editBtn)
+
+    expect(mockOpenProfessionalCategoryModal).toHaveBeenCalled()
   })
 })

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -43,22 +43,14 @@ const userData = {
     student: [],
     tutor: [
       {
-        _id: '645b9f4a1c0272f5cde0e11e',
-        name: 'Danish',
-        category: '6459347d943e375d1c0a1912',
-        totalOffers: 0
+        _id: '648850c4fdc2d1a130c24aea',
+        category: { _id: '64884f21fdc2d1a130c24ac0', name: 'Music' },
+        subjects: [{ _id: '64885108fdc2d1a130c24af9', name: 'Guitar' }]
       },
       {
-        _id: '6422d995d898aa732d038e8f',
-        name: 'Guitar',
-        category: '6421ed8ed991d46a84721dfa',
-        totalOffers: 4
-      },
-      {
-        _id: '6422ad6a74c1353b96c7c132',
-        name: 'Web design',
-        category: '6421ed8ed991d46a84721df4',
-        totalOffers: 9
+        _id: '648850c4fdc2d1342130c24d',
+        category: { _id: '64884f21fdc2d1a130c24ac0', name: 'Cooking' },
+        subjects: [{ _id: '64885108fdc2d1a130c24af9', name: 'Gastronomy' }]
       }
     ]
   },

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -51,7 +51,7 @@ describe('EditProfile', () => {
   beforeEach(async () => {
     await waitFor(() => {
       mockAxiosClient
-        .onGet(`${URLs.users.get}/${userId}?role=${userRole}`)
+        .onGet(`${URLs.users.get}/${userId}?role=${userRole}&isEdit=true`)
         .reply(200, userMock)
       renderWithProviders(<EditProfile />, {
         preloadedState: mockState

--- a/tests/unit/pages/tutor-profile/TutorProfile.spec.jsx
+++ b/tests/unit/pages/tutor-profile/TutorProfile.spec.jsx
@@ -42,21 +42,13 @@ const mockData = {
     tutor: [
       {
         _id: '648850c4fdc2d1a130c24aea',
-        name: 'Guitar',
-        category: '64884f21fdc2d1a130c24ac0',
-        totalOffers: {
-          student: 4,
-          tutor: 12
-        }
+        category: { _id: '64884f21fdc2d1a130c24ac0', name: 'Music' },
+        subjects: [{ _id: '64885108fdc2d1a130c24af9', name: 'Guitar' }]
       },
       {
-        _id: '64885108fdc2d1a130c24af9',
-        name: 'Cybersecurity',
-        category: '64884f33fdc2d1a130c24ac2',
-        totalOffers: {
-          student: 3,
-          tutor: 20
-        }
+        _id: '648850c4fdc2d1342130c24d',
+        category: { _id: '64884f21fdc2d1a130c24ac0', name: 'Cooking' },
+        subjects: [{ _id: '64885108fdc2d1a130c24af9', name: 'Gastronomy' }]
       }
     ]
   },


### PR DESCRIPTION
https://github.com/ita-social-projects/SpaceToStudy-Client/assets/105641724/979a2a83-0afd-4afa-83e4-2c427bd3d78f

### [Backend PR](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/pull/785)
- Removed deactivation and prefessional level because they was redundant and didn't used expect for edit page
- Updated selection logic - so user can add only those categories which are not exist in his/her profile
- Deletion logic - calculated on the backend - it's not possible to delete category if offer or cooperation is 'active' - to delete category passed it's _id and empty name (not the best solution, was made to avoid creating new route only to handle mainSubject - small feature)
- Created #1915 issue to investigate stepper behavior, because this pr is too heavy already
- Updated tests (But need to be updated in `AddProfessionalCategoryModal.spec.jsx` )