### PR TITLE
Added the possibility to add a resource to a Cooperation in two ways: by duplicating or linking

### DIFF
--- a/src/components/checkbox-with-tooltip/CheckboxWithTooltip.tsx
+++ b/src/components/checkbox-with-tooltip/CheckboxWithTooltip.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, useCallback } from 'react'
 
 import {
   Box,
@@ -15,13 +15,20 @@ import { styles } from './CheckboxWithTooltip.styles'
 interface CheckboxWithTooltipProps extends CheckboxProps {
   label: ReactNode
   tooltipTitle: ReactNode
+  onChecked?: (value: boolean) => void
 }
 
 const CheckboxWithTooltip = ({
   label,
   tooltipTitle,
+  onChecked,
   ...props
 }: CheckboxWithTooltipProps) => {
+  const onChangeHandler = useCallback(
+    (_: React.SyntheticEvent, checked: boolean) => onChecked?.(checked),
+    [onChecked]
+  )
+
   return (
     <Box sx={styles.root}>
       <FormControlLabel
@@ -32,6 +39,7 @@ const CheckboxWithTooltip = ({
         }}
         control={<Checkbox {...props} />}
         label={label}
+        onChange={onChangeHandler}
         sx={styles.label}
       />
       <Tooltip

--- a/src/containers/add-resources/AddResources.tsx
+++ b/src/containers/add-resources/AddResources.tsx
@@ -28,7 +28,7 @@ import { getErrorKey } from '~/utils/get-error-key'
 
 interface AddResourcesProps<T extends CourseResource | Question> {
   resources?: T[]
-  onAddResources: (resource: T[]) => void
+  onAddResources: (resource: T[], isDuplicate: boolean) => void
   resourceTab: ResourcesTabsEnum
   columns: TableColumn<T>[]
   removeColumnRules: RemoveColumnRules<T>
@@ -45,12 +45,15 @@ const AddResources = <T extends CourseResource | Question>({
   requestService,
   showCheckboxWithTooltip = false
 }: AddResourcesProps<T>) => {
-  const [selectedRows, setSelectedRows] = useState<T[]>(resources)
-  const { closeModal } = useModalContext()
   const dispatch = useAppDispatch()
   const breakpoints = useBreakpoints()
+  const { closeModal } = useModalContext()
+
+  const [selectedRows, setSelectedRows] = useState<T[]>(resources)
+  const [isDuplicate, setIsDuplicate] = useState<boolean>(false)
+
   const initialSelect = resources.map((resource) => resource._id)
-  const select = useSelect({ initialSelect })
+  const { clearSelected, ...select } = useSelect({ initialSelect })
   const sortOptions = useSort({ initialSort })
 
   const { sort } = sortOptions
@@ -97,8 +100,19 @@ const AddResources = <T extends CourseResource | Question>({
   }
 
   const onAddItems = () => {
-    onAddResources(selectedRows)
+    onAddResources(selectedRows, isDuplicate)
     closeModal()
+  }
+
+  const onCreateResourceCopy = (value: boolean) => {
+    setIsDuplicate(value)
+    if (value) {
+      setSelectedRows([])
+      clearSelected()
+    } else {
+      setSelectedRows(resources)
+      select.setSelected(resources.map((item) => item._id))
+    }
   }
 
   const getItems = useCallback(
@@ -138,6 +152,7 @@ const AddResources = <T extends CourseResource | Question>({
     selectedRows,
     isSelection: true,
     onAddItems,
+    onCreateResourceCopy,
     data: { loading, getItems },
     onRowClick,
     resourceTab,

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -81,6 +81,35 @@ const CourseSectionContainer: FC<SectionProps> = ({
     [sectionData.resources]
   )
 
+  const allNonDuplicateResources = useMemo(
+    () => allResources.filter((resource) => !resource.isDuplicate),
+    [allResources]
+  )
+
+  const lessons = useMemo(
+    () =>
+      allNonDuplicateResources.filter(
+        (resource) => resource.resourceType === ResourceType.Lesson
+      ) as Lesson[],
+    [allNonDuplicateResources]
+  )
+
+  const quizzes = useMemo(
+    () =>
+      allNonDuplicateResources.filter(
+        (resource) => resource.resourceType === ResourceType.Quiz
+      ) as Quiz[],
+    [allNonDuplicateResources]
+  )
+
+  const attachments = useMemo(
+    () =>
+      allNonDuplicateResources.filter(
+        (resource) => resource.resourceType === ResourceType.Attachment
+      ) as Attachment[],
+    [allNonDuplicateResources]
+  )
+
   const handleResourcesSort = useCallback(
     (resources: CourseResource[]) => {
       resourceEventHandler?.({
@@ -173,12 +202,15 @@ const CourseSectionContainer: FC<SectionProps> = ({
       sectionId: sectionData.id
     })
   }
-
-  const handleAddResources = <T extends CourseResource>(newResources: T[]) => {
+  const handleAddResources = <T extends CourseResource>(
+    newResources: T[],
+    isDuplicate: boolean
+  ) => {
     resourceEventHandler?.({
       type: CourseResourceEventType.AddSectionResources,
       sectionId: sectionData.id,
-      resources: newResources
+      resources: newResources,
+      isDuplicate: isDuplicate
     })
   }
 
@@ -191,6 +223,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
           removeColumnRules={removeLessonColumnRules}
           requestService={ResourceService.getUsersLessons}
           resourceTab={resourcesData.lessons.resourceTab}
+          resources={lessons}
           showCheckboxWithTooltip
         />
       )
@@ -206,6 +239,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
           removeColumnRules={removeQuizColumnRules}
           requestService={ResourceService.getQuizzes}
           resourceTab={resourcesData.quizzes.resourceTab}
+          resources={quizzes}
           showCheckboxWithTooltip
         />
       )
@@ -221,6 +255,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
           removeColumnRules={removeAttachmentColumnRules}
           requestService={ResourceService.getAttachments}
           resourceTab={resourcesData.attachments.resourceTab}
+          resources={attachments}
           showCheckboxWithTooltip
         />
       )

--- a/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
+++ b/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
@@ -164,7 +164,8 @@ const CooperationActivitiesList = () => {
           dispatch(
             addSectionResources({
               sectionId: event.sectionId,
-              resources: event.resources
+              resources: event.resources,
+              isDuplicate: event.isDuplicate
             })
           )
           break

--- a/src/containers/my-resources/add-resource-modal/AddResourceModal.tsx
+++ b/src/containers/my-resources/add-resource-modal/AddResourceModal.tsx
@@ -31,6 +31,7 @@ interface AddResourceModalProps<T>
   }
   selectedRows: T[]
   onAddItems: () => void
+  onCreateResourceCopy?: (value: boolean) => void
   uploadItem?: (data: FormData) => Promise<void>
   resourceTab: ResourcesTabsEnum
   showCheckboxWithTooltip?: boolean
@@ -40,6 +41,7 @@ const AddResourceModal = <T extends TableItem>({
   data,
   selectedRows,
   onAddItems,
+  onCreateResourceCopy,
   uploadItem,
   resourceTab,
   showCheckboxWithTooltip,
@@ -105,8 +107,9 @@ const AddResourceModal = <T extends TableItem>({
                 `myResourcesPage.resourceDuplication.resource.${resourceTab}`
               )
             })}
+            onChecked={onCreateResourceCopy}
             tooltipTitle={t('myResourcesPage.resourceDuplication.tooltip')}
-          ></CheckboxWithTooltip>
+          />
         )}
         <Box sx={styles.buttonsArea}>
           <AppButton onClick={closeModal} variant={ButtonVariantEnum.Tonal}>

--- a/src/hooks/table/use-select.tsx
+++ b/src/hooks/table/use-select.tsx
@@ -16,6 +16,7 @@ interface UseSelectOutput {
     items: Item[]
   ) => (e: ChangeEvent<HTMLInputElement>) => void
   handleSelectClick: (id: string) => void
+  setSelected: (ids: string[]) => void
 }
 
 const useSelect = ({ initialSelect = [] }: UseSelectInput): UseSelectOutput => {
@@ -54,7 +55,8 @@ const useSelect = ({ initialSelect = [] }: UseSelectInput): UseSelectOutput => {
     isSelected,
     clearSelected,
     createSelectAllHandler,
-    handleSelectClick
+    handleSelectClick,
+    setSelected
   }
 }
 

--- a/src/redux/features/cooperationsSlice.ts
+++ b/src/redux/features/cooperationsSlice.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid'
 import { PayloadAction, createSlice } from '@reduxjs/toolkit'
 import { RootState } from '~/redux/store'
 import { sliceNames } from '~/redux/redux.constants'
@@ -112,6 +113,7 @@ const cooperationsSlice = createSlice({
       action: PayloadAction<{
         sectionId: CourseSection['id']
         resources: CourseResource[]
+        isDuplicate?: boolean
       }>
     ) {
       const section = state.sections.find(
@@ -123,10 +125,24 @@ const cooperationsSlice = createSlice({
       const newResources = action.payload.resources
         .filter((resource) => {
           return !section.resources.some(
-            (item) => item.resource._id === resource._id
+            (item) =>
+              item.resource._id === resource._id && !action.payload.isDuplicate
           )
         })
-        .map((resource) => ({ resource, resourceType: resource.resourceType }))
+        .map((resource) => {
+          if (action.payload.isDuplicate) {
+            return {
+              resource: { ...resource, _id: uuidv4() },
+              resourceType: resource.resourceType,
+              isDuplicate: true
+            }
+          }
+
+          return {
+            resource,
+            resourceType: resource.resourceType
+          }
+        })
 
       section.resources = [...section.resources, ...newResources]
     },

--- a/src/types/common/interfaces/common.interfaces.ts
+++ b/src/types/common/interfaces/common.interfaces.ts
@@ -129,6 +129,7 @@ export interface AddSectionResourcesEvent {
   type: CourseResourceEventType.AddSectionResources
   sectionId: string
   resources: CourseResource[]
+  isDuplicate?: boolean
 }
 
 export type ResourceEventHandler = (

--- a/src/types/my-resources/interfaces/myResources.interface.ts
+++ b/src/types/my-resources/interfaces/myResources.interface.ts
@@ -11,6 +11,7 @@ export interface ResourceBase {
   description: string
   resourceType: ResourceType
   availability?: ResourceAvailability
+  isDuplicate?: boolean
 }
 
 export interface Lesson extends CommonEntityFields, ResourceBase {

--- a/tests/unit/components/checkbox-with-tooltip/CheckboxWithTooltip.spec.jsx
+++ b/tests/unit/components/checkbox-with-tooltip/CheckboxWithTooltip.spec.jsx
@@ -3,7 +3,8 @@ import CheckboxWithTooltip from '~/components/checkbox-with-tooltip/CheckboxWith
 
 const props = {
   label: 'Test Checkbox',
-  tooltipTitle: 'Test Tooltip'
+  tooltipTitle: 'Test Tooltip',
+  onChecked: vi.fn()
 }
 
 describe('CheckboxWithTooltip', () => {
@@ -24,5 +25,17 @@ describe('CheckboxWithTooltip', () => {
 
     expect(checkbox).toBeInTheDocument()
     expect(tooltip).toBeInTheDocument()
+  })
+
+  it('calls onChecked callback when checkbox is toggled', () => {
+    const checkbox = screen.getByLabelText(props.label)
+
+    fireEvent.click(checkbox)
+
+    expect(props.onChecked).toHaveBeenCalledWith(true)
+
+    fireEvent.click(checkbox)
+
+    expect(props.onChecked).toHaveBeenCalledWith(false)
   })
 })

--- a/tests/unit/containers/cooperation-details/cooperation-activities/CooperationActivities.spec.jsx
+++ b/tests/unit/containers/cooperation-details/cooperation-activities/CooperationActivities.spec.jsx
@@ -72,7 +72,6 @@ vi.mock('~/components/app-select/AppSelect', () => ({
     <input
       data-testid='mock-AppSelect'
       onChange={(e) => {
-        console.log('e.target.value', e.target.value)
         setValue(JSON.parse(e.target.value))
       }}
       {...props}

--- a/tests/unit/containers/course-section/CourseSectionContainer.spec.constants.js
+++ b/tests/unit/containers/course-section/CourseSectionContainer.spec.constants.js
@@ -1,0 +1,68 @@
+import { ResourcesTypesEnum as ResourceType } from '~/types'
+
+export const mockedSectionData = {
+  id: 1,
+  title: 'Title',
+  description: 'Description',
+  resources: [
+    {
+      resource: {
+        availability: {
+          status: 'open',
+          date: null
+        },
+        _id: '64cd12f1fad091e0sfe12134',
+        title: 'Lesson1',
+        author: 'some author',
+        content: 'Content',
+        description: 'Description',
+        attachments: [],
+        category: null,
+        resourceType: ResourceType.Lesson
+      },
+      resourceType: ResourceType.Lesson
+    },
+    {
+      resource: {
+        availability: {
+          status: 'open',
+          date: null
+        },
+        _id: '64fb2c33eba89699411d22bb',
+        title: 'Quiz',
+        description: '',
+        items: [],
+        author: '648afee884936e09a37deaaa',
+        category: { id: '64fb2c33eba89699411d22bb', name: 'Music' },
+        createdAt: '2023-09-08T14:14:11.373Z',
+        updatedAt: '2023-09-08T14:14:11.373Z',
+        resourceType: ResourceType.Quiz
+      },
+      resourceType: ResourceType.Quiz
+    },
+    {
+      resource: {
+        availability: {
+          status: 'open',
+          date: null
+        },
+        _id: '64cd12f1fad091e0ee719830',
+        author: '6494128829631adbaf5cf615',
+        fileName: 'spanish.pdf',
+        link: 'link',
+        category: { id: '64fb2c33eba89699411d22bb', name: 'History' },
+        description: 'Mock description for attachments',
+        size: 100,
+        createdAt: '2023-07-25T13:12:12.998Z',
+        updatedAt: '2023-07-25T13:12:12.998Z',
+        resourceType: ResourceType.Attachment
+      },
+      resourceType: ResourceType.Attachment
+    }
+  ]
+}
+
+export const mockedUpdatedResources = [
+  { _id: 'resource1', resourceType: 'lesson' },
+  { _id: 'resource2', resourceType: 'quiz' }
+]

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
@@ -1,0 +1,41 @@
+import { ResourcesTypesEnum as ResourceType } from '~/types'
+
+export const mockedCourseData = {
+  title: 'Course title',
+  description: 'Course description',
+  sections: [
+    {
+      title: 'Course section1 title',
+      description: 'Course section1 description',
+      resources: [],
+      id: '17121748017182'
+    }
+  ]
+}
+
+export const mockedSectionsData = [
+  {
+    title: 'Section1',
+    description: 'Section1 description',
+    resources: [
+      {
+        resource: {
+          _id: '66183816fb40f35f91bb77ce',
+          title: 'Lesson 1',
+          description: 'Lesson 1 description',
+          content: 'Lesson 1 content'
+        },
+        resourceType: ResourceType.Lesson
+      }
+    ],
+    id: '17121748017180'
+  },
+  {
+    title: 'Section2 title',
+    description: 'Section2 description',
+    resources: [],
+    id: '17121748017181'
+  }
+]
+
+export const mockedEmptySectionsData = []

--- a/tests/unit/redux/cooperationsSlice.spec.js
+++ b/tests/unit/redux/cooperationsSlice.spec.js
@@ -1,0 +1,144 @@
+import reducer, {
+  setCooperationSections,
+  updateCooperationSection,
+  deleteCooperationSection,
+  addSectionResources,
+  updateResourcesOrder,
+  updateResource,
+  deleteResource,
+  setResourcesAvailability
+} from '~/redux/features/cooperationsSlice'
+
+import { ResourcesAvailabilityEnum } from '~/types'
+
+describe('Test cooperationsSlice', () => {
+  let initialState
+
+  beforeEach(() => {
+    initialState = {
+      sections: [],
+      resourcesAvailability: ResourcesAvailabilityEnum.OpenAll
+    }
+  })
+
+  it('should set sections correctly with setCooperationSections', () => {
+    const sections = [
+      { id: '1', resources: [] },
+      { id: '2', resources: [] }
+    ]
+    const action = setCooperationSections(sections)
+    const state = reducer(initialState, action)
+    expect(state.sections).toEqual(sections)
+  })
+
+  it('should update section correctly with updateCooperationSection', () => {
+    const sectionId = '1'
+    const initialStateWithSections = {
+      ...initialState,
+      sections: [{ id: sectionId, title: 'Initial Title', resources: [] }]
+    }
+    const action = updateCooperationSection({
+      id: sectionId,
+      field: 'title',
+      value: 'Updated Title'
+    })
+    const state = reducer(initialStateWithSections, action)
+    expect(state.sections[0].title).toEqual('Updated Title')
+  })
+
+  it('should delete section correctly with deleteCooperationSection', () => {
+    const sectionId = '1'
+    const initialStateWithSections = {
+      ...initialState,
+      sections: [{ id: sectionId, resources: [] }]
+    }
+    const action = deleteCooperationSection(sectionId)
+    const state = reducer(initialStateWithSections, action)
+    expect(state.sections.length).toBe(0)
+  })
+
+  it('should add resources to section correctly with addSectionResources', () => {
+    const sectionId = '1'
+    const resources = [
+      { _id: 'r1', title: 'Resource 1', resourceType: 'video' }
+    ]
+    const initialStateWithSections = {
+      ...initialState,
+      sections: [{ id: sectionId, resources: [] }]
+    }
+    const action = addSectionResources({ sectionId, resources })
+    const state = reducer(initialStateWithSections, action)
+    expect(state.sections[0].resources).toHaveLength(1)
+    expect(state.sections[0].resources[0].resource).toEqual(resources[0])
+  })
+
+  it('should update resources order correctly with updateResourcesOrder', () => {
+    const sectionId = '1'
+    const initialStateWithSections = {
+      ...initialState,
+      sections: [{ id: sectionId, resources: [{ _id: 'r1' }, { _id: 'r2' }] }]
+    }
+    const newResources = [{ _id: 'r2' }, { _id: 'r1' }]
+    const action = updateResourcesOrder({ sectionId, resources: newResources })
+    const state = reducer(initialStateWithSections, action)
+    expect(state.sections[0].resources[0].resource._id).toEqual('r2')
+  })
+
+  it('should update a resource correctly with updateResource', () => {
+    const sectionId = '1'
+    const resourceId = 'r1'
+    const initialStateWithSections = {
+      ...initialState,
+      sections: [
+        {
+          id: sectionId,
+          resources: [{ resource: { _id: resourceId, title: 'Old Title' } }]
+        }
+      ]
+    }
+    const action = updateResource({
+      sectionId,
+      resourceId,
+      resource: { title: 'New Title' }
+    })
+    const state = reducer(initialStateWithSections, action)
+    expect(state.sections[0].resources[0].resource.title).toEqual('New Title')
+  })
+
+  it('should delete a resource correctly with deleteResource', () => {
+    const sectionId = '1'
+    const resourceId = 'r1'
+    const initialStateWithSections = {
+      ...initialState,
+      sections: [
+        { id: sectionId, resources: [{ resource: { _id: resourceId } }] }
+      ]
+    }
+    const action = deleteResource({ sectionId, resourceId })
+    const state = reducer(initialStateWithSections, action)
+    expect(state.sections[0].resources.length).toBe(0)
+  })
+
+  it('should set resources availability correctly with setResourcesAvailability', () => {
+    const sectionId = '1'
+    const initialStateWithSections = {
+      ...initialState,
+      sections: [
+        {
+          id: sectionId,
+          resources: [
+            { resource: { _id: 'r1', availability: { status: 'Open' } } }
+          ]
+        }
+      ]
+    }
+    const action = setResourcesAvailability(ResourcesAvailabilityEnum.ClosedAll)
+    const state = reducer(initialStateWithSections, action)
+    expect(state.resourcesAvailability).toBe(
+      ResourcesAvailabilityEnum.ClosedAll
+    )
+    expect(state.sections[0].resources[0].resource.availability.status).toBe(
+      'closed'
+    )
+  })
+})


### PR DESCRIPTION
## Added the possibility to add a resource to a `Cooperation` in two ways: by duplicating or linking [ Close #2359 ]
Added the possibility for a user to add a resource **only once as a link** and **multiple times as a copy** of the current resource.

- [x] If the checkbox '`Make a copy of the selected lesson/quiz/attachment`' is **not checked**, the user can add resources that have not been added before as a link:
<img width="1104" alt="Screenshot 2024-08-20 at 15 12 32" src="https://github.com/user-attachments/assets/ed415ad9-654a-4f6f-91b7-1360e9ab7058">

- [x] If the checkbox '`Make a copy of the selected lesson/quiz/attachment`' is **checked**, all resources become available to add, and the user can add a copy of these resources as many times as they want:
<img width="1104" alt="Screenshot 2024-08-20 at 15 12 51" src="https://github.com/user-attachments/assets/bd08e8c7-e78c-46cd-9f6c-1856b74ab004">

- [x] Added `isDuplicate=true` in cooperation redux store when a resource is added **as a copy**. If a resource is added **as a link**, the `isDuplicate` field is omitted:
<img width="1652" alt="Screenshot 2024-08-20 at 15 27 17" src="https://github.com/user-attachments/assets/3187ad2c-2f9b-4d81-951c-c1bafa31f88d">

#### Additionally, I wrote the spec for `cooperationsSlice.ts`: 
<img width="942" alt="Screenshot 2024-08-21 at 00 25 49" src="https://github.com/user-attachments/assets/855e9a3a-4412-4762-a67c-3f7eac50cb7f">

#### Also bumped up code coverage for `CourseSectionContainer.tsx` container:
_Coverage before changes_:
<img width="1293" alt="Screenshot 2024-08-21 at 13 13 31" src="https://github.com/user-attachments/assets/15af7a90-0aa3-4262-a726-3e44870b670f">

_Current Test Coverage:_
<img width="1293" alt="Screenshot 2024-08-21 at 15 40 38" src="https://github.com/user-attachments/assets/c391496e-5da1-44d5-bfb4-f54b45f03430">

