### PR TITLE
Corrected date translation in all possible places on the website

### DIFF
--- a/src/utils/helper-functions.tsx
+++ b/src/utils/helper-functions.tsx
@@ -1,4 +1,5 @@
 import { SxProps, Theme } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import {
   Breakpoints,
   ConvertedSize,
@@ -84,6 +85,11 @@ const addOrdinalSuffix = (day: number): string => {
   }
 }
 
+const mapper: Record<string, string> = {
+  en: 'en-US',
+  uk: 'uk-UA'
+}
+
 export const getFormattedDate = ({
   date,
   locales = 'en-US',
@@ -95,8 +101,12 @@ export const getFormattedDate = ({
   isCurrentDayHours = false,
   includeOrdinal = false
 }: FormatedDate): string => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { i18n } = useTranslation()
+  const get_language = i18n.language
+  const language_key = mapper[get_language]
   const currentDate = new Date()
-  const formattedDate = new Date(date).toLocaleString(locales, options)
+  const formattedDate = new Date(date).toLocaleString(language_key, options)
 
   if (
     isCurrentDayHours &&

--- a/src/utils/helper-functions.tsx
+++ b/src/utils/helper-functions.tsx
@@ -1,5 +1,5 @@
 import { SxProps, Theme } from '@mui/material'
-import { useTranslation } from 'react-i18next'
+import i18next from 'i18next'
 import {
   Breakpoints,
   ConvertedSize,
@@ -101,9 +101,7 @@ export const getFormattedDate = ({
   isCurrentDayHours = false,
   includeOrdinal = false
 }: FormatedDate): string => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { i18n } = useTranslation()
-  const get_language = i18n.language
+  const get_language = i18next.language
   const language_key = mapper[get_language]
   const currentDate = new Date()
   const formattedDate = new Date(date).toLocaleString(language_key, options)


### PR DESCRIPTION
Changed logic of formatting dates by adding date translation 

![image_2024-08-15_00-05-19](https://github.com/user-attachments/assets/d787bcb5-8e7c-4296-85c7-bec8fbb81e53)


![image_2024-08-15_00-05-42](https://github.com/user-attachments/assets/4a696add-7590-42f9-b64a-84f9bdc92024)
