### PR TITLE
Fixed date serialization and mask input issues in DatePicker component #2103

### DIFF
--- a/src/containers/course-section/resource-item/ResourceItem.tsx
+++ b/src/containers/course-section/resource-item/ResourceItem.tsx
@@ -86,7 +86,7 @@ const ResourceItem: FC<ResourceItemProps> = ({
   const setOpenFromDate = (date: Date | null) => {
     updateAvailability?.(resource, {
       status: resourceAvailabilityStatus,
-      date
+      date: date?.toISOString() ?? null
     })
   }
 
@@ -117,6 +117,7 @@ const ResourceItem: FC<ResourceItemProps> = ({
           <Box sx={styles.datePicker}>
             {availabilityIcon}
             <DatePicker
+              disableMaskedInput
               disablePast
               inputFormat={'MMM d, yyyy'}
               label={t('cooperationDetailsPage.datePickerLabel')}

--- a/src/types/course/types/course.types.ts
+++ b/src/types/course/types/course.types.ts
@@ -8,7 +8,7 @@ import {
 
 export interface ResourceAvailability {
   status: ResourceAvailabilityStatusEnum
-  date: Date | null
+  date: string | null
 }
 
 export type CourseResource = Lesson | Quiz | Attachment


### PR DESCRIPTION
### Fixed date serialization and mask input issues in the `DatePicker` component [ Close #2103 ]
In this PR, two warnings that appear during the **_change of a resource's availability to "open from date" status in cooperations_** have been fixed:

- [x] Ensured `availability.date` is properly serialized to ISO string before dispatching actions:
A non-serializable value (`Date` object) was detected in the state, specifically in the path: **cooperations.sections.0.resources.0.resource.availability.date**. This warning is raised because Redux state should only contain plain serializable _objects_, _arrays_, and _primitives_. The reducer handling this action type is `cooperationsSlice/updateResource`:
<img width="640" alt="Screenshot 2024-07-15 at 18 20 58" src="https://github.com/user-attachments/assets/0a1ef15e-0f43-4fbe-9604-3bcd61d48ef9">

- [x] Adjusted props for `DatePicker` component to use fixed-length date parts to resolve mask input warning:
<img width="391" alt="Screenshot 2024-08-07 at 14 00 23" src="https://github.com/user-attachments/assets/2ac47c2e-5b0d-4dbb-8d80-eb6c06a2a311">
