### PR TITLE
Fixed icons for quiz options

### DIFF
--- a/src/components/question-editor/QuestionEditor.constants.tsx
+++ b/src/components/question-editor/QuestionEditor.constants.tsx
@@ -1,17 +1,17 @@
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
-import NotesIcon from '@mui/icons-material/Notes'
 import RuleIcon from '@mui/icons-material/Rule'
+import ListIcon from '@mui/icons-material/List'
+import ShortTextIcon from '@mui/icons-material/ShortText'
 
 import { SizeEnum, QuestionTypesEnum } from '~/types'
 
 export const sortQuestions = [
   {
-    icon: <CheckCircleOutlineIcon fontSize={SizeEnum.Small} />,
+    icon: <ListIcon fontSize={SizeEnum.Small} />,
     title: 'questionPage.questionType.multipleChoice',
     value: QuestionTypesEnum.MultipleChoice
   },
   {
-    icon: <NotesIcon fontSize={SizeEnum.Small} />,
+    icon: <ShortTextIcon fontSize={SizeEnum.Small} />,
     title: 'questionPage.questionType.openAnswer',
     value: QuestionTypesEnum.OpenAnswer
   },

--- a/src/containers/add-resources/AddQuestions.constants.tsx
+++ b/src/containers/add-resources/AddQuestions.constants.tsx
@@ -1,4 +1,4 @@
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import ListIcon from '@mui/icons-material/CheckCircleOutline'
 import Typography from '@mui/material/Typography'
 
 import AppChip from '~/components/app-chip/AppChip'
@@ -28,7 +28,7 @@ export const columns: TableColumn<Question>[] = [
               component={ComponentEnum.Span}
               sx={styles.questionTitle}
             >
-              <CheckCircleOutlineIcon sx={styles.questionIcon} />
+              <ListIcon sx={styles.questionIcon} />
               {question.title}
             </Typography>
           }

--- a/src/utils/check-icons.tsx
+++ b/src/utils/check-icons.tsx
@@ -1,10 +1,10 @@
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
+import ListIcon from '@mui/icons-material/CheckCircleOutline'
 import DriveFileRenameOutlineOutlinedIcon from '@mui/icons-material/DriveFileRenameOutlineOutlined'
 import FormatListBulletedOutlinedIcon from '@mui/icons-material/FormatListBulletedOutlined'
 
 export const CheckIcons = (type: string) => {
   return (
-    (type === 'oneAnswer' && <CheckCircleOutlineIcon />) ||
+    (type === 'oneAnswer' && <ListIcon />) ||
     (type === 'openAnswer' && <DriveFileRenameOutlineOutlinedIcon />) ||
     (type === 'multipleChoice' && <FormatListBulletedOutlinedIcon />)
   )


### PR DESCRIPTION
### Updated icons: 
<img width="226" alt="Screenshot 2024-07-03 at 19 40 30" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/1c1ec20e-d5c3-48ce-8a91-ab119a13c337">
<img width="187" alt="Screenshot 2024-07-03 at 19 40 42" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/3cf240eb-b24a-46f6-8a8e-bdfa85ce88af">
<img width="183" alt="Screenshot 2024-07-03 at 19 41 48" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/b2b4c0b6-d5a0-45e5-bff0-509aa10c5334">

[Figma](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=11426-38457&t=fGvHiOltU3HU31n9-0)

<img width="207" alt="Screenshot 2024-07-03 at 19 43 00" src="https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/fd146c05-8e20-4f28-ae43-7b8ddb3f9caa">

We don't have a MUI icon for the "One Answer" option that matches the one in Figma, so I think it would be better to update the icon in Figma to match the one from the screenshot above.