### PR TITLE
Fixed translation of proficiency / preparation levels #1964

### DIFF
--- a/src/components/checkbox-list/CheckboxList.tsx
+++ b/src/components/checkbox-list/CheckboxList.tsx
@@ -15,7 +15,7 @@ interface CheckboxListProps<T> extends Pick<TypographyProps, 'variant'> {
   error?: string
   fillRange?: boolean
   singleSelect?: boolean
-  labels?: Map<T, string>
+  labels?: ReadonlyMap<T, string>
   onChange: (checkbox: T[]) => void
 }
 
@@ -56,7 +56,7 @@ const CheckboxList = <T extends string>({
       key={checkbox}
       label={
         <Typography variant={variant}>
-          {labels?.has(checkbox) ? labels.get(checkbox)! : t(checkbox)}
+          {labels?.has(checkbox) ? t(labels.get(checkbox)!) : t(checkbox)}
         </Typography>
       }
       onChange={() => handleCheckbox(checkbox)}

--- a/src/components/checkbox-list/CheckboxList.tsx
+++ b/src/components/checkbox-list/CheckboxList.tsx
@@ -15,6 +15,7 @@ interface CheckboxListProps<T> extends Pick<TypographyProps, 'variant'> {
   error?: string
   fillRange?: boolean
   singleSelect?: boolean
+  labels?: Map<T, string>
   onChange: (checkbox: T[]) => void
 }
 
@@ -26,6 +27,7 @@ const CheckboxList = <T extends string>({
   fillRange,
   singleSelect = false,
   variant,
+  labels,
   onChange
 }: CheckboxListProps<T>) => {
   const { t } = useTranslation()
@@ -52,7 +54,11 @@ const CheckboxList = <T extends string>({
         />
       }
       key={checkbox}
-      label={<Typography variant={variant}>{t(checkbox)}</Typography>}
+      label={
+        <Typography variant={variant}>
+          {labels?.has(checkbox) ? labels.get(checkbox)! : t(checkbox)}
+        </Typography>
+      }
       onChange={() => handleCheckbox(checkbox)}
     />
   ))

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -1,0 +1,12 @@
+import { ProficiencyLevelEnum } from '~/types'
+
+export const proficiencyLevelLabels: Readonly<
+  Record<ProficiencyLevelEnum, string>
+> = {
+  [ProficiencyLevelEnum.Beginner]: 'common.levels.beginner',
+  [ProficiencyLevelEnum.Intermediate]: 'common.levels.intermediate',
+  [ProficiencyLevelEnum.Advanced]: 'common.levels.advanced',
+  [ProficiencyLevelEnum.TestPreparation]: 'common.levels.testPreparation',
+  [ProficiencyLevelEnum.Professional]: 'common.levels.professional',
+  [ProficiencyLevelEnum.Specialized]: 'common.levels.specialized'
+}

--- a/src/constants/labels.ts
+++ b/src/constants/labels.ts
@@ -1,12 +1,11 @@
 import { ProficiencyLevelEnum } from '~/types'
 
-export const proficiencyLevelLabels: Readonly<
-  Record<ProficiencyLevelEnum, string>
-> = {
-  [ProficiencyLevelEnum.Beginner]: 'common.levels.beginner',
-  [ProficiencyLevelEnum.Intermediate]: 'common.levels.intermediate',
-  [ProficiencyLevelEnum.Advanced]: 'common.levels.advanced',
-  [ProficiencyLevelEnum.TestPreparation]: 'common.levels.testPreparation',
-  [ProficiencyLevelEnum.Professional]: 'common.levels.professional',
-  [ProficiencyLevelEnum.Specialized]: 'common.levels.specialized'
-}
+export const proficiencyLevelLabels: ReadonlyMap<ProficiencyLevelEnum, string> =
+  new Map([
+    [ProficiencyLevelEnum.Beginner, 'common.levels.beginner'],
+    [ProficiencyLevelEnum.Intermediate, 'common.levels.intermediate'],
+    [ProficiencyLevelEnum.Advanced, 'common.levels.advanced'],
+    [ProficiencyLevelEnum.TestPreparation, 'common.levels.testPreparation'],
+    [ProficiencyLevelEnum.Professional, 'common.levels.professional'],
+    [ProficiencyLevelEnum.Specialized, 'common.levels.specialized']
+  ])

--- a/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
+++ b/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Typography from '@mui/material/Typography'
@@ -48,18 +48,6 @@ const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
   const handleCheckboxesChange = (value: ProficiencyLevelEnum[]) => {
     handleNonInputValueChange('proficiencyLevel', value)
   }
-
-  const levelLabels = useMemo(
-    () =>
-      new Map(
-        Object.entries(proficiencyLevelLabels).map(([key, value]) => [
-          key,
-          t(value)
-        ])
-      ),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
 
   const subjectError = data.category && errors.subject
 
@@ -119,7 +107,7 @@ const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
             error={t(errors.proficiencyLevel)}
             {...checkboxListProps}
             items={levelOptions}
-            labels={levelLabels}
+            labels={proficiencyLevelLabels}
             onChange={handleCheckboxesChange}
             value={data.proficiencyLevel}
           />

--- a/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
+++ b/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Typography from '@mui/material/Typography'
@@ -45,7 +45,25 @@ const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
   const handleCheckboxesChange = (value: ProficiencyLevelEnum[]) => {
     handleNonInputValueChange('proficiencyLevel', value)
   }
-  const levelOptions = Object.values(ProficiencyLevelEnum)
+
+  const levelOptions = useMemo(() => Object.values(ProficiencyLevelEnum), [])
+  const levelLabels = useMemo(
+    () =>
+      new Map([
+        [ProficiencyLevelEnum.Beginner, t('common.levels.beginner')],
+        [ProficiencyLevelEnum.Intermediate, t('common.levels.intermediate')],
+        [ProficiencyLevelEnum.Advanced, t('common.levels.advanced')],
+        [
+          ProficiencyLevelEnum.TestPreparation,
+          t('common.levels.testPreparation')
+        ],
+        [ProficiencyLevelEnum.Professional, t('common.levels.professional')],
+        [ProficiencyLevelEnum.Specialized, t('common.levels.specialized')]
+      ]),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
   const subjectError = data.category && errors.subject
 
   const checkboxListProps =
@@ -104,6 +122,7 @@ const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
             error={t(errors.proficiencyLevel)}
             {...checkboxListProps}
             items={levelOptions}
+            labels={levelLabels}
             onChange={handleCheckboxesChange}
             value={data.proficiencyLevel}
           />

--- a/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
+++ b/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
@@ -17,7 +17,10 @@ import {
   ProficiencyLevelEnum,
   UserRoleEnum
 } from '~/types'
+import { proficiencyLevelLabels } from '~/constants/labels'
 import { styles } from '~/containers/offer-page/OfferPage.styles'
+
+const levelOptions = Object.values(ProficiencyLevelEnum)
 
 const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
   data,
@@ -46,20 +49,14 @@ const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
     handleNonInputValueChange('proficiencyLevel', value)
   }
 
-  const levelOptions = useMemo(() => Object.values(ProficiencyLevelEnum), [])
   const levelLabels = useMemo(
     () =>
-      new Map([
-        [ProficiencyLevelEnum.Beginner, t('common.levels.beginner')],
-        [ProficiencyLevelEnum.Intermediate, t('common.levels.intermediate')],
-        [ProficiencyLevelEnum.Advanced, t('common.levels.advanced')],
-        [
-          ProficiencyLevelEnum.TestPreparation,
-          t('common.levels.testPreparation')
-        ],
-        [ProficiencyLevelEnum.Professional, t('common.levels.professional')],
-        [ProficiencyLevelEnum.Specialized, t('common.levels.specialized')]
-      ]),
+      new Map(
+        Object.entries(proficiencyLevelLabels).map(([key, value]) => [
+          key,
+          t(value)
+        ])
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )

--- a/tests/unit/components/checkbox-list/CheckboxList.spec.jsx
+++ b/tests/unit/components/checkbox-list/CheckboxList.spec.jsx
@@ -1,11 +1,16 @@
-import { render , fireEvent, screen } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import CheckboxList from '~/components/checkbox-list/CheckboxList'
 
 const mockedItemChanged = 'Beginner'
 
-const mockedItems =  ['Beginner', 'Intermediate', 'Advanced']
+const mockedItems = ['Beginner', 'Intermediate', 'Advanced']
 const mockedValue = ['Advanced']
+const mockedLabels = new Map([
+  ['Beginner', 'Початковий'],
+  ['Intermediate', 'Середній'],
+  ['Advanced', 'Високий']
+])
 
 const mockedGetCheckbox = vi.fn()
 
@@ -15,24 +20,50 @@ describe('CheckboxList component', () => {
   it('should get checked state of checkbox on click', () => {
     render(
       <CheckboxList
-        items={ mockedItems } 
-        onChange={ mockedGetCheckbox }
+        items={mockedItems}
+        onChange={mockedGetCheckbox}
         title='Levels'
-        value={ mockedValue }
-      />)
-    
+        value={mockedValue}
+      />
+    )
+
     const checkbox = screen.getByLabelText('Beginner')
     expect(checkbox.checked).toBe(false)
-    
+
     fireEvent.click(checkbox)
 
-    expect(mockedGetCheckbox).toHaveBeenCalledWith([...mockedValue, mockedItemChanged ])
+    expect(mockedGetCheckbox).toHaveBeenCalledWith([
+      ...mockedValue,
+      mockedItemChanged
+    ])
   })
+
   it('should not render title element if no title in props was inserted', () => {
-    render(<CheckboxList items={ mockedItems } onChange={ mockedGetCheckbox } value={ mockedValue } />)
-    
+    render(
+      <CheckboxList
+        items={mockedItems}
+        onChange={mockedGetCheckbox}
+        value={mockedValue}
+      />
+    )
+
     const title = screen.queryByLabelText(titleId)
 
     expect(title).toBeNull()
+  })
+
+  it('should render checkbox labels correctly based on provided labels map and translation function', () => {
+    render(
+      <CheckboxList
+        items={mockedItems}
+        labels={mockedLabels}
+        onChange={mockedGetCheckbox}
+      />
+    )
+
+    mockedItems.forEach((item) => {
+      const label = mockedLabels.get(item) || item
+      expect(screen.getByText(label)).toBeInTheDocument()
+    })
   })
 })

--- a/tests/unit/containers/offer-page/specialization-block/SpecializationBlock.spec.jsx
+++ b/tests/unit/containers/offer-page/specialization-block/SpecializationBlock.spec.jsx
@@ -1,0 +1,276 @@
+import { vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '~tests/test-utils'
+
+import { useAppSelector } from '~/hooks/use-redux'
+import { ProficiencyLevelEnum, UserRoleEnum } from '~/types'
+
+import SpecializationBlock from '~/containers/offer-page/specialization-block/SpecializationBlock'
+
+const mockHandleBlur = vi.fn()
+const mockHandleNonInputValueChange = vi.fn()
+
+vi.mock('~/hooks/use-redux', () => ({
+  useAppSelector: vi.fn()
+}))
+
+vi.mock('~/services/category-service', () => ({
+  categoryService: {
+    getCategoriesNames: vi.fn()
+  }
+}))
+
+vi.mock('~/services/subject-service', () => ({
+  subjectService: {
+    getSubjectsNames: vi.fn()
+  }
+}))
+
+vi.mock('~/components/async-autocomlete/AsyncAutocomplete', () => ({
+  __esModule: true,
+  default: ({ onChange, ...props }) => (
+    <input
+      aria-describedby={
+        props.textFieldProps?.error ? 'error-text' : 'helper-text'
+      }
+      aria-invalid={props.textFieldProps?.error ? 'true' : 'false'}
+      aria-label={props.textFieldProps?.label}
+      onChange={(e) => {
+        onChange(e, JSON.parse(e.target.value))
+      }}
+      required={props.textFieldProps?.required}
+    />
+  )
+}))
+
+vi.mock('~/components/checkbox-list/CheckboxList', () => ({
+  __esModule: true,
+  default: ({ onChange, value, items }) => (
+    <div>
+      {items.map((item) => (
+        <label key={item}>
+          <input
+            aria-label={`${item}`}
+            checked={value.includes(item)}
+            onChange={() => onChange(item)}
+            type='checkbox'
+          />
+          {item}
+        </label>
+      ))}
+    </div>
+  )
+}))
+
+describe('Test SpecializationBlock container - [ user role: tutor & with errors in fields ]', () => {
+  const mockData = {
+    category: 'data category',
+    subject: '',
+    proficiencyLevel: []
+  }
+
+  const mockErrors = {
+    category: 'some error message',
+    subject: 'some error message',
+    proficiencyLevel: ''
+  }
+
+  beforeEach(() => {
+    useAppSelector.mockReturnValue({ userRole: UserRoleEnum.Tutor })
+
+    renderWithProviders(
+      <SpecializationBlock
+        data={mockData}
+        errors={mockErrors}
+        handleBlur={mockHandleBlur}
+        handleNonInputValueChange={mockHandleNonInputValueChange}
+      />
+    )
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should correctly render offer page labels based on tutor user role', () => {
+    expect(
+      screen.getByText(/offerPage.title.firstStep.tutor/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/offerPage.description.category.tutor/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/offerPage.description.level.tutor/i)
+    ).toBeInTheDocument()
+  })
+
+  it('should handle category change correctly', () => {
+    const selectedCategory = { _id: 'mockedId', name: 'Selected Category' }
+    const categoryAsyncAutocomplete = screen.getByLabelText(
+      /offerPage.labels.category/i
+    )
+    expect(categoryAsyncAutocomplete).toBeInTheDocument()
+    fireEvent.change(categoryAsyncAutocomplete, {
+      target: { value: JSON.stringify(selectedCategory) }
+    })
+    fireEvent.blur(categoryAsyncAutocomplete)
+
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledWith(
+      'category',
+      selectedCategory._id
+    )
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledWith('subject', '')
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle category change with null id correctly', () => {
+    const selectedCategory = { _id: null, name: 'Selected Category without ID' }
+    const categoryAsyncAutocomplete = screen.getByLabelText(
+      /offerPage.labels.category/i
+    )
+    expect(categoryAsyncAutocomplete).toBeInTheDocument()
+    fireEvent.change(categoryAsyncAutocomplete, {
+      target: { value: JSON.stringify(selectedCategory) }
+    })
+    fireEvent.blur(categoryAsyncAutocomplete)
+
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledWith('category', '')
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledWith('subject', '')
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledTimes(2)
+  })
+
+  it('should handle subject change correctly', async () => {
+    const selectedSubject = { _id: 'mockedID', name: 'Selected Subject' }
+    const subjectAsyncAutocomplete = screen.getByLabelText(
+      /offerPage.labels.subject/i
+    )
+    expect(subjectAsyncAutocomplete).toBeInTheDocument()
+    fireEvent.change(subjectAsyncAutocomplete, {
+      target: { value: JSON.stringify(selectedSubject) }
+    })
+    fireEvent.blur(subjectAsyncAutocomplete)
+
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledWith(
+      'subject',
+      selectedSubject._id
+    )
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle proficiency level change correctly', () => {
+    const beginnerCheckbox = screen.getByLabelText('Beginner')
+    const advancedCheckbox = screen.getByLabelText('Advanced')
+    waitFor(() => {
+      fireEvent.click(beginnerCheckbox)
+      fireEvent.click(advancedCheckbox)
+      fireEvent.change(beginnerCheckbox, { target: { checked: true } })
+      fireEvent.change(advancedCheckbox, { target: { checked: true } })
+    })
+
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledWith(
+      'proficiencyLevel',
+      ProficiencyLevelEnum.Beginner
+    )
+    expect(mockHandleNonInputValueChange).toHaveBeenCalledWith(
+      'proficiencyLevel',
+      ProficiencyLevelEnum.Advanced
+    )
+    expect(beginnerCheckbox.checked).toBe(true)
+    expect(advancedCheckbox.checked).toBe(true)
+  })
+
+  it('should check textFieldProps for category AsyncAutocomplete', () => {
+    const categoryAsyncAutocomplete = screen.getByLabelText(
+      /offerPage.labels.category/i
+    )
+    expect(categoryAsyncAutocomplete).toBeInTheDocument()
+    expect(categoryAsyncAutocomplete).toHaveAttribute('required')
+    expect(categoryAsyncAutocomplete).toHaveAttribute('aria-invalid', 'true')
+    expect(categoryAsyncAutocomplete).toHaveAttribute(
+      'aria-describedby',
+      'error-text'
+    )
+  })
+
+  it('should check textFieldProps for subject AsyncAutocomplete', () => {
+    const subjectAsyncAutocomplete = screen.getByLabelText(
+      /offerPage.labels.subject/i
+    )
+    expect(subjectAsyncAutocomplete).toBeInTheDocument()
+    expect(subjectAsyncAutocomplete).toHaveAttribute('required')
+    expect(subjectAsyncAutocomplete).toHaveAttribute('aria-invalid', 'true')
+    expect(subjectAsyncAutocomplete).toHaveAttribute(
+      'aria-describedby',
+      'error-text'
+    )
+  })
+})
+
+describe('Test SpecializationBlock container - [ user role: student & without errors in fields ]', () => {
+  const mockData = {
+    category: 'data category',
+    subject: '',
+    proficiencyLevel: []
+  }
+
+  const mockErrors = {
+    category: '',
+    subject: '',
+    proficiencyLevel: ''
+  }
+
+  beforeEach(() => {
+    useAppSelector.mockReturnValue({ userRole: UserRoleEnum.Student })
+
+    renderWithProviders(
+      <SpecializationBlock
+        data={mockData}
+        errors={mockErrors}
+        handleBlur={mockHandleBlur}
+        handleNonInputValueChange={mockHandleNonInputValueChange}
+      />
+    )
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should correctly render offer page labels based on student user role', () => {
+    expect(
+      screen.getByText(/offerPage.title.firstStep.student/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/offerPage.description.category.student/i)
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/offerPage.description.level.student/i)
+    ).toBeInTheDocument()
+  })
+
+  it('should check textFieldProps for category AsyncAutocomplete', () => {
+    const categoryAsyncAutocomplete = screen.getByLabelText(
+      /offerPage.labels.category/i
+    )
+    expect(categoryAsyncAutocomplete).toBeInTheDocument()
+    expect(categoryAsyncAutocomplete).toHaveAttribute('required')
+    expect(categoryAsyncAutocomplete).toHaveAttribute('aria-invalid', 'false')
+    expect(categoryAsyncAutocomplete).toHaveAttribute(
+      'aria-describedby',
+      'helper-text'
+    )
+  })
+
+  it('should check textFieldProps for subject AsyncAutocomplete', () => {
+    const subjectAsyncAutocomplete = screen.getByLabelText(
+      /offerPage.labels.subject/i
+    )
+    expect(subjectAsyncAutocomplete).toBeInTheDocument()
+    expect(subjectAsyncAutocomplete).toHaveAttribute('required')
+    expect(subjectAsyncAutocomplete).toHaveAttribute('aria-invalid', 'false')
+    expect(subjectAsyncAutocomplete).toHaveAttribute(
+      'aria-describedby',
+      'helper-text'
+    )
+  })
+})


### PR DESCRIPTION
## Fixed translation of proficiency levels [ Close #1964 ]
Fixed issue with translation of `proficiency` / `preparation` levels into `Ukrainian` language.
For this, the `CheckboxList` component was extended with the ability to display custom labels passed from the outside.

| Before changing | After changing |
|-----------------|----------------|
| ![Before](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/27d8035e-827c-40bd-9796-f43fa5cc2204) | ![After](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/25a4b77d-47ab-4dcc-b256-52723d3be6c5) |

### Additionally, test coverage was enhanced: 
#### Improved coverage for `CheckboxList` [component](https://github.com/ita-social-projects/SpaceToStudy-Client/blob/develop/src/components/checkbox-list/CheckboxList.tsx)
_Current Test Coverage:_
<img width="1239" alt="Screenshot 2024-06-19 at 16 25 54" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/dad2aecd-19fe-4554-ae04-92c0760e9e59">

#### Added Unit Testing for `SpecializationBlock` [container](https://github.com/ita-social-projects/SpaceToStudy-Client/blob/develop/src/containers/offer-page/specialization-block/SpecializationBlock.tsx)
The following scenarios are covered in this implementation:
 - [x] **Rendering Offer Page Labels for Student:** Confirms that the correct labels are rendered for the student user role.
 - [x] **Rendering Offer Page Labels for Tutor:** Confirms that the correct labels are rendered for the tutor user role.
 - [x] **Handling Category Change:** Validates the handling of category change events.
 - [x] **Handling Category Change with `null` ID:** Ensures correct behavior when a category with null ID is selected.
 - [x] **Handling Subject Change:** Validates the handling of subject change events.
 - [x] **Handling Proficiency Level Change:** Ensures correct handling of proficiency level changes.
 - [x] **Checking `textFieldProps` for Category AsyncAutocomplete:** Validates the props of the category AsyncAutocomplete component.
 - [x] **Checking `textFieldProps` for Subject AsyncAutocomplete:** Validates the props of the subject AsyncAutocomplete component.
 
<img width="903" alt="Screenshot 2024-06-20 at 00 32 47" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/000f9fd7-3f9f-484f-9da4-92e34148debf">

