### PR TITLE
Changed the message about successful creation of a quiz question to a clearer one

### DIFF
--- a/src/containers/my-quizzes/create-or-edit-quiz-question/CreateOrEditQuizQuestion.tsx
+++ b/src/containers/my-quizzes/create-or-edit-quiz-question/CreateOrEditQuizQuestion.tsx
@@ -72,7 +72,7 @@ const CreateOrEditQuizQuestion: FC<CreateOrEditQuizQuestionProps> = ({
     dispatch(
       openAlert({
         severity: snackbarVariants.success,
-        message: 'categoriesPage.newSubject.successMessage'
+        message: 'myResourcesPage.questions.successAddedQuestion'
       })
     )
     onCancel()


### PR DESCRIPTION
#1957 
I changed the text in the notification that was displayed, after successfully adding a new question to the quiz. 
Now the notification text is **"Question was successfully added"** and it is more understandable.

The result is provided in the video:

https://github.com/ita-social-projects/SpaceToStudy-Client/assets/108517274/b5fc145c-38c6-4f01-beb0-bb50e07f25c1

