### PR TITLE
Fix styles for edit profile tab according to the mockup

### DIFF
--- a/src/components/page-wrapper/PageWrapper.tsx
+++ b/src/components/page-wrapper/PageWrapper.tsx
@@ -18,7 +18,7 @@ const PageWrapper = (
 
   return (
     <Container
-      maxWidth='xl'
+      maxWidth='lg'
       ref={ref}
       sx={spliceSx(styles.container, sx)}
       {...rest}

--- a/src/containers/user-profile/profile-info/ProfileInfo.styles.js
+++ b/src/containers/user-profile/profile-info/ProfileInfo.styles.js
@@ -19,7 +19,7 @@ export const styles = {
     borderRadius: '15px'
   },
   infoWrapper: {
-    maxWidth: { sm: '345px', lg: '834px' },
+    maxWidth: { sm: '345px', lg: '552px' },
     width: '100%'
   },
   iconBtn: {


### PR DESCRIPTION
Fixed page wrapper according to figma design. Also fixed a bug with profile info that occurred after changing the wrapper

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/118522791/8d741215-3641-4d47-90bf-aa28b5492c7d)
