### PR TITLE
Corrected Count of Offers in 'Other offers' Carousel

### DIFF
--- a/src/containers/offer-details/offer-carousel/OfferCarousel.constants.ts
+++ b/src/containers/offer-details/offer-carousel/OfferCarousel.constants.ts
@@ -1,5 +1,5 @@
 export const itemsLoadLimit = {
-  desktop: 4,
+  desktop: 3,
   tablet: 2,
   mobile: 1,
   default: 3


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/996a9c54-5bd1-4f6c-b811-6ea63393ec83)

After:
![image](https://github.com/user-attachments/assets/82bede5c-d598-4e60-8bfd-4c0ae80e600c)
