### PR TITLE
Fixed "My resources" page to match with Figma

### DIFF
--- a/src/components/app-button-menu/AppButtonMenu.styles.ts
+++ b/src/components/app-button-menu/AppButtonMenu.styles.ts
@@ -13,7 +13,6 @@ export const styles = {
   text: { typography: TypographyVariantEnum.Subtitle1 },
   chosenFilters: {
     typography: TypographyVariantEnum.Subtitle1,
-    ml: '4px',
     fontWeight: 500,
     overflow: 'hidden',
     whiteSpace: 'nowrap',

--- a/src/components/app-button-menu/AppButtonMenu.styles.ts
+++ b/src/components/app-button-menu/AppButtonMenu.styles.ts
@@ -47,5 +47,9 @@ export const styles = {
   },
   scrollableContent: { maxHeight: '216px' },
   loader: { color: 'primary.700' },
-  noItemsIcon: { color: 'primary.400' }
+  noItemsIcon: { color: 'primary.400' },
+  unorderedListIcon: {
+    width: '14px',
+    height: '14px'
+  }
 }

--- a/src/components/app-button-menu/AppButtonMenu.tsx
+++ b/src/components/app-button-menu/AppButtonMenu.tsx
@@ -8,6 +8,7 @@ import { PopoverOrigin } from '@mui/material/Popover'
 import Typography from '@mui/material/Typography'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import CircleIcon from '@mui/icons-material/Circle'
 
 import useAxios from '~/hooks/use-axios'
 import useMenu from '~/hooks/use-menu'
@@ -150,6 +151,7 @@ const AppButtonMenu = <T extends Pick<CategoryNameInterface, '_id'>>({
         sx={spliceSx(styles.root, customSx?.root)}
         variant={ButtonVariantEnum.Tonal}
       >
+        <CircleIcon sx={{ width: '14px', height: '14px' }} />
         <Typography sx={styles.text}>{title}:</Typography>
         <Typography sx={styles.chosenFilters}>{chosenFiltersText}</Typography>
         <KeyboardArrowDownIcon sx={styles.arrowIcon(Boolean(anchorEl))} />

--- a/src/components/app-button-menu/AppButtonMenu.tsx
+++ b/src/components/app-button-menu/AppButtonMenu.tsx
@@ -151,7 +151,7 @@ const AppButtonMenu = <T extends Pick<CategoryNameInterface, '_id'>>({
         sx={spliceSx(styles.root, customSx?.root)}
         variant={ButtonVariantEnum.Tonal}
       >
-        <CircleIcon sx={{ width: '14px', height: '14px' }} />
+        <CircleIcon sx={styles.unorderedListIcon} />
         <Typography sx={styles.text}>{title}:</Typography>
         <Typography sx={styles.chosenFilters}>{chosenFiltersText}</Typography>
         <KeyboardArrowDownIcon sx={styles.arrowIcon(Boolean(anchorEl))} />

--- a/src/components/enhanced-table/EnhancedTable.styles.ts
+++ b/src/components/enhanced-table/EnhancedTable.styles.ts
@@ -19,7 +19,8 @@ export const styles = {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    columnGap: 1
+    columnGap: 1,
+    borderRadius: '10px'
   },
   loader: { py: '170px' }
 }

--- a/src/constants/translations/en/my-resources-page.json
+++ b/src/constants/translations/en/my-resources-page.json
@@ -16,10 +16,11 @@
     "lastUpdates": "Last updates",
     "emptyItems": "You have no lessons yet",
     "confirmDeletionTitle": "Do you confirm lesson deletion?",
-    "successDeletion": "Lesson was deleted successfully"
+    "successDeletion": "Lesson was deleted successfully", 
+    "searchInput": "Search a lesson"
   },
   "attachments": {
-    "addBtn": "Add Attachment",
+    "addBtn": "Add attachment",
     "add": "Add Attachments",
     "edit": "Edit Attachment",
     "description": "Attachment description",
@@ -32,7 +33,9 @@
     "successDeletion": "Attachment was deleted successfully",
     "validationError": "File name cannot be longer than 55 symbol.",
     "attachmentName": "Attachment name",
-    "attachmentCategory": "Attachment category"
+    "attachmentCategory": "Attachment category",
+    "searchInput": "Search an attachment"
+
   },
   "quizzes": {
     "addBtn": "New quiz",
@@ -53,6 +56,7 @@
     "savePreviousQuestion": "Please save the previous question",
     "addQuestion": "Add question",
     "settingsPointsAndAnswers": "Settings: Points and answers",
+    "searchInput": "Search a quizz",
     "pointValues": "Point values",
     "pointValuesDesc": "Respondents can see total points and points received for each question",
     "scoredUnscoredResponses": "Scored / Unscored responses",
@@ -80,7 +84,8 @@
     "successDeletion": "Question was deleted successfully",
     "successDuplication": "Question was successfully duplicated",
     "successEditedQuestion": "Question was successfully edited",
-    "successAddedQuestion": "Question was successfully added"
+    "successAddedQuestion": "Question was successfully added",
+    "searchInput": "Search a question"
   },
   "categories": {
     "category": "Category",
@@ -95,7 +100,8 @@
     "confirmDeletionTitle": "Do you confirm category deletion?",
     "categoryDropdown": "Category...",
     "selectCategory": "Select category",
-    "categoryAlreadyExistsError": "Category with the same name already exists"
+    "categoryAlreadyExistsError": "Category with the same name already exists",
+    "searchInput": "Search a category"
   },
   "confirmDeletionMessage": "This action is permanent and will remove all related content. Please review your decision before proceeding."
 }

--- a/src/containers/add-documents/AddDocuments.styles.ts
+++ b/src/containers/add-documents/AddDocuments.styles.ts
@@ -8,7 +8,10 @@ export const styles = {
   },
   fileUpload: {
     root: {
-      border: 'none'
+      border: 'none',
+      Label: {
+        // py: '12px'
+      }
     },
     button: {
       backgroundColor: 'primary.50'

--- a/src/containers/add-documents/AddDocuments.styles.ts
+++ b/src/containers/add-documents/AddDocuments.styles.ts
@@ -10,7 +10,7 @@ export const styles = {
     root: {
       border: 'none',
       Label: {
-        // py: '12px'
+        py: '12px'
       }
     },
     button: {

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -112,6 +112,7 @@ const QuizzesContainer = () => {
         btnText={'myResourcesPage.quizzes.addBtn'}
         fetchData={fetchData}
         link={authRoutes.myResources.newQuiz.path}
+        placeholder={'myResourcesPage.quizzes.searchInput'}
         searchRef={searchTitle}
         selectedItems={selectedItems}
         setItems={setSelectedItems}

--- a/src/containers/my-resources/add-resource-with-input/AddResourceWithInput.styles.ts
+++ b/src/containers/my-resources/add-resource-with-input/AddResourceWithInput.styles.ts
@@ -8,15 +8,14 @@ export const styles = {
   searchIcon: { color: 'primary.700' },
   input: {
     flex: 1,
-    maxWidth: '285px',
+    maxWidth: '500px',
     border: '1px solid',
     borderColor: 'primary.500',
-    borderRadius: '6px'
+    borderRadius: '6px',
+    width: '285px'
   },
   filterWithInput: {
     display: 'flex',
-    columnGap: '25px',
-    maxWidth: '457px',
-    width: '100%'
+    columnGap: '25px'
   }
 }

--- a/src/containers/my-resources/add-resource-with-input/AddResourceWithInput.tsx
+++ b/src/containers/my-resources/add-resource-with-input/AddResourceWithInput.tsx
@@ -33,7 +33,8 @@ interface AddResourceWithInputProps {
   button?: ReactElement
   selectedItems?: string[]
   setItems?: Dispatch<SetStateAction<string[]>>
-  sortOptions: SortHook
+  sortOptions?: SortHook
+  placeholder: string
 }
 
 const AddResourceWithInput: FC<AddResourceWithInputProps> = ({
@@ -44,7 +45,8 @@ const AddResourceWithInput: FC<AddResourceWithInputProps> = ({
   button,
   selectedItems,
   setItems,
-  sortOptions
+  sortOptions,
+  placeholder
 }) => {
   const { t } = useTranslation()
   const { isMobile, isTablet } = useBreakpoints()
@@ -77,6 +79,11 @@ const AddResourceWithInput: FC<AddResourceWithInputProps> = ({
     <>
       {selectedItems && setItems && (
         <AppButtonMenu<CategoryNameInterface>
+          customSx={{
+            root: {
+              borderRadius: '100px !important'
+            }
+          }}
           position={PositionEnum.Right}
           selectedItems={selectedItems}
           service={ResourceService.getResourcesCategoriesNames}
@@ -90,7 +97,7 @@ const AddResourceWithInput: FC<AddResourceWithInputProps> = ({
         endAdornment={<SearchIcon sx={styles.searchIcon} />}
         onChange={onChange}
         onClear={onClear}
-        placeholder={t('common.search')}
+        placeholder={t(placeholder)}
         sx={styles.input}
         value={searchInput}
       />
@@ -112,7 +119,7 @@ const AddResourceWithInput: FC<AddResourceWithInputProps> = ({
         button
       )}
 
-      {isMobileOrTablet && setItems ? (
+      {isMobileOrTablet && setItems && sortOptions ? (
         <ResourcesToolBarDrawer
           isMobile={isMobile}
           setCategories={setItems}

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -194,6 +194,7 @@ const AttachmentsContainer = () => {
         />
       }
       fetchData={fetchAttachments}
+      placeholder={'myResourcesPage.attachments.searchInput'}
       searchRef={searchFileName}
       selectedItems={selectedItems}
       setItems={setSelectedItems}

--- a/src/containers/my-resources/categories-container/CategoriesContainer.style.ts
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.style.ts
@@ -12,7 +12,16 @@ export const styles = {
   addIcon: { ml: '5px', width: { xs: '18px', sm: '22px' } },
   table: {
     '& td,th': {
-      '&:first-of-type': { maxWidth: { xs: '80%', sm: '50%' }, width: '100%' }
+      '&:first-of-type': {
+        maxWidth: { xs: '80%', sm: '50%' },
+        width: '100%',
+        borderTopLeftRadius: '10px',
+        borderBottomLeftRadius: '10px'
+      },
+      '&:last-of-type': {
+        borderTopRightRadius: '10px',
+        borderBottomRightRadius: '10px'
+      }
     }
   }
 }

--- a/src/containers/my-resources/categories-container/CategoriesContainer.tsx
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.tsx
@@ -203,6 +203,7 @@ const CategoriesContainer = () => {
           </AppButton>
         }
         fetchData={fetchData}
+        placeholder={'myResourcesPage.categories.searchInput'}
         searchRef={searchTitle}
       />
       {loading ? (

--- a/src/containers/my-resources/lessons-container/LessonsContainer.tsx
+++ b/src/containers/my-resources/lessons-container/LessonsContainer.tsx
@@ -111,6 +111,7 @@ const LessonsContainer = () => {
         btnText={'myResourcesPage.lessons.addBtn'}
         fetchData={fetchData}
         link={authRoutes.myResources.newLesson.path}
+        placeholder={'myResourcesPage.lessons.searchInput'}
         searchRef={searchTitle}
         selectedItems={selectedItems}
         setItems={setSelectedItems}

--- a/src/containers/my-resources/questions-container/QuestionsContainer.tsx
+++ b/src/containers/my-resources/questions-container/QuestionsContainer.tsx
@@ -164,6 +164,7 @@ const QuestionsContainer = () => {
         btnText={'myResourcesPage.questions.addBtn'}
         fetchData={fetchData}
         link={authRoutes.myResources.newQuestion.path}
+        placeholder={'myResourcesPage.questions.searchInput'}
         searchRef={searchTitle}
         selectedItems={selectedItems}
         setItems={setSelectedItems}

--- a/tests/unit/containers/my-resources/AddResourceWithInput.spec.jsx
+++ b/tests/unit/containers/my-resources/AddResourceWithInput.spec.jsx
@@ -12,6 +12,7 @@ const route = '/my-resources'
 
 const props = {
   btnText: 'myResourcesPage.quizzes.newQuizBtn',
+  placeholder: 'common.search',
   fetchData: fetchDataMock,
   link: '#',
   searchRef: { current: text },


### PR DESCRIPTION
- [x] border-radius should be rounded for all containers
- [x]  input placeholder should be changed depending on the chosen source. e.g. "Seach for a lesson" if we choose a "Lessons" source
- [x]  there should be an unordered icon next to the "Category:"
- [x]  if we choose a "Category tab", the input search should be right-aligned
- [x]  edit padding for the "Add attachment" as only this button differs from other "Add" buttons
- [x]  edit search input width, so it matches [Figma](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=3-35603&t=auzG7Q3ttM1QDMnz-0)

### Before: 
<img width="1065" alt="Screenshot 2024-06-26 at 20 40 33" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/e81bcec4-bf2e-47f9-a678-a34710681f2c">

### After: 
<img width="1467" alt="Screenshot 2024-06-27 at 00 23 28" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/e64c3533-2958-4114-a9e2-070ffa5bbc60">

