### PR TITLE
Set not visible button 'Edit' for the student in cooperations

### DIFF
--- a/src/containers/cooperation-details/cooperetion-activities-view/CooperationActivitiesView.tsx
+++ b/src/containers/cooperation-details/cooperetion-activities-view/CooperationActivitiesView.tsx
@@ -11,6 +11,7 @@ import {
 } from '~/redux/features/cooperationsSlice'
 
 import { styles } from '~/containers/cooperation-details/cooperetion-activities-view/CooperationActivitiesView.style'
+import { CourseSection, UserRoleEnum } from '~/types'
 
 interface CooperationActivitiesViewProps {
   sections: CourseSection[]
@@ -28,20 +29,26 @@ const CooperationActivitiesView: FC<CooperationActivitiesViewProps> = ({
     dispatch(setIsAddedClicked(false))
   }
 
+  const { userRole } = useAppSelector((state) => state.appMain)
+  const isTutor = userRole === UserRoleEnum.Tutor
+
   return (
     <Box sx={styles.root}>
       {sections.map((item) => (
         <CooperationSectionView id={item._id} item={item} key={item._id} />
       ))}
-      <Box sx={styles.editContainer}>
-        <IconButton
-          data-testid='iconButton'
-          onClick={onEdit}
-          sx={styles.editButton}
-        >
-          <EditIcon />
-        </IconButton>
-      </Box>
+
+      {isTutor && (
+        <Box sx={styles.editContainer}>
+          <IconButton
+            data-testid='iconButton'
+            onClick={onEdit}
+            sx={styles.editButton}
+          >
+            <EditIcon />
+          </IconButton>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/tests/unit/containers/cooperation-details/ CooperationActivitiesView.spec.jsx
+++ b/tests/unit/containers/cooperation-details/ CooperationActivitiesView.spec.jsx
@@ -1,5 +1,6 @@
 import { render, screen, act, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { UserRoleEnum } from '~/types'
 import CooperationActivitiesView from '~/containers/cooperation-details/cooperetion-activities-view/CooperationActivitiesView.tsx'
 
 vi.mock('~/components/cooperation-section-view/CooperationSectionView', () => ({
@@ -13,7 +14,8 @@ vi.mock('~/hooks/use-redux', () => ({
     sections: [
       { _id: '1', title: 'Section1' },
       { _id: '2', title: 'Section2' }
-    ]
+    ],
+    userRole: UserRoleEnum.Tutor
   }),
   useAppDispatch: vi.fn().mockReturnValue(vi.fn())
 }))


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/46759168-b88f-40f0-bd8e-d4a043529b4e)

After:
![image](https://github.com/user-attachments/assets/465647c7-d711-480d-befd-449650942049)

all bugs fixed by #2061  