### PR TITLE
Fixed translation on the Home Page and the input's width in the TitleBlock 

### DIFF
--- a/src/components/title-block/TitleBlock.styles.ts
+++ b/src/components/title-block/TitleBlock.styles.ts
@@ -12,11 +12,12 @@ export const styles = {
     pr: { lg: 15 }
   },
   info: {
-    minWidth: '60%'
+    minWidth: '80%'
   },
   form: {
     display: 'flex',
-    flexWrap: { sm: 'nowrap', xs: 'wrap' }
+    flexWrap: { sm: 'nowrap', xs: 'wrap' },
+    maxWidth: { md: '80%' }
   },
   titleWithDescription: {
     wrapper: {

--- a/src/constants/translations/en/student-home-page.json
+++ b/src/constants/translations/en/student-home-page.json
@@ -4,7 +4,9 @@
       "student": "A Global Network of Tutors",
       "tutor": "A Global Network of Students"
     },
-    "description": "A Space2Study platform is a place where you can learn from the best.\nType who or what would you like to learn from and find the best tutor.",
+    "description": {
+      "student": "A Space2Study platform is a place where you can learn from the best.\nType who or what would you like to learn from and find the best tutor."
+    },
     "label": "Who or what do you want to learn from?",
     "button": "Find tutor"
   },

--- a/src/constants/translations/en/tutor-home-page.json
+++ b/src/constants/translations/en/tutor-home-page.json
@@ -3,7 +3,9 @@
     "title": {
       "tutor": "A Global Network of Students"
     },
-    "description": "A Space2Study platform is the best place where you can teach.\nType who or what would you like to teach and find students for that.",
+    "description": {
+      "tutor": "A Space2Study platform is the best place where you can teach.\nType who or what would you like to teach and find students for that."
+    },
     "label": "Who or what do you want to teach?",
     "button": "Find student"
   },

--- a/src/scss/src/atoms/Button.scss
+++ b/src/scss/src/atoms/Button.scss
@@ -29,8 +29,8 @@
     @extend %size-extra-large;
   }
 
-  &__extraExtraLarge {
-    @extend %size-extra-extra-large;
+  &__xxl {
+    @extend %size-xxl;
   }
 
   &__contained {
@@ -76,7 +76,7 @@
   column-gap: spacing(3);
 }
 
-%size-extra-extra-large {
+%size-xxl {
   padding: 0.75rem 2rem; 
   column-gap: 0.75rem;
 }


### PR DESCRIPTION
- [x] fixed translation for TitleWithDescription on the Home Page
- [x] after the translation is fixed, reduced the input's width
- [x] updated scss class name for a Button.scss as it was missed in the already closed [PR](https://github.com/ita-social-projects/SpaceToStudy-Client/issues/1988)

### Before: 
<img width="1470" alt="Screenshot 2024-06-28 at 17 18 21" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/0b447e3d-66d5-4344-ab6d-e0b1bf952f2b">

<img width="1221" alt="Screenshot 2024-06-28 at 17 28 23" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/81e88907-b081-4c70-9c70-86082ebc47e0">

### After:
<img width="1221" alt="Screenshot 2024-06-28 at 17 38 57" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/bb60c90a-77ee-46aa-bc4a-f5ae37fe552b">
