### PR TITLE
Make CardWithLink component accept SVG icon and color

### DIFF
--- a/src/components/card-with-link/CardWithLink.styles.ts
+++ b/src/components/card-with-link/CardWithLink.styles.ts
@@ -1,11 +1,28 @@
+import { alpha } from '@mui/material/styles'
+
 export const styles = {
-  img: {
-    width: '100%',
-    alignSelf: 'center',
-    mr: '24px',
-    maxWidth: '62px',
-    maxHeight: '62px'
+  card: {
+    padding: { xs: '20px 30px', lg: '25px 32px' },
+    display: 'flex',
+    gap: '24px',
+    justifyContent: 'flex-start',
+    alignItems: 'center'
   },
+  iconContainer: (bgColor: string) => ({
+    flexShrink: 0,
+    width: '62px',
+    height: '62px',
+    borderRadius: '6px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: alpha(bgColor, 0.2)
+  }),
+  icon: (color: string) => ({
+    width: '32px',
+    height: '32px',
+    color: color
+  }),
   titleWithDescription: {
     wrapper: {
       minWidth: '110px',

--- a/src/components/card-with-link/CardWithLink.styles.ts
+++ b/src/components/card-with-link/CardWithLink.styles.ts
@@ -2,7 +2,7 @@ import { alpha } from '@mui/material/styles'
 
 export const styles = {
   card: {
-    padding: { xs: '20px 30px', lg: '25px 32px' },
+    p: { xs: '20px 30px', lg: '25px 32px' },
     display: 'flex',
     gap: '24px',
     justifyContent: 'flex-start',

--- a/src/components/card-with-link/CardWithLink.tsx
+++ b/src/components/card-with-link/CardWithLink.tsx
@@ -1,27 +1,39 @@
 import { FC } from 'react'
 import Box from '@mui/material/Box'
-
 import AppCard from '~/components/app-card/AppCard'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
+import { getCategoryIcon } from '~/services/category-icon-service'
+import palette from '~/styles/app-theme/app.pallete'
 
 import { styles } from '~/components/card-with-link/CardWithLink.styles'
 
 interface CardWithLinkProps {
-  img: string
+  icon: string
+  iconColor: string
   title: string
   description: string
   link: string
 }
 
+const hexColorPattern = /(^#[0-9A-F]{6}$)|(^#[0-9A-F]{3}$)/i
+
 const CardWithLink: FC<CardWithLinkProps> = ({
-  img,
+  icon,
+  iconColor,
   title,
   description,
   link
 }) => {
+  const Icon = getCategoryIcon(icon)
+  const color = hexColorPattern.test(iconColor)
+    ? iconColor
+    : palette.success[500]
+
   return (
-    <AppCard link={link}>
-      <Box alt='item image' component='img' src={img} sx={styles.img} />
+    <AppCard link={link} sx={styles.card}>
+      <Box sx={styles.iconContainer(color)}>
+        <Icon sx={styles.icon(color)} />
+      </Box>
       <TitleWithDescription
         description={description}
         style={styles.titleWithDescription}

--- a/src/components/card-with-link/CardWithLink.tsx
+++ b/src/components/card-with-link/CardWithLink.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
 import Box from '@mui/material/Box'
+
 import AppCard from '~/components/app-card/AppCard'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import { getCategoryIcon } from '~/services/category-icon-service'
-import palette from '~/styles/app-theme/app.pallete'
 
+import palette from '~/styles/app-theme/app.pallete'
 import { styles } from '~/components/card-with-link/CardWithLink.styles'
 
 interface CardWithLinkProps {

--- a/src/components/popular-categories/PopularCategories.tsx
+++ b/src/components/popular-categories/PopularCategories.tsx
@@ -12,7 +12,6 @@ import Loader from '~/components/loader/Loader'
 import CardWithLink from '~/components/card-with-link/CardWithLink'
 import { authRoutes } from '~/router/constants/authRoutes'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
-import serviceIcon from '~/assets/img/student-home-page/service_icon.png'
 import CardsList from '~/components/cards-list/CardsList'
 import { CategoryInterface, ItemsWithCount } from '~/types'
 import useBreakpoints from '~/hooks/use-breakpoints'
@@ -62,7 +61,8 @@ const PopularCategories: FC<PopularCategoriesProps> = ({
           description={`${item.totalOffers[oppositeRole]} ${t(
             'common.offers'
           )}`}
-          img={serviceIcon}
+          icon={item.appearance.icon}
+          iconColor={item.appearance.color}
           key={item._id}
           link={`${authRoutes.subjects.path}?categoryId=${item._id}`}
           title={item.name}

--- a/src/components/popular-categories/PopularCategories.tsx
+++ b/src/components/popular-categories/PopularCategories.tsx
@@ -1,29 +1,28 @@
-import { FC, useMemo, useCallback } from 'react'
+import Box from '@mui/material/Box'
+import { SxProps } from '@mui/material/styles'
+import { FC, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
-import Box from '@mui/material/Box'
-import { SxProps } from '@mui/material/styles'
-
-import useAxios from '~/hooks/use-axios'
-import { categoryService } from '~/services/category-service'
-import { useAppSelector } from '~/hooks/use-redux'
-import Loader from '~/components/loader/Loader'
 import CardWithLink from '~/components/card-with-link/CardWithLink'
-import { authRoutes } from '~/router/constants/authRoutes'
-import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import CardsList from '~/components/cards-list/CardsList'
-import { CategoryInterface, ItemsWithCount } from '~/types'
+import Loader from '~/components/loader/Loader'
+import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
+import useAxios from '~/hooks/use-axios'
 import useBreakpoints from '~/hooks/use-breakpoints'
+import { useAppSelector } from '~/hooks/use-redux'
+import { authRoutes } from '~/router/constants/authRoutes'
+import { categoryService } from '~/services/category-service'
 
-import {
-  getScreenBasedLimit,
-  spliceSx,
-  getOpositeRole
-} from '~/utils/helper-functions'
-import { styles } from '~/components/popular-categories/PopularCategories.styles'
-import { defaultResponses } from '~/constants'
 import { itemsLoadLimit } from '~/components/popular-categories/PopularCategories.constants'
+import { defaultResponses } from '~/constants'
+import {
+  getOpositeRole,
+  getScreenBasedLimit,
+  spliceSx
+} from '~/utils/helper-functions'
+import { CategoryInterface, ItemsWithCount } from '~/types'
+import { styles } from '~/components/popular-categories/PopularCategories.styles'
 
 interface PopularCategoriesProps {
   title: string

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -20,7 +20,6 @@ import AppToolbar from '~/components/app-toolbar/AppToolbar'
 import DirectionLink from '~/components/direction-link/DirectionLink'
 import NotFoundResults from '~/components/not-found-results/NotFoundResults'
 import CreateSubjectModal from '~/containers/find-offer/create-new-subject/CreateNewSubject'
-import serviceIcon from '~/assets/img/student-home-page/service_icon.png'
 import { getOpositeRole, getScreenBasedLimit } from '~/utils/helper-functions'
 
 import {
@@ -76,7 +75,8 @@ const Categories = () => {
             description={`${item.totalOffers[oppositeRole]} ${t(
               'categoriesPage.offers'
             )}`}
-            img={serviceIcon}
+            icon={item.appearance.icon}
+            iconColor={item.appearance.color}
             key={item._id}
             link={`${authRoutes.subjects.path}?categoryId=${item._id}`}
             title={item.name}

--- a/src/pages/subjects/Subjects.tsx
+++ b/src/pages/subjects/Subjects.tsx
@@ -25,7 +25,6 @@ import AppToolbar from '~/components/app-toolbar/AppToolbar'
 import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
 import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
 import useBreakpoints from '~/hooks/use-breakpoints'
-import serviceIcon from '~/assets/img/student-home-page/service_icon.png'
 import { getOpositeRole, getScreenBasedLimit } from '~/utils/helper-functions'
 import { mapArrayByField } from '~/utils/map-array-by-field'
 
@@ -102,7 +101,8 @@ const Subjects = () => {
             description={`${item.totalOffers[oppositeRole]} ${t(
               'categoriesPage.offers'
             )}`}
-            img={serviceIcon}
+            icon={item.category.appearance.icon}
+            iconColor={item.category.appearance.color}
             key={item._id}
             link={`${authRoutes.findOffers.path}?categoryId=${categoryId}&subjectId=${item._id}`}
             title={item.name}

--- a/src/services/category-icon-service.ts
+++ b/src/services/category-icon-service.ts
@@ -1,0 +1,33 @@
+import AccountBalanceIcon from '@mui/icons-material/AccountBalance'
+import BiotechIcon from '@mui/icons-material/Biotech'
+import ColorLensIcon from '@mui/icons-material/ColorLens'
+import DesignServicesIcon from '@mui/icons-material/DesignServices'
+import DesktopMacOutlinedIcon from '@mui/icons-material/DesktopMacOutlined'
+import LanguageIcon from '@mui/icons-material/Language'
+import LegendToggleIcon from '@mui/icons-material/LegendToggle'
+import MusicNoteIcon from '@mui/icons-material/MusicNote'
+import ScienceIcon from '@mui/icons-material/Science'
+import StarIcon from '@mui/icons-material/Star'
+import TagIcon from '@mui/icons-material/Tag'
+import HistoryEduIcon from '@mui/icons-material/HistoryEdu'
+import { SvgIconComponent } from '@mui/icons-material'
+
+const CATEGORY_ICONS = {
+  LanguageIcon,
+  ColorLensIcon,
+  BiotechIcon,
+  DesktopMacOutlinedIcon,
+  TagIcon,
+  AccountBalanceIcon,
+  StarIcon,
+  DesignServicesIcon,
+  MusicNoteIcon,
+  ScienceIcon,
+  LegendToggleIcon,
+  HistoryEduIcon
+} as const
+
+type CategoryIconKey = keyof typeof CATEGORY_ICONS
+
+export const getCategoryIcon = (iconName: string): SvgIconComponent =>
+  CATEGORY_ICONS[iconName as CategoryIconKey] ?? CATEGORY_ICONS.LanguageIcon

--- a/src/types/common/interfaces/common.interfaces.ts
+++ b/src/types/common/interfaces/common.interfaces.ts
@@ -46,7 +46,7 @@ export interface CategoryNameInterface {
 export interface SubjectInterface {
   _id: string
   name: string
-  category: Pick<CategoryNameInterface, 'name' | '_id'>
+  category: Pick<CategoryInterface, '_id' | 'appearance'>
   totalOffers: DataByRole<number>
   createdAt: string
   updatedAt: string

--- a/tests/unit/components/card-with-link/CardWithLink.spec.jsx
+++ b/tests/unit/components/card-with-link/CardWithLink.spec.jsx
@@ -4,31 +4,41 @@ import { renderWithProviders } from '~tests/test-utils'
 import CardWithLink from '~/components/card-with-link/CardWithLink'
 
 const props = {
-  id: '1',
-  img: 'icon.png',
+  icon: 'LanguageIcon',
+  iconColor: '#ffffff',
   description: 234,
   title: 'Languages',
   link: '#'
 }
 
 describe('CardWithLink component', () => {
-  beforeEach(() => {
+  it('should render icon', () => {
     renderWithProviders(<CardWithLink {...props} />)
+
+    const icon = screen.getByTestId('LanguageIcon')
+
+    expect(icon).toBeInTheDocument()
   })
 
-  it('should render icon', () => {
-    const icon = screen.getByRole('img')
+  it('should render icon with default color', () => {
+    renderWithProviders(<CardWithLink {...props} iconColor='invalidColor' />)
+
+    const icon = screen.getByTestId('LanguageIcon')
 
     expect(icon).toBeInTheDocument()
   })
 
   it('should render service title', () => {
+    renderWithProviders(<CardWithLink {...props} />)
+
     const title = screen.getByText(props.title)
 
     expect(title).toBeInTheDocument()
   })
 
   it('should render tutors count', () => {
+    renderWithProviders(<CardWithLink {...props} />)
+
     const count = screen.getByText(props.description)
 
     expect(count).toBeInTheDocument()

--- a/tests/unit/components/popular-categories/PopularCategories.spec.jsx
+++ b/tests/unit/components/popular-categories/PopularCategories.spec.jsx
@@ -7,12 +7,20 @@ const items = [
   {
     _id: '1',
     name: 'Math',
-    totalOffers: 10
+    totalOffers: 10,
+    appearance: {
+      icon: 'math.svg',
+      color: '#FF0000'
+    }
   },
   {
     _id: '2',
     name: 'Science',
-    totalOffers: 20
+    totalOffers: 20,
+    appearance: {
+      icon: 'science.svg',
+      color: '#22ff33'
+    }
   }
 ]
 

--- a/tests/unit/pages/categories/Categories.spec.jsx
+++ b/tests/unit/pages/categories/Categories.spec.jsx
@@ -26,8 +26,24 @@ describe('Categories page', () => {
     useLoadMore.mockImplementation(() => ({
       loading: false,
       data: [
-        { _id: '1', name: 'Languages', totalOffers: 0 },
-        { _id: '2', name: 'Music', totalOffers: 0 }
+        {
+          _id: '1',
+          name: 'Languages',
+          totalOffers: 0,
+          appearance: {
+            icon: 'Languages.svg',
+            color: '#FF0000'
+          }
+        },
+        {
+          _id: '2',
+          name: 'Music',
+          totalOffers: 0,
+          appearance: {
+            icon: 'Music.svg',
+            color: '#440fff'
+          }
+        }
       ],
       resetData: resetDataMock,
       loadMore: loadMoreMock,

--- a/tests/unit/services/category-icon-service.spec.js
+++ b/tests/unit/services/category-icon-service.spec.js
@@ -1,0 +1,79 @@
+import { vi } from 'vitest'
+import { getCategoryIcon } from '~/services/category-icon-service'
+
+vi.mock('@mui/icons-material/Language', () => ({
+  default: 'LanguageIcon'
+}))
+
+vi.mock('@mui/icons-material/ColorLens', () => ({
+  default: 'ColorLensIcon'
+}))
+
+vi.mock('@mui/icons-material/Biotech', () => ({
+  default: 'BiotechIcon'
+}))
+
+vi.mock('@mui/icons-material/DesktopMacOutlined', () => ({
+  default: 'DesktopMacOutlinedIcon'
+}))
+
+vi.mock('@mui/icons-material/Tag', () => ({
+  default: 'TagIcon'
+}))
+
+vi.mock('@mui/icons-material/AccountBalance', () => ({
+  default: 'AccountBalanceIcon'
+}))
+
+vi.mock('@mui/icons-material/Star', () => ({
+  default: 'StarIcon'
+}))
+
+vi.mock('@mui/icons-material/DesignServices', () => ({
+  default: 'DesignServicesIcon'
+}))
+
+vi.mock('@mui/icons-material/MusicNote', () => ({
+  default: 'MusicNoteIcon'
+}))
+
+vi.mock('@mui/icons-material/Science', () => ({
+  default: 'ScienceIcon'
+}))
+
+vi.mock('@mui/icons-material/LegendToggle', () => ({
+  default: 'LegendToggleIcon'
+}))
+
+vi.mock('@mui/icons-material/HistoryEdu', () => ({
+  default: 'HistoryEduIcon'
+}))
+
+const iconNames = [
+  'LanguageIcon',
+  'ColorLensIcon',
+  'BiotechIcon',
+  'DesktopMacOutlinedIcon',
+  'TagIcon',
+  'AccountBalanceIcon',
+  'StarIcon',
+  'DesignServicesIcon',
+  'MusicNoteIcon',
+  'ScienceIcon',
+  'LegendToggleIcon',
+  'HistoryEduIcon'
+]
+
+describe('categoryIconService test', () => {
+  it('should return icons', () => {
+    iconNames.forEach((iconName) => {
+      const icon = getCategoryIcon(iconName)
+      expect(icon).toEqual(iconName)
+    })
+  })
+
+  it('should return LanguageIcon for invalid icon name', () => {
+    const icon = getCategoryIcon('InvalidIcon')
+    expect(icon).toEqual('LanguageIcon')
+  })
+})


### PR DESCRIPTION
- [x] should use only MUI icons from the Figma design
- [x] handle invalid icon names and colors
- [x] should receive proper data on all pages where this component is used


![image](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/32570823/ff20799d-ea4e-4a5d-ae03-0d674ee12d0f) 