### PR TITLE
Created useAccordion hook

### DIFF
--- a/src/components/accordion-with-image/AccordionWithImage.tsx
+++ b/src/components/accordion-with-image/AccordionWithImage.tsx
@@ -1,7 +1,8 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 
 import Accordions from '~/components/accordion/Accordions'
 import Box from '@mui/material/Box'
+import useAccordions from '~/hooks/use-accordions'
 
 import { styles } from '~/components/accordion-with-image/AccordionWithImage.styles'
 import { AccordionWithImageItem, TypographyVariantEnum } from '~/types'
@@ -11,16 +12,23 @@ interface AccordionWithImageProps {
 }
 
 const AccordionWithImage: FC<AccordionWithImageProps> = ({ items }) => {
-  const [activeItemId, setActiveItemId] = useState(0)
+  const [expandedItem, handleAccordionChange] = useAccordions({
+    toggle: false,
+    initialState: 0
+  })
 
   return (
     <Box className='section' data-testid='accordion' sx={styles.feature}>
-      <Box component='img' src={items[activeItemId].image} sx={styles.image} />
+      <Box
+        component='img'
+        src={items[expandedItem || 0].image}
+        sx={styles.image}
+      />
       <Accordions
-        activeIndex={activeItemId}
+        activeIndex={expandedItem}
         descriptionVariant={TypographyVariantEnum.Body2}
         items={items}
-        onChange={(id) => setActiveItemId(id)}
+        onChange={handleAccordionChange}
         titleVariant={TypographyVariantEnum.H6}
       />
     </Box>

--- a/src/components/multi-accordion-with-title/MultiAccordionWIthTitle.tsx
+++ b/src/components/multi-accordion-with-title/MultiAccordionWIthTitle.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useState } from 'react'
+import { FC, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Typography from '@mui/material/Typography'
@@ -11,6 +11,7 @@ import {
   TypographyVariantEnum
 } from '~/types'
 import Accordions from '~/components/accordion/Accordions'
+import useAccordions from '~/hooks/use-accordions'
 
 interface MultiAccordionWithTitleProps {
   items: AccordionItem[]
@@ -27,19 +28,9 @@ const MultiAccordionWithTitle: FC<MultiAccordionWithTitleProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  const [activeItems, setActiveItems] = useState<number[]>([])
-
-  const onChange = (activeItem: number) => {
-    setActiveItems((prevActiveItems) => {
-      if (prevActiveItems.includes(activeItem)) {
-        return prevActiveItems.filter(
-          (prevActiveItem) => prevActiveItem !== activeItem
-        )
-      } else {
-        return [...prevActiveItems, activeItem]
-      }
-    })
-  }
+  const [expandedItems, handleAccordionChange] = useAccordions({
+    multiple: true
+  })
 
   const accordionTitle = title && (
     <Typography sx={sx.title}>{t(title)}</Typography>
@@ -47,13 +38,13 @@ const MultiAccordionWithTitle: FC<MultiAccordionWithTitleProps> = ({
 
   const accordionList = (
     <Accordions
-      activeIndex={activeItems}
+      activeIndex={expandedItems}
       descriptionVariant={TypographyVariantEnum.Body2}
       elevation={0}
       icon={icon}
       items={items}
       multiple
-      onChange={onChange}
+      onChange={handleAccordionChange}
       sx={{
         withIcon: sx.withIcon,
         noIcon: sx.noIcon

--- a/src/containers/edit-profile/professional-info-tab/about-tutor-accordion/AboutTutorAccordion.tsx
+++ b/src/containers/edit-profile/professional-info-tab/about-tutor-accordion/AboutTutorAccordion.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 
 import { useTranslation } from 'react-i18next'
 
@@ -11,6 +11,7 @@ import {
 
 import ExpandMore from '@mui/icons-material/ExpandMore'
 
+import useAccordions from '~/hooks/use-accordions'
 import Accordions from '~/components/accordion/Accordions'
 import AppTextArea from '~/components/app-text-area/AppTextArea'
 
@@ -29,7 +30,10 @@ const AboutTutorAccordion: FC<AboutTutorAccordionProps> = ({
   handleInputChange
 }) => {
   const { t } = useTranslation()
-  const [activeItemId, setActiveItemId] = useState(0)
+  const [expandedItem, handleAccordionChange] = useAccordions({
+    initialState: 0,
+    toggle: false
+  })
 
   const accordionItems: AccordionItem[] = [
     {
@@ -93,11 +97,11 @@ const AboutTutorAccordion: FC<AboutTutorAccordionProps> = ({
 
   return (
     <Accordions
-      activeIndex={activeItemId}
+      activeIndex={expandedItem}
       descriptionVariant={TypographyVariantEnum.Body2}
       icon={<ExpandMore />}
       items={accordionItems}
-      onChange={(index) => setActiveItemId(index)}
+      onChange={handleAccordionChange}
       sx={styles.accordion}
       titleVariant={TypographyVariantEnum.Body2}
     />

--- a/src/containers/student-home-page/faq/Faq.tsx
+++ b/src/containers/student-home-page/faq/Faq.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -6,6 +5,7 @@ import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
 
 import { accordionItems } from '~/containers/student-home-page/faq/accordionItems'
 import Accordions from '~/components/accordion/Accordions'
+import useAccordions from '~/hooks/use-accordions'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import { studentRoutes } from '~/router/constants/studentRoutes'
 import { TypographyVariantEnum } from '~/types'
@@ -14,10 +14,8 @@ import { styles } from '~/containers/student-home-page/faq/Faq.styles'
 
 const Faq = () => {
   const { t } = useTranslation()
-  const [activeItemId, setActiveItemId] = useState<number | null>(null)
 
-  const changeAccordion = (id: number) =>
-    activeItemId === id ? setActiveItemId(null) : setActiveItemId(id)
+  const [expandedItem, handleAccordionChange] = useAccordions()
 
   return (
     <Box
@@ -32,11 +30,11 @@ const Faq = () => {
       />
 
       <Accordions
-        activeIndex={activeItemId}
+        activeIndex={expandedItem}
         descriptionVariant={TypographyVariantEnum.Body2}
         icon={<ExpandMoreRoundedIcon />}
         items={accordionItems}
-        onChange={changeAccordion}
+        onChange={handleAccordionChange}
         square
         titleVariant={TypographyVariantEnum.H6}
       />

--- a/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
+++ b/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -7,6 +7,7 @@ import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import Accordions from '~/components/accordion/Accordions'
+import useAccordions from '~/hooks/use-accordions'
 import { ProfessionalBlock, TypographyVariantEnum } from '~/types'
 
 import { styles } from '~/containers/user-profile/about-tutor-block/AboutTutorBlock.styles'
@@ -18,11 +19,8 @@ interface AboutTutorBlockProps {
 const AboutTutorBlock: FC<AboutTutorBlockProps> = ({ data }) => {
   const { t } = useTranslation()
   const { isMobile } = useBreakpoints()
-  const [activeIndex, setActiveIndex] = useState<number | null>(null)
 
-  const handleAccordionChange = (index: number) => {
-    setActiveIndex(activeIndex !== index ? index : null)
-  }
+  const [expandedItem, handleAccordionChange] = useAccordions()
 
   const professionalBlockKeys = Object.keys(data) as Array<
     keyof ProfessionalBlock
@@ -49,7 +47,7 @@ const AboutTutorBlock: FC<AboutTutorBlockProps> = ({ data }) => {
       </Typography>
       <Box sx={styles.wrapper}>
         <Accordions
-          activeIndex={activeIndex}
+          activeIndex={expandedItem}
           descriptionVariant={TypographyVariantEnum.Body1}
           icon={<ExpandMoreRoundedIcon />}
           items={accordionItems}

--- a/src/hooks/use-accordions.tsx
+++ b/src/hooks/use-accordions.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+
+type AccordionState = number[] | null | number
+
+type RetunedValue<T extends boolean> = T extends true ? number[] : null | number
+
+interface Options<T extends boolean = false> {
+  multiple?: T
+  toggle?: boolean
+  initialState?: AccordionState
+}
+
+const defaultOptions = {
+  toggle: true,
+  initialState: null
+}
+
+function useAccordions<T extends boolean = false>({
+  multiple,
+  initialState = null,
+  toggle = true
+}: Options<T> = defaultOptions) {
+  const [expanded, setExpanded] = useState<AccordionState>(initialState)
+
+  const handleChange = (value: number) => {
+    setExpanded((prev) => {
+      if (multiple && Array.isArray(prev)) {
+        const isItemAlreadyActive = prev.includes(value)
+        return isItemAlreadyActive
+          ? prev.filter((index) => index !== value)
+          : [...prev, value]
+      } else {
+        const shouldToggleCurrentlyActive = prev === value && toggle
+        return shouldToggleCurrentlyActive ? null : value
+      }
+    })
+  }
+
+  return [expanded as RetunedValue<T>, handleChange] as const
+}
+
+export default useAccordions

--- a/src/pages/lesson-details/LessonDetails.tsx
+++ b/src/pages/lesson-details/LessonDetails.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { AxiosResponse } from 'axios'
@@ -14,6 +14,7 @@ import useAxios from '~/hooks/use-axios'
 import { ResourceService } from '~/services/resource-service'
 import { defaultResponse } from '~/pages/lesson-details/LessonDetails.constants'
 import Accordions from '~/components/accordion/Accordions'
+import useAccordion from '~/hooks/use-accordions'
 import IconExtensionWithTitle from '~/components/icon-extension-with-title/IconExtensionWithTitle'
 import AppButton from '~/components/app-button/AppButton'
 
@@ -25,24 +26,15 @@ import { createUrlPath } from '~/utils/helper-functions'
 import { useAppSelector } from '~/hooks/use-redux'
 
 const LessonDetails = () => {
-  const [activeItems, setActiveItems] = useState<number[]>([0])
-
   const { lessonId } = useParams()
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { userId } = useAppSelector((state) => state.appMain)
 
-  const onChange = (activeItem: number) => {
-    setActiveItems((prevActiveItems) => {
-      if (prevActiveItems.includes(activeItem)) {
-        return prevActiveItems.filter(
-          (prevActiveItem) => prevActiveItem !== activeItem
-        )
-      } else {
-        return [...prevActiveItems, activeItem]
-      }
-    })
-  }
+  const [expandedItems, handleAccordionChange] = useAccordion({
+    initialState: 0,
+    multiple: true
+  })
 
   const responseError = useCallback(
     () => navigate(errorRoutes.notFound.path),
@@ -110,12 +102,12 @@ const LessonDetails = () => {
           title={response.title}
         />
         <Accordions
-          activeIndex={activeItems}
+          activeIndex={expandedItems}
           descriptionVariant={TypographyVariantEnum.Body2}
           icon={<ExpandMoreIcon />}
           items={items}
           multiple
-          onChange={onChange}
+          onChange={handleAccordionChange}
           sx={styles.accordion}
           titleVariant={TypographyVariantEnum.Subtitle2}
         />

--- a/tests/unit/hooks/use-accordions.spec.js
+++ b/tests/unit/hooks/use-accordions.spec.js
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react'
+import useAccordions from '~/hooks/use-accordions'
+
+describe('UseAccordions tests', () => {
+  it('Should have initial state', () => {
+    const { result } = renderHook(() => useAccordions({ initialState: 1 }))
+
+    const accordionState = result.current[0]
+    expect(accordionState).toBe(1)
+  })
+
+  it('Should expand accordion while closing previous expanded', () => {
+    const { result } = renderHook(() => useAccordions({ initialState: 1 }))
+
+    act(() => {
+      const expandAccordion = result.current[1]
+      expandAccordion(5)
+    })
+
+    const accordionState = result.current[0]
+    expect(accordionState).toBe(5)
+  })
+
+  it('Should toggle specified accordion', () => {
+    const { result } = renderHook(() => useAccordions({ initialState: 2 }))
+
+    act(() => {
+      const expandAccordion = result.current[1]
+      expandAccordion(2)
+    })
+
+    const accordionState = result.current[0]
+    expect(accordionState).toBe(null)
+  })
+
+  it('Should not toggle specified accordion', () => {
+    const { result } = renderHook(() =>
+      useAccordions({ initialState: 2, toggle: false })
+    )
+
+    act(() => {
+      const expandAccordion = result.current[1]
+      expandAccordion(2)
+    })
+
+    const accordionState = result.current[0]
+    expect(accordionState).toBe(2)
+  })
+
+  it('Should expand one more accordion', () => {
+    const { result } = renderHook(() =>
+      useAccordions({ initialState: [5, 8], multiple: true })
+    )
+
+    act(() => {
+      const expandAccordion = result.current[1]
+      expandAccordion(9)
+    })
+
+    const accordionState = result.current[0]
+    expect(accordionState).toEqual([5, 8, 9])
+  })
+
+  it('Should hide specified accordion', () => {
+    const { result } = renderHook(() =>
+      useAccordions({ initialState: [5, 8], multiple: true })
+    )
+
+    act(() => {
+      const expandAccordion = result.current[1]
+      expandAccordion(5)
+    })
+
+    const accordionState = result.current[0]
+    expect(accordionState).toEqual([8])
+  })
+})


### PR DESCRIPTION
- I added `useAccordion` hook and tests for it.
-  There is such property as multiple. We need it because some of our <Accordions /> can have few expanded items at the time and other can have only one expanded item at a time. There is also toggle option, which is used to control whether accordion item needs to be toggled (if the same item is clicked, should it close or still be expanded). I added it because again, different components in our project handled this logic differently.
- You may also notice that I used function overloading. Firstly I thought to use generics or conditional types, but it only made code look complicated and required few `as` keywords. Because of types, I also used Array.isArray() which can be confusing.