### PR TITLE
Fix translation of proficiency levels

### DIFF
--- a/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
+++ b/src/containers/my-courses/course-toolbar/CourseToolbar.tsx
@@ -9,6 +9,7 @@ import useUserCategoriesAndSubjects from '~/hooks/use-user-categories-and-subjec
 import AppTextField from '~/components/app-text-field/AppTextField'
 import AppToolbar from '~/components/app-toolbar/AppToolbar'
 import DividedDropdownAutocomplete from '~/components/divider-dropdown-autocomplete/DividerDropdownAutocomplete'
+import { proficiencyLevelLabels } from '~/constants/labels'
 
 import {
   CategoryNameInterface,
@@ -125,6 +126,7 @@ const CourseToolbar = ({
         errorMessage={errors.proficiencyLevel}
         fillRange
         label={t('breadCrumbs.level')}
+        labels={proficiencyLevelLabels}
         onBlur={handleBlur('proficiencyLevel')}
         onChange={onLevelChange}
         sx={{ select: styles.levelSelect, formSx: { flex: 1 } }}

--- a/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
+++ b/src/containers/proficiency-level-select/ProficiencyLevelSelect.tsx
@@ -17,6 +17,7 @@ interface ProficiencyLevelSelectProps
   extends Omit<SelectProps<ProficiencyLevelEnum[]>, 'sx' | 'onChange'> {
   value: ProficiencyLevelEnum[]
   label?: string
+  labels?: ReadonlyMap<ProficiencyLevelEnum, string>
   errorMessage?: string
   fillRange?: boolean
   sx?: {
@@ -29,6 +30,7 @@ interface ProficiencyLevelSelectProps
 const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
   value = [],
   label,
+  labels,
   errorMessage = '',
   sx,
   fillRange = false,
@@ -57,7 +59,9 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
       value={checkbox}
     >
       <Checkbox checked={value.indexOf(checkbox) > -1} />
-      <ListItemText primary={checkbox} />
+      <ListItemText
+        primary={labels?.has(checkbox) ? t(labels.get(checkbox)!) : t(checkbox)}
+      />
     </MenuItem>
   ))
 
@@ -70,9 +74,15 @@ const ProficiencyLevelSelect: FC<ProficiencyLevelSelectProps> = ({
   )
 
   const renderSelectedValue = (selected: ProficiencyLevelEnum[]) => {
+    const translatedValues = selected.map((level) =>
+      labels?.has(level) ? t(labels.get(level)!) : t(level)
+    )
+
     return fillRange && selected.length > 1
-      ? `${selected[0]} - ${selected[selected.length - 1]}`
-      : selected.join(', ')
+      ? `${translatedValues[0]} - ${
+          translatedValues[translatedValues.length - 1]
+        }`
+      : translatedValues.join(', ')
   }
 
   return (

--- a/tests/unit/containers/my-courses/course-toolbar/CourseToolbar.spec.jsx
+++ b/tests/unit/containers/my-courses/course-toolbar/CourseToolbar.spec.jsx
@@ -3,6 +3,7 @@ import { mockAxiosClient, selectOption } from '~tests/test-utils'
 import CourseToolbar from '~/containers/my-courses/course-toolbar/CourseToolbar'
 import { URLs } from '~/constants/request'
 import { ProficiencyLevelEnum } from '~/types'
+import { proficiencyLevelLabels } from '~/constants/labels'
 
 const mockData = {
   title: '',
@@ -171,7 +172,7 @@ describe('CourseToolbar', () => {
       })
 
       const proficiencyCheckbox = screen.getByText(
-        ProficiencyLevelEnum.Beginner
+        proficiencyLevelLabels.get(ProficiencyLevelEnum.Beginner)
       )
       fireEvent.click(proficiencyCheckbox)
 


### PR DESCRIPTION
Fixed translation of proficiency levels so now it looks like this:

![Screenshot 2024-08-06 133634](https://github.com/user-attachments/assets/39cbbb93-f78a-4e1a-828d-a58f5ef713f2)

![Screenshot 2024-08-06 133621](https://github.com/user-attachments/assets/40c6886b-d89f-49e5-b95b-3652c2d65f6c)
