### PR TITLE
Increase indent before the 'What students say' block

### DIFF
--- a/src/containers/user-profile/comments-with-rating-block/CommentsWithRatingBlock.styles.ts
+++ b/src/containers/user-profile/comments-with-rating-block/CommentsWithRatingBlock.styles.ts
@@ -25,5 +25,8 @@ export const styles = {
     maxWidth: '250px',
     alignItems: 'center'
   } as SxProps<Theme>,
-  title: { typography: { xs: 'button', sm: 'h5', md: 'h4' } } as SxProps<Theme>
+  title: {
+    typography: { xs: 'button', sm: 'h5', md: 'h4' },
+    marginTop: '100px'
+  } as SxProps<Theme>
 }

--- a/src/containers/user-profile/comments-with-rating-block/CommentsWithRatingBlock.styles.ts
+++ b/src/containers/user-profile/comments-with-rating-block/CommentsWithRatingBlock.styles.ts
@@ -27,6 +27,6 @@ export const styles = {
   } as SxProps<Theme>,
   title: {
     typography: { xs: 'button', sm: 'h5', md: 'h4' },
-    marginTop: '100px'
+    mt: '100px'
   } as SxProps<Theme>
 }


### PR DESCRIPTION
How it was:
![image](https://github.com/user-attachments/assets/554a443a-63bc-41ae-9373-3e4e4b060ebf)


Result:
![image](https://github.com/user-attachments/assets/337d8b14-6e0f-4f27-b70b-09b36378ef03)
