### PR TITLE
Fixed "Login" pop-up scaling issue #1038

### DIFF
--- a/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
+++ b/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
@@ -69,7 +69,7 @@ const LoginDialog = () => {
             handleChange={handleInputChange}
             handleSubmit={handleSubmit}
           />
-          <GoogleLogin buttonWidth={styles.form.width} type={login} />
+          <GoogleLogin buttonWidth={styles.form.minWidth} type={login} />
         </Box>
       </Box>
     </Box>

--- a/src/containers/guest-home-page/login-dialog/LoginDialog.styles.js
+++ b/src/containers/guest-home-page/login-dialog/LoginDialog.styles.js
@@ -37,7 +37,7 @@ const style = {
     lineHeight: '48px'
   },
   form: {
-    width: '340px',
+    minWidth: '340px',
     overflow: 'auto',
     pt: '16px',
     pr: { xs: '8px', sm: '96px', md: '80px', lg: '96px' },


### PR DESCRIPTION
#### Fixed "Login" pop-up scaling issue [ Close #1038 ]

This PR ensures proper alignment of the "Sign up with Google" button and the "or continue" description on the "Login" pop-up across different scaling settings.

| Before changing | After changing |
|-----------------|----------------|
| ![Before](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/5b43c53e-548d-4aac-83cf-51a9bad165b0) | ![After](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/16162477-845a-4805-be14-0396c5354cc3) |
