### PR TITLE
Fixed cooperation buttons divider

### DIFF
--- a/src/components/tab-navigation/TabNavigation.tsx
+++ b/src/components/tab-navigation/TabNavigation.tsx
@@ -48,7 +48,7 @@ const TabNavigation = <T extends string, U extends Record<T, BaseTabsData>>({
     )
   })
 
-  return <Box sx={spliceSx(sx?.root, styles.tabs)}>{tabs}</Box>
+  return <Box sx={spliceSx(styles.tabs, sx?.root)}>{tabs}</Box>
 }
 
 export default TabNavigation

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.styles.ts
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.styles.ts
@@ -23,7 +23,10 @@ export const styles = {
   },
   tabsWrapper: {
     display: 'flex',
-    justifyContent: 'space-between'
+    justifyContent: 'space-between',
+    borderBottom: '1px solid',
+    borderColor: 'primary.100',
+    mb: '24px'
   },
   pageContent: {
     flex: 1
@@ -47,6 +50,8 @@ export const styles = {
   },
   tabs: {
     root: {
+      borderBottom: '0px',
+      mb: '0px',
       '& > button': {
         minWidth: '100px'
       },


### PR DESCRIPTION
- [x] fixed cooperation buttons divider styles

In the process, I spotted that in the TabNavigation component, it was not possible to update default styles on line 51, so I fixed that and ensured that it wouldn't cause any problems on other pages where we use the TabNavigation component

[screen-capture (4).webm](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/32570823/df536514-e0c7-4fba-ba0b-8c7bdce97ed2)


