### PR TITLE
Fixed styles for AppToolbar and CourseToolbar

### DIFF
--- a/src/components/app-toolbar/AppToolbar.styles.ts
+++ b/src/components/app-toolbar/AppToolbar.styles.ts
@@ -7,6 +7,6 @@ export const styles = {
     alignItems: 'center',
     boxShadow: commonShadow,
     mb: { xs: '20px', sm: '50px' },
-    p: '25px 0px 0px'
+    p: { xs: '10px 24px', sm: '25px 45px' }
   }
 }

--- a/src/components/app-toolbar/AppToolbar.styles.ts
+++ b/src/components/app-toolbar/AppToolbar.styles.ts
@@ -7,6 +7,6 @@ export const styles = {
     alignItems: 'center',
     boxShadow: commonShadow,
     mb: { xs: '20px', sm: '50px' },
-    p: { xs: '10px 24px', sm: '25px 45px' }
+    p: '25px 0px 0px'
   }
 }

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
@@ -17,14 +17,15 @@ export const styles = {
   },
   autocomplete: {
     width: { md: '370px', xs: '100%' },
-    mr: '30px',
+    mr: '20px',
     '& .MuiOutlinedInput-root': {
       padding: '5px 9px'
     },
     label: {
       lineHeight: '20px'
     },
-    position: 'relative'
+    position: 'relative',
+    flex: 1
   },
   autocompleteDropdownDivider: {
     m: '8px 0 10px 0',
@@ -39,7 +40,13 @@ export const styles = {
     ...commonStyle
   },
   levelSelect: {
-    width: { md: '370px', xs: '100%' }
+    width: '100%',
+    '& .MuiOutlinedInput-root': {
+      padding: '5px 9px'
+    },
+    label: {
+      lineHeight: '20px'
+    }
   },
   otherToolbar: {
     borderRadius: '10px',
@@ -88,7 +95,7 @@ export const styles = {
     display: 'flex',
     flexDirection: { md: 'row', xs: 'column' },
     justifyContent: { md: 'space-between', xs: 'center' },
-    gap: { md: '30px', sm: '20px', xs: '15px' }
+    gap: { md: '0px', sm: '20px', xs: '15px' }
   },
   categories: {
     color: 'basic.bismark'
@@ -100,6 +107,7 @@ export const styles = {
     display: 'flex',
     borderBottom: '1px solid',
     borderColor: 'primary.100',
-    my: '32px'
+    mt: { sm: '32px', md: '10px' },
+    mb: '32px'
   }
 }

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.style.ts
@@ -55,6 +55,7 @@ export const styles = {
     justifyContent: 'space-between',
     backgroundColor: 'backgroundColor',
     boxShadow: 'none',
+    p: '25px 0px 0px',
     mb: 0
   },
   input: {

--- a/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
@@ -127,7 +127,7 @@ const CourseToolbar = ({
         label={t('breadCrumbs.level')}
         onBlur={handleBlur('proficiencyLevel')}
         onChange={onLevelChange}
-        sx={{ select: styles.levelSelect }}
+        sx={{ select: styles.levelSelect, formSx: { flex: 1 } }}
         value={proficiencyLevel}
       />
     </>

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -21,6 +21,7 @@ interface ProficiencyLevelSelectProps
   fillRange?: boolean
   sx?: {
     select: SxProps
+    formSx?: SxProps
   }
   onChange: (event: ProficiencyLevelEnum[]) => void
 }
@@ -75,7 +76,7 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
   }
 
   return (
-    <FormControl error={hasError}>
+    <FormControl error={hasError} sx={sx?.formSx}>
       <InputLabel
         id={`${id}-multiple-checkbox-label`}
         required


### PR DESCRIPTION
- [x]  Centered the AppToolBar component on the "My courses" page
- [x]  Edited margin for an even space between autocompletes and a divider

link to [Figma](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=3-35603&t=6t0nJk4Rt2Dy0Vt4-0).

### Before:
<img width="1468" alt="Screenshot 2024-06-21 at 14 17 46" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/cd178940-017e-450d-b034-d3ef17c68316">

### After: 
<img width="1464" alt="Screenshot 2024-06-21 at 20 57 35" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/1f5884f1-cb2f-45e6-bc78-6c4afa7bc499">
