### PR TITLE
Fixed overlapping "TurnedInNotIcon" and first & last name

### DIFF
--- a/src/components/user-profile-info/UserProfileInfo.tsx
+++ b/src/components/user-profile-info/UserProfileInfo.tsx
@@ -55,7 +55,13 @@ const UserProfileInfo: FC<UserProfileInfoProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  const name = `${firstName} ${lastName}`
+  const name = (
+    <>
+      {firstName}
+      <br />
+      {lastName}
+    </>
+  )
 
   const userURL = createUrlPath(authRoutes.userProfile.path, _id, {
     role

--- a/src/components/user-profile-info/UserProfileInfo.tsx
+++ b/src/components/user-profile-info/UserProfileInfo.tsx
@@ -55,13 +55,7 @@ const UserProfileInfo: FC<UserProfileInfoProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  const name = (
-    <>
-      {firstName}
-      <br />
-      {lastName}
-    </>
-  )
+  const name = `${firstName} ${lastName}`
 
   const userURL = createUrlPath(authRoutes.userProfile.path, _id, {
     role

--- a/src/containers/find-offer/offer-card-square/OfferCardSquare.styles.ts
+++ b/src/containers/find-offer/offer-card-square/OfferCardSquare.styles.ts
@@ -38,8 +38,8 @@ export const styles = {
   iconButton: {
     color: 'basic.black',
     position: 'absolute',
-    top: 0,
-    right: 0
+    top: '-20px',
+    right: '-20px'
   },
   priceContainer: {
     display: 'flex',


### PR DESCRIPTION
### Before: 
<img width="1465" alt="Screenshot 2024-06-17 at 18 14 05" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/d5534e0b-ce10-4a04-9979-4d7370dca324">

### After:
<img width="1469" alt="Screenshot 2024-06-17 at 21 53 25" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/a3e1add7-c6ee-493c-bcb8-46a66168a0d2">

- [x]  the "TurnedInNotIcon" should not overlap with the first and last names and have some space between them.