### PR TITLE
Created 'cn' utility for efficient class name management

### DIFF
--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,23 @@
+export function cn(...args: unknown[]): string {
+  return args
+    .flat(5)
+    .reduce<string[]>((previousValue, currentValue) => {
+      if (!currentValue) return previousValue
+
+      if (typeof currentValue === 'object') {
+        Object.entries(currentValue).forEach(([k, v]) => {
+          if (v) previousValue.push(k)
+        })
+        return previousValue
+      }
+
+      if (typeof currentValue === 'string') {
+        previousValue.push(currentValue)
+        return previousValue
+      }
+
+      return previousValue
+    }, [])
+    .join(' ')
+    .trim()
+}

--- a/tests/unit/utils/cn.spec.js
+++ b/tests/unit/utils/cn.spec.js
@@ -16,7 +16,7 @@ describe('cn', () => {
   })
 
   it('should be trimmed', () => {
-    const result = cn('', 'b', {}, '')
+    const result = cn(' ', 'b', {}, ' ')
     expect(result).toBe('b')
   })
 

--- a/tests/unit/utils/cn.spec.js
+++ b/tests/unit/utils/cn.spec.js
@@ -1,0 +1,93 @@
+import { cn } from '~/utils/cn'
+
+describe('cn', () => {
+  it('keeps object keys with truthy values', () => {
+    const result = cn({ a: true, b: false, c: 0, d: null, e: undefined, f: 1 })
+    expect(result).toBe('a f')
+  })
+  it('joins arrays of class names and ignore falsy values', () => {
+    const result = cn('a', 0, null, undefined, true, 1, 'b')
+    expect(result).toBe('a b')
+  })
+
+  it('supports heterogenous arguments', () => {
+    const result = cn({ a: true }, 'b', 0)
+    expect(result).toBe('a b')
+  })
+
+  it('should be trimmed', () => {
+    const result = cn('', 'b', {}, '')
+    expect(result).toBe('b')
+  })
+
+  it('returns an empty string for an empty configuration', () => {
+    const result = cn({})
+    expect(result).toBe('')
+  })
+
+  it('supports an array of class names', () => {
+    const result = cn(['a', 'b'])
+    expect(result).toBe('a b')
+  })
+
+  it('joins array arguments with string arguments', () => {
+    expect(cn(['a', 'b'], 'c')).toBe('a b c')
+    expect(cn('c', ['a', 'b'])).toBe('c a b')
+  })
+
+  it('handles multiple array arguments', () => {
+    expect(cn(['a', 'b'], ['c', 'd'])).toBe('a b c d')
+  })
+
+  it('handles arrays that include falsy and true values', () => {
+    expect(cn(['a', 0, null, undefined, false, true, 'b'])).toBe('a b')
+  })
+
+  it('handles arrays that include arrays', () => {
+    expect(cn(['a', ['b', 'c']])).toBe('a b c')
+  })
+
+  it('handles arrays that include objects', () => {
+    expect(cn(['a', { b: true, c: false }])).toBe('a b')
+  })
+
+  it('handles deep array recursion', () => {
+    expect(cn(['a', ['b', ['c', { d: true }]]])).toBe('a b c d')
+  })
+
+  it('handles arrays that are empty', () => {
+    expect(cn('a', [])).toBe('a')
+  })
+
+  it('handles nested arrays that have empty nested arrays', () => {
+    expect(cn('a', [[]])).toBe('a')
+  })
+
+  it('handles all types of truthy and falsy property values as expected', () => {
+    const result = cn({
+      // falsy:
+      null: null,
+      emptyString: '',
+      noNumber: NaN,
+      zero: 0,
+      negativeZero: -0,
+      false: false,
+      undefined: undefined,
+
+      // truthy
+      nonEmptyString: 'foobar',
+      number: 23,
+      negativeNumber: -42,
+      function: Object.prototype.toString,
+      emptyObject: {},
+      nonEmptyObject: { a: 1, b: 2 },
+      emptyList: [],
+      nonEmptyList: [1, 2, 3],
+      greaterZero: 0.1
+    })
+
+    expect(result).toBe(
+      'nonEmptyString number negativeNumber function emptyObject nonEmptyObject emptyList nonEmptyList greaterZero'
+    )
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,12 @@ export default defineConfig({
     coverage: {
       all: true,
       reporter: ['lcov', 'text'],
-      include: ['src/**/*.jsx', 'src/**/*.tsx'],
+      include: [
+        'src/**/*.jsx',
+        'src/**/*.tsx',
+        'src/utils/**/*.ts',
+        'src/utils/**/*.js'
+      ],
       exclude: ['src/stories', './tests/setup-tests.js'],
       reportsDirectory: './tests/coverage'
     },


### PR DESCRIPTION
The `cn` function is a custom implementation inspired by the popular `clsx` library, allowing a more concise and readable way to conditionally combine class names.

Key Features:
1. **Conditional Class Names:** `cn` allows for effortless inclusion or exclusion of class names based on truthy or falsy conditions.
2. **Array and Object Support:** Easily combine class names from arrays and objects, improving flexibility in how we manage dynamic classes.
3. **No External Dependencies:** The `cn` utility is lightweight and self-contained, meaning no additional external dependencies are required.
4. **Improved Readability:** By using `cn`, our components and styles become more readable and maintainable, reducing clutter from complex ternary operations and nested conditionals.

### Usage example:
```typescript
//before
const className =
  `card ${highlighted ? 'card-highlighted' : ''} ${
    shadowed ? 'card-shadowed' : ''
  }` + (size ? ` card-${size}` : '')

//after
const className = cn('card', {
  'card-highlighted': highlighted,
  'card-shadowed': shadowed,
  [`card-${size}`]: size
})
//or
const className = cn(
  'card',
  highlighted && 'card-highlighted',
  shadowed && 'card-shadowed',
  size && `card-${size}`
)

// result: card card-highlighted card-shadowed card-XXL
```


### [More usage examples](https://github.com/lukeed/clsx?tab=readme-ov-file#usage)
