### PR TITLE
Fixed quiz and lesson description

### DIFF
--- a/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
+++ b/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
@@ -253,6 +253,8 @@ const CreateOrEditQuizContainer = ({
           fullWidth
           inputProps={styles.input}
           label={t('myResourcesPage.quizzes.defaultNewDescription')}
+          maxRows={3}
+          multiline
           onChange={onDescriptionChange}
           value={description}
           variant={TextFieldVariantEnum.Standard}

--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.styles.ts
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.styles.ts
@@ -10,7 +10,7 @@ const inputFontSize = {
 
 const titleAndDescription = {
   fontSize: '16px',
-  maxHeight: '16px',
+  maxHeight: '24px',
   marginTop: 0
 }
 

--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
@@ -240,6 +240,7 @@ const CreateOrEditLesson = () => {
           fullWidth
           inputProps={styles.input}
           label={data.description ? '' : t('lesson.labels.description')}
+          maxRows={3}
           multiline
           onChange={handleInputChange('description')}
           value={data.description}


### PR DESCRIPTION
 - [x] fixed a description field when creating a new Quiz and a Lesson
### Before: 
https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/04ac72db-6e54-4bd3-9018-4b7754cbea8b

### After: 
https://github.com/ita-social-projects/SpaceToStudy-Client/assets/102433497/92176c39-84ca-4e93-bda5-7872432a5b29

