### PR TITLE
Added 'Remember me' option to the login form #971

### DIFF
--- a/src/constants/translations/en/login.json
+++ b/src/constants/translations/en/login.json
@@ -1,9 +1,10 @@
 {
   "head": "Welcome back",
   "forgotPassword": "Forgot password?",
+  "rememberMe": "Remember me",
   "googleButton": "Login with Google",
   "continue": "or continue",
-  "haveAccount": "Don`t have an account yet?",
+  "haveAccount": "Don't have an account yet?",
   "joinUs": "Join us for free",
   "enterEmail": "Enter the email address associated with your account and we`ll send you a link to reset your password.",
   "sendPassword": "Send me password reset link",

--- a/src/constants/translations/ua/login.json
+++ b/src/constants/translations/ua/login.json
@@ -1,6 +1,7 @@
 {
   "head": "З поверненням",
   "forgotPassword": "Забули пароль?",
+  "rememberMe": "Запам’ятати мене",
   "googleButton": "Увійти за допомогою Google",
   "continue": "або продовжити",
   "haveAccount": "Ще не маєте акаунту?",

--- a/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
+++ b/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
@@ -46,7 +46,7 @@ const LoginDialog = () => {
           )
         }
       },
-      initialValues: { email: '', password: '' },
+      initialValues: { email: '', password: '', rememberMe: false },
       validations: { email }
     }
   )

--- a/src/containers/guest-home-page/login-form/LoginForm.jsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.jsx
@@ -7,6 +7,7 @@ import ButtonBase from '@mui/material/ButtonBase'
 import Typography from '@mui/material/Typography'
 import Checkbox from '@mui/material/Checkbox'
 import FormControlLabel from '@mui/material/FormControlLabel'
+
 import { useModalContext } from '~/context/modal-context'
 import ForgotPassword from '~/containers/guest-home-page/forgot-password/ForgotPassword'
 import AppTextField from '~/components/app-text-field/AppTextField'

--- a/src/containers/guest-home-page/login-form/LoginForm.jsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.jsx
@@ -5,6 +5,8 @@ import { useSelector } from 'react-redux'
 import Box from '@mui/material/Box'
 import ButtonBase from '@mui/material/ButtonBase'
 import Typography from '@mui/material/Typography'
+import Checkbox from '@mui/material/Checkbox'
+import FormControlLabel from '@mui/material/FormControlLabel'
 import { useModalContext } from '~/context/modal-context'
 import ForgotPassword from '~/containers/guest-home-page/forgot-password/ForgotPassword'
 import AppTextField from '~/components/app-text-field/AppTextField'
@@ -61,14 +63,25 @@ const LoginForm = ({
         value={data.password}
       />
 
-      <Typography
-        component={ButtonBase}
-        onClick={openForgotPassword}
-        sx={styles.forgotPass}
-        variant='subtitle2'
-      >
-        {t('login.forgotPassword')}
-      </Typography>
+      <Box sx={styles.loginOptionsContainer}>
+        <FormControlLabel
+          control={<Checkbox />}
+          label={t('login.rememberMe')}
+          labelPlacement='end'
+          onChange={handleChange('rememberMe')}
+          sx={styles.checkboxLabel}
+          value={data.rememberMe}
+        />
+
+        <Typography
+          component={ButtonBase}
+          onClick={openForgotPassword}
+          sx={styles.forgotPass}
+          variant='subtitle2'
+        >
+          {t('login.forgotPassword')}
+        </Typography>
+      </Box>
 
       <AppButton
         disabled={!data.email || !data.password}

--- a/src/containers/guest-home-page/login-form/LoginForm.styles.js
+++ b/src/containers/guest-home-page/login-form/LoginForm.styles.js
@@ -9,7 +9,7 @@ export const styles = {
     flexDirection: 'row',
     justifyContent: 'space-between',
     height: '40px',
-    padding: '0px 5px',
+    p: '0px 5px',
     mb: '10px'
   },
   input: {

--- a/src/containers/guest-home-page/login-form/LoginForm.styles.js
+++ b/src/containers/guest-home-page/login-form/LoginForm.styles.js
@@ -4,12 +4,26 @@ export const styles = {
     flexDirection: 'column',
     minWidth: { sm: '340px' }
   },
+  loginOptionsContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    height: '40px',
+    padding: '0px 5px',
+    mb: '10px'
+  },
   input: {
     maxWidth: '343px'
   },
   loginButton: {
     width: '100%',
     py: '14px'
+  },
+  checkboxLabel: {
+    mr: 0,
+    '& .MuiFormControlLabel-label': {
+      typography: 'body2'
+    }
   },
   forgotPass: {
     cursor: 'pointer',
@@ -21,8 +35,6 @@ export const styles = {
     '&:focus': {
       outline: '2px solid',
       borderRadius: '2px'
-    },
-    mb: '20px',
-    alignSelf: 'end'
+    }
   }
 }

--- a/tests/unit/containers/guest-home-page/login-form/LoginForm.spec.jsx
+++ b/tests/unit/containers/guest-home-page/login-form/LoginForm.spec.jsx
@@ -9,8 +9,12 @@ vi.mock('~/hooks/use-confirm', () => {
   }
 })
 
-const errors = { email: false, password: false }
-const data = { email: 'email@mail.com', password: 'passTest1' }
+const errors = { email: false, password: false, rememberMe: false }
+const data = {
+  email: 'email@mail.com',
+  password: 'passTest1',
+  rememberMe: false
+}
 const handleChange = vi.fn()
 const handleBlur = vi.fn()
 const handleSubmit = vi.fn()


### PR DESCRIPTION
#### Added 'Remember me' option to the login form [ Close #971 ]

Now the '`Remember me`' checkbox is included in the login popup, following the mockup in [Figma](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=2-24753&t=yFp3udW5yyzK561A-4)

| Before changing | After changing |
|-----------------|----------------|
| ![Before](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/5ef5867d-b18e-4bbb-b93b-341b88b4154a) | ![After](https://github.com/ita-social-projects/SpaceToStudy-Client/assets/28622400/b471736e-317e-48ec-bbeb-8d9d38118e62) |