### PR TITLE
Fixed space between titleWithDescription and img in TitleBlock component

### DIFF
--- a/src/components/title-block/TitleBlock.styles.ts
+++ b/src/components/title-block/TitleBlock.styles.ts
@@ -19,7 +19,8 @@ export const styles = {
   titleWithDescription: {
     wrapper: {
       textAlign: 'left',
-      mb: '8px'
+      mb: '8px',
+      width: { md: '80%' }
     },
     title: {
       typography: {


### PR DESCRIPTION
- [x] TitleBlock matches [Figma](https://figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=3-28679&t=auzG7Q3ttM1QDMnz-0)

### Before: 
<img width="1470" alt="Screenshot 2024-06-26 at 20 15 08" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/b2a0531c-5d6b-42ba-a5fc-3f47e77b9496">

### After:
<img width="1469" alt="Screenshot 2024-06-26 at 20 16 10" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/ac8dac7d-4115-4226-9285-f429c887bcfd">