### PR TITLE
Fix CardList grid to match figma design

### DIFF
--- a/src/components/cards-list/CardsList.styles.ts
+++ b/src/components/cards-list/CardsList.styles.ts
@@ -5,8 +5,7 @@ export const styles = {
     gridTemplateColumns: {
       xs: 'repeat(1, minmax(264px, 1fr))',
       sm: 'repeat(2, minmax(264px, 1fr))',
-      md: 'repeat(3, minmax(264px, 1fr))',
-      lg: 'repeat(4, minmax(264px, 1fr))'
+      md: 'repeat(3, minmax(264px, 1fr))'
     },
     gridAutoRows: '112px',
     gridGap: '24px'


### PR DESCRIPTION

- [x] Fix the CardList grid to match figma design

![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/32570823/3245ec5a-def7-44f0-a36d-475d2c791b5e)
