### PR TITLE
Fixed translation for count of reviews into Ukrainian for the offer list #1976

### DIFF
--- a/src/constants/translations/ua/user-profile-page.json
+++ b/src/constants/translations/ua/user-profile-page.json
@@ -35,6 +35,7 @@
     "starsCount_one": "{{count}} зірка",
     "starsCount_few": "{{count}} зірки",
     "starsCount_many": "{{count}} зірок",
+    "reviewsCount_zero": "{{count}} відгуків",
     "reviewsCount_one": "{{count}} відгук",
     "reviewsCount_few": "{{count}} відгуки",
     "reviewsCount_many": "{{count}} відгуків"


### PR DESCRIPTION
#### Fixed the issue of translating the count of reviews into `Ukrainian` for the offer list page [ Close #1976 ]

| Before changing | After changing |
|-----------------|----------------|
| ![Before](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/9cc918b9-57bf-44e4-aa9f-a415e18660d1) | ![After](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/43868e20-d519-4599-a06e-e5a6d20406ea) |
