### PR TITLE
Added space between TitleBlock and a logo

### DIFF
--- a/src/components/find-block/find-block.styles.js
+++ b/src/components/find-block/find-block.styles.js
@@ -3,7 +3,7 @@ export const styles = {
     mt: { xs: '64px', md: '84px' },
 
     img: {
-      xs: { display: 'none', width: '168px', height: '168px' },
+      xs: { display: 'none', width: '246px', height: '246px' },
       md: { display: 'block' }
     }
   },

--- a/src/components/find-block/find-block.styles.js
+++ b/src/components/find-block/find-block.styles.js
@@ -3,7 +3,7 @@ export const styles = {
     mt: { xs: '64px', md: '84px' },
 
     img: {
-      xs: { display: 'none', width: '246px', height: '246px' },
+      xs: { display: 'none', width: '186px', height: '186px' },
       md: { display: 'block' }
     }
   },

--- a/src/components/title-block/TitleBlock.styles.ts
+++ b/src/components/title-block/TitleBlock.styles.ts
@@ -2,8 +2,10 @@ import { TypographyVariantEnum } from '~/types'
 
 export const styles = {
   container: {
+    display: 'flex',
     justifyContent: 'space-between',
     backgroundColor: 'companyBlue',
+    alignItems: 'center',
     borderRadius: 2,
     px: { md: 7, xs: 3 },
     py: { sm: 9, xs: 4 },

--- a/src/components/title-block/TitleBlock.tsx
+++ b/src/components/title-block/TitleBlock.tsx
@@ -27,7 +27,7 @@ const TitleBlock: FC<TitleBlockProps> = ({
   const { userRole } = useAppSelector((state) => state.appMain)
 
   return (
-    <Box className='section' sx={{ ...styles.container, ...style }}>
+    <Box sx={{ ...styles.container, ...style }}>
       <Box sx={styles.info}>
         <TitleWithDescription
           description={t(`${translationKey}.description`)}


### PR DESCRIPTION
- [x]  added a space-between between the Title text block and an icon, so it matches a [Figma](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=3-21654&t=mET3xqcPBxxqVokB-0) design. 

### Before: 
<img width="1094" alt="Screenshot 2024-06-20 at 15 57 55" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/e0778e99-d7ec-4ad8-9121-16fbb278b1e0">


### With applied changes: 
<img width="1214" alt="Screenshot 2024-06-20 at 22 44 43" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/a0ab16c7-8d74-489e-90fa-f61a04bbb253">

