### PR TITLE
Updated icon display based on resource addition method (link vs copy)

### DIFF
--- a/src/components/cooperation-section-view/CooperationSectionView.tsx
+++ b/src/components/cooperation-section-view/CooperationSectionView.tsx
@@ -20,7 +20,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
   id
 }) => {
   const { t } = useTranslation()
-  const [isVisible, setIsVisible] = useState(true)
+  const [isVisible, setIsVisible] = useState<boolean>(true)
 
   const resources = useMemo<undefined | ReactNode[]>(
     () =>
@@ -36,7 +36,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
   )
 
   return (
-    <Box sx={styles.root}>
+    <Box key={id} sx={styles.root}>
       <HeaderTextWithDropdown
         isView
         isVisible={isVisible}
@@ -44,7 +44,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
         setIsVisible={setIsVisible}
       />
       {isVisible && (
-        <Box key={id} sx={styles.showBlock}>
+        <Box sx={styles.showBlock}>
           <AppTextField
             InputProps={styles.descriptionInput}
             fullWidth

--- a/src/components/enhanced-table/EnhancedTable.tsx
+++ b/src/components/enhanced-table/EnhancedTable.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SxProps } from '@mui/material'
@@ -13,8 +14,8 @@ import EnhancedTableRow from '~/components/enhanced-table/enhanced-table-row/Enh
 import FilterRow from '~/components/enhanced-table/filter-row/FilterRow'
 import Loader from '~/components/loader/Loader'
 
-import { spliceSx } from '~/utils/helper-functions'
 import { styles } from '~/components/enhanced-table/EnhancedTable.styles'
+import { spliceSx } from '~/utils/helper-functions'
 import {
   TableColumn,
   TableData,
@@ -29,14 +30,16 @@ export interface EnhancedTableProps<I, F> extends Omit<TableProps, 'style'> {
   columns: TableColumn<I>[]
   isSelection?: boolean
   rowActions?: TableRowAction[]
+  onRowClick?: (item: I) => void
   select?: TableSelect<I>
   filter?: TableFilter<F>
   sort: TableSort
   rowsPerPage?: number
   data: TableData<I>
-  onRowClick?: (item: I) => void
+  disableInitialSelectedRows?: boolean
   emptyTableKey?: string
   selectedRows?: I[]
+  initialSelectedRows?: I[]
   style?: {
     root?: SxProps
     tableContainer?: SxProps
@@ -53,27 +56,46 @@ const EnhancedTable = <I extends TableItem, F = undefined>({
   sort,
   rowsPerPage,
   data,
+  disableInitialSelectedRows = false,
   emptyTableKey = 'table.noExactMatches',
   selectedRows = [],
+  initialSelectedRows = [],
   style = {},
   ...props
 }: EnhancedTableProps<I, F>) => {
   const { t } = useTranslation()
   const { items, loading, getData } = data
 
-  const rows = items.map((item) => (
-    <EnhancedTableRow
-      columns={columns}
-      isSelection={isSelection}
-      item={item}
-      key={item._id}
-      onRowClick={onRowClick}
-      refetchData={getData}
-      rowActions={rowActions}
-      select={select}
-      selectedRows={selectedRows}
-    />
-  ))
+  const rows = useMemo(
+    () =>
+      items.map((item) => (
+        <EnhancedTableRow
+          columns={columns}
+          initialSelectedRows={initialSelectedRows}
+          isDisableRow={disableInitialSelectedRows}
+          isSelection={isSelection}
+          item={item}
+          key={item._id}
+          onRowClick={onRowClick}
+          refetchData={getData}
+          rowActions={rowActions}
+          select={select}
+          selectedRows={selectedRows}
+        />
+      )),
+    [
+      items,
+      columns,
+      initialSelectedRows,
+      disableInitialSelectedRows,
+      isSelection,
+      onRowClick,
+      getData,
+      rowActions,
+      select,
+      selectedRows
+    ]
+  )
 
   const tableBody = (
     <TableContainer

--- a/src/components/enhanced-table/enhanced-table-row/EnhancedTableRow.styles.ts
+++ b/src/components/enhanced-table/enhanced-table-row/EnhancedTableRow.styles.ts
@@ -1,11 +1,15 @@
 import palette from '~/styles/app-theme/app.pallete'
 
 export const styles = {
-  row: (isSelected: boolean, isRowOnClick = false) => ({
+  row: (isSelected: boolean, isRowOnClick = false, isDisableRow = false) => ({
     ...(isRowOnClick && { cursor: 'pointer' }),
     ...(isSelected && { background: palette.basic.grey }),
     '&:hover .addCategory': {
       visibility: 'visible'
-    }
+    },
+    ...(isDisableRow && {
+      pointerEvents: 'none',
+      opacity: 0.5
+    })
   })
 }

--- a/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
+++ b/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
@@ -29,13 +29,13 @@ const CooperationActivitiesView: FC<CooperationActivitiesViewProps> = ({
 
   const onEdit = () => {
     setEditMode(true)
-    dispatch(setIsAddedClicked(false))
+    dispatch(setIsAddedClicked(false)) // Why is this needed?
   }
 
   return (
     <Box sx={styles.root}>
       {sections.map((item) => (
-        <CooperationSectionView id={item._id} item={item} key={item._id} />
+        <CooperationSectionView id={item.id} item={item} key={item.id} />
       ))}
 
       {isTutor && (

--- a/src/containers/course-section/resource-item/ResourceItem.styles.ts
+++ b/src/containers/course-section/resource-item/ResourceItem.styles.ts
@@ -41,5 +41,9 @@ export const styles = {
   },
   editBtn: {
     color: palette.basic.blueGray
+  },
+  linkBtn: {
+    color: palette.basic.blueGray,
+    transform: 'rotate(315deg)'
   }
 }

--- a/src/containers/course-section/resource-item/ResourceItem.tsx
+++ b/src/containers/course-section/resource-item/ResourceItem.tsx
@@ -6,6 +6,7 @@ import TextField from '@mui/material/TextField'
 import IconButton from '@mui/material/IconButton'
 import CloseIcon from '@mui/icons-material/Close'
 import EditIcon from '@mui/icons-material/Edit'
+import LinkRoundedIcon from '@mui/icons-material/LinkRounded'
 import { DatePicker } from '@mui/x-date-pickers/DatePicker'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
@@ -52,15 +53,19 @@ const ResourceItem: FC<ResourceItemProps> = ({
 }) => {
   const { t } = useTranslation()
 
-  const handleDeleteResource = () => {
+  const handleDeleteResource = useCallback(() => {
     deleteResource?.(resource)
-  }
+  }, [deleteResource, resource])
 
-  const handleEditResource = () => {
+  const handleEditResource = useCallback(() => {
     editResource?.(resource)
-  }
+  }, [editResource, resource])
 
-  const renderResourceIcon = () => {
+  const handleLinkResource = useCallback(() => {
+    editResource?.(resource)
+  }, [editResource, resource])
+
+  const renderResourceIcon = useCallback(() => {
     const { Lesson, Quiz } = ResourceType
 
     const type = resourceType || resource.resourceType
@@ -73,27 +78,29 @@ const ResourceItem: FC<ResourceItemProps> = ({
       default:
         return null
     }
-  }
+  }, [resourceType, resource.resourceType])
 
   const resourceAvailability = resource.availability
-
   const resourceAvailabilityStatus =
     resourceAvailability?.status ?? ResourceAvailabilityStatusEnum.Open
 
   const shouldShowDatePicker =
     resourceAvailabilityStatus === ResourceAvailabilityStatusEnum.OpenFrom
 
-  const setOpenFromDate = (date: Date | null) => {
-    updateAvailability?.(resource, {
-      status: resourceAvailabilityStatus,
-      date: date?.toISOString() ?? null
-    })
-  }
+  const setOpenFromDate = useCallback(
+    (date: Date | null) => {
+      updateAvailability?.(resource, {
+        status: resourceAvailabilityStatus,
+        date: date?.toISOString() ?? null
+      })
+    },
+    [resource, resourceAvailabilityStatus, updateAvailability]
+  )
 
   const setAvailabilityStatus = useCallback(
     (status: ResourceAvailabilityStatusEnum) => {
       updateAvailability?.(resource, {
-        status: status,
+        status,
         date: null
       })
     },
@@ -130,7 +137,7 @@ const ResourceItem: FC<ResourceItemProps> = ({
       )}
       <AppSelect
         fields={selectionFields}
-        setValue={(value) => setAvailabilityStatus(value)}
+        setValue={setAvailabilityStatus}
         sx={styles.availabilitySelect}
         value={resourceAvailabilityStatus}
       />
@@ -145,9 +152,15 @@ const ResourceItem: FC<ResourceItemProps> = ({
   ) : (
     <Box sx={styles.resourceActions}>
       {isCooperation && availabilitySelection}
-      <IconButton aria-label='edit' onClick={handleEditResource}>
-        <EditIcon fontSize={SizeEnum.Small} sx={styles.editBtn} />
-      </IconButton>
+      {resource.isDuplicate ? (
+        <IconButton aria-label='edit' onClick={handleEditResource}>
+          <EditIcon fontSize={SizeEnum.Small} sx={styles.editBtn} />
+        </IconButton>
+      ) : (
+        <IconButton aria-label='link' onClick={handleLinkResource}>
+          <LinkRoundedIcon fontSize={SizeEnum.Small} sx={styles.linkBtn} />
+        </IconButton>
+      )}
       <IconButton aria-label='delete' onClick={handleDeleteResource}>
         <CloseIcon fontSize={SizeEnum.Small} />
       </IconButton>

--- a/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
+++ b/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
@@ -31,16 +31,10 @@ import {
 import { useAppSelector, useAppDispatch } from '~/hooks/use-redux'
 
 const CooperationActivitiesList = () => {
-  const {
-    selectedCourse,
-    isAddedClicked,
-    currentSectionIndex,
-    isNewActivity,
-    sections
-  } = useAppSelector(cooperationsSelector)
+  const { selectedCourse, isAddedClicked, isNewActivity, sections } =
+    useAppSelector(cooperationsSelector)
 
   const dispatch = useAppDispatch()
-  const Id = uuidv4()
 
   // This logic looks very complicated and seems that it doesn't work
   // Why do we need to store some flags for user actions?
@@ -53,7 +47,7 @@ const CooperationActivitiesList = () => {
     if (selectedCourse && !sections.length && isAddedClicked) {
       const allSections = selectedCourse.sections.map((section) => ({
         ...section,
-        id: Id
+        id: uuidv4()
       }))
       setSectionsData(allSections)
     }
@@ -62,7 +56,7 @@ const CooperationActivitiesList = () => {
       const addNewSectionsCourse = (index: number | undefined = undefined) => {
         const newSectionData = selectedCourse.sections.map((section) => ({
           ...section,
-          id: Id
+          id: uuidv4()
         }))
         let newSections
         if (index !== undefined) {
@@ -76,7 +70,7 @@ const CooperationActivitiesList = () => {
         }
         setSectionsData(newSections)
       }
-      addNewSectionsCourse(currentSectionIndex)
+      addNewSectionsCourse(0) // this is a mock and will always insert at the 0 position, but it will change in issue #2064
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAddedClicked])
@@ -106,7 +100,7 @@ const CooperationActivitiesList = () => {
     (index: number | undefined = undefined) => {
       // This logic should be moved to the reducer
       const newSectionData = { ...initialCooperationSectionData }
-      newSectionData.id = Date.now().toString()
+      newSectionData.id = uuidv4()
       const newSections = [...sections]
       newSections.splice(index ?? sections.length, 0, newSectionData)
 

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -48,14 +48,14 @@ import {
 const CooperationDetails = () => {
   const { t } = useTranslation()
   const { id } = useParams()
-  const { isActivityCreated } = useAppSelector(cooperationsSelector)
+  const { isActivityCreated } = useAppSelector(cooperationsSelector) // Why is this needed?
   const navigate = useNavigate()
   const { isDesktop } = useBreakpoints()
   const [activeTab, setActiveTab] = useState<CooperationTabsEnum>(
     CooperationTabsEnum.Activities
   )
-  const [isNotesOpen, setIsNotesOpen] = useState(false)
-  const [editMode, setEditMode] = useState(false)
+  const [isNotesOpen, setIsNotesOpen] = useState<boolean>(false)
+  const [editMode, setEditMode] = useState<boolean>(false)
   const dispatch = useAppDispatch()
 
   const responseError = useCallback(

--- a/src/pages/create-course/CreateCourse.tsx
+++ b/src/pages/create-course/CreateCourse.tsx
@@ -161,7 +161,7 @@ const CreateCourse = () => {
 
   const addNewSection = useCallback(() => {
     const newSectionData = { ...sectionInitialData }
-    newSectionData.id = Date.now().toString()
+    newSectionData.id = uuidv4()
     setSectionsData([...data.sections, newSectionData])
   }, [data.sections, setSectionsData])
 

--- a/src/pages/create-course/CreateCourse.tsx
+++ b/src/pages/create-course/CreateCourse.tsx
@@ -217,9 +217,10 @@ const CreateCourse = () => {
         })
         .map((resource) => {
           return {
-            resource: isDuplicate ? { ...resource, _id: uuidv4() } : resource,
-            resourceType: resource.resourceType,
-            ...(isDuplicate && { isDuplicate: true })
+            resource: isDuplicate
+              ? { ...resource, _id: uuidv4(), isDuplicate: true }
+              : resource,
+            resourceType: resource.resourceType
           }
         })
 

--- a/src/redux/features/cooperationsSlice.ts
+++ b/src/redux/features/cooperationsSlice.ts
@@ -131,9 +131,10 @@ const cooperationsSlice = createSlice({
         })
         .map((resource) => {
           return {
-            resource: isDuplicate ? { ...resource, _id: uuidv4() } : resource,
-            resourceType: resource.resourceType,
-            ...(isDuplicate && { isDuplicate: true })
+            resource: isDuplicate
+              ? { ...resource, _id: uuidv4(), isDuplicate: true }
+              : resource,
+            resourceType: resource.resourceType
           }
         })
 

--- a/src/redux/features/cooperationsSlice.ts
+++ b/src/redux/features/cooperationsSlice.ts
@@ -16,7 +16,6 @@ interface CooperationsState {
   isActivityCreated: boolean // delete it
   isAddedClicked: boolean // delete it
   isNewActivity: boolean // delete it
-  currentSectionIndex?: number // delete it
   sections: CourseSection[]
   resourcesAvailability: ResourcesAvailabilityEnum
 }
@@ -26,7 +25,6 @@ const initialState: CooperationsState = {
   isActivityCreated: false, // delete it
   isAddedClicked: false, // delete it
   isNewActivity: false, // delete it
-  currentSectionIndex: 0, // delete it
   sections: [],
   resourcesAvailability: ResourcesAvailabilityEnum.OpenAll
 }
@@ -63,13 +61,6 @@ const cooperationsSlice = createSlice({
     ) {
       state.isNewActivity = action.payload
     },
-    setCurrentSectionIndex(
-      // delete it
-      state,
-      action: PayloadAction<CooperationsState['currentSectionIndex']>
-    ) {
-      state.currentSectionIndex = action.payload
-    },
 
     setCooperationSections(
       state,
@@ -78,6 +69,7 @@ const cooperationsSlice = createSlice({
       // state.sections = action.payload if courses will be fixed
       state.sections = (action.payload ?? []).map((section) => ({
         ...section,
+        id: section._id ?? uuidv4(),
         resources: section.resources ?? []
       }))
     },
@@ -233,7 +225,6 @@ export const {
   setIsActivityCreated,
   setIsAddedClicked,
   setIsNewActivity,
-  setCurrentSectionIndex,
   setCooperationSections,
   updateCooperationSection,
   deleteCooperationSection,

--- a/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
+++ b/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
@@ -13,8 +13,8 @@ vi.mock('~/components/cooperation-section-view/CooperationSectionView', () => ({
 vi.mock('~/hooks/use-redux', () => ({
   useAppSelector: vi.fn().mockReturnValue({
     sections: [
-      { _id: '1', title: 'Section1' },
-      { _id: '2', title: 'Section2' }
+      { id: '1', title: 'Section1' },
+      { id: '2', title: 'Section2' }
     ],
     userRole: UserRoleEnum.Tutor
   }),

--- a/tests/unit/containers/course-section/CourseSectionContainer.spec.constants.js
+++ b/tests/unit/containers/course-section/CourseSectionContainer.spec.constants.js
@@ -63,6 +63,6 @@ export const mockedSectionData = {
 }
 
 export const mockedUpdatedResources = [
-  { _id: 'resource1', resourceType: 'lesson' },
-  { _id: 'resource2', resourceType: 'quiz' }
+  { _id: 'resource1', resourceType: ResourceType.Lesson },
+  { _id: 'resource2', resourceType: ResourceType.Quiz }
 ]

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants.js
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants.js
@@ -1,0 +1,51 @@
+import { ResourcesTypesEnum as ResourceType } from '~/types'
+
+export const mockedLessonDataOriginal = {
+  _id: '66b67d84b58ba31be667ee2d',
+  author: '6658f73f93885febb491e08b',
+  title: 'Exploring Systems of Linear Equations',
+  description:
+    'Students will learn to solve systems of linear equations using different methods, including graphing, substitution, and elimination.',
+  content: '<h4>Lesson Plan:</h4>',
+  attachments: [],
+  category: '6684175179e5232bce4579ed',
+  resourceType: ResourceType.Lesson,
+  availability: null
+}
+
+export const mockedQuizDataDuplicate = {
+  _id: '66b67e2ab58ba31be667ee4c',
+  title: 'Quiz: Basics of Multiplication',
+  description:
+    'A quiz to test the understanding of basic multiplication concepts.',
+  items: ['66b67e02b58ba31be667ee43'],
+  author: '6658f73f93885febb491e08b',
+  category: '6684175179e5232bce4579ed',
+  resourceType: ResourceType.Quiz,
+  settings: {
+    view: 'Scroll',
+    shuffle: false,
+    pointValues: false,
+    scoredResponses: false,
+    correctAnswers: false
+  },
+  availability: {
+    status: 'openFrom',
+    date: '2022-05-01T00:00:00.000Z'
+  },
+  isDuplicate: true
+}
+
+export const mockedAttachmentDataOriginal = {
+  _id: '66b67eafb58ba31be667ee83',
+  author: '6658f73f93885febb491e08b',
+  fileName: 'Exploring Systems of Linear Equations.png',
+  link: '1723236050559-Exploring Systems of Linear Equations.png',
+  size: 39340,
+  category: '6684175179e5232bce4579ed',
+  resourceType: ResourceType.Attachment,
+  availability: {
+    status: 'open',
+    date: null
+  }
+}

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -1,40 +1,65 @@
 import { renderWithProviders } from '~tests/test-utils'
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+
+import {
+  mockedLessonDataOriginal,
+  mockedQuizDataDuplicate,
+  mockedAttachmentDataOriginal
+} from '~tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants'
 
 import ResourceItem from '~/containers/course-section/resource-item/ResourceItem'
-import { ResourcesTypesEnum as ResourceType } from '~/types'
 
-const mockedLessonData = {
-  _id: '1',
-  title: 'Lesson1',
-  author: 'some author',
-  content: 'Content',
-  description: 'Description',
-  attachments: [],
-  category: null,
-  resourceType: ResourceType.Lesson
-}
+const mockDeleteResource = vi.fn()
+const mockEditResource = vi.fn()
+const mockUpdateAvailability = vi.fn()
 
-const mockedSetResourceAvailability = vi.fn()
+vi.mock('@mui/x-date-pickers/LocalizationProvider', async () => {
+  const actual = await vi.importActual(
+    '@mui/x-date-pickers/LocalizationProvider'
+  )
+  return {
+    ...actual,
+    LocalizationProvider: ({ children }) => (
+      <div data-testid='mock-LocalizationProvider'>{children}</div>
+    )
+  }
+})
 
-const mockedDeleteFunc = vi.fn()
-const mockedEditFunc = vi.fn()
+vi.mock('@mui/x-date-pickers/DatePicker', () => ({
+  __esModule: true,
+  DatePicker: ({ onChange }) => (
+    <input
+      data-testid='mock-DatePicker'
+      onChange={(e) => {
+        const newDate = new Date(e.target.value)
+        onChange(newDate)
+      }}
+      type='date'
+    />
+  )
+}))
 
-describe('new course section ResourceItem tests', () => {
+describe('ResourceItem tests', () => {
   beforeEach(() => {
     renderWithProviders(
       <ResourceItem
-        deleteResource={mockedDeleteFunc}
-        editResource={mockedEditFunc}
-        resource={mockedLessonData}
-        setResourceAvailability={mockedSetResourceAvailability}
+        deleteResource={mockDeleteResource}
+        editResource={mockEditResource}
+        isCooperation
+        resource={mockedLessonDataOriginal}
+        updateAvailability={mockUpdateAvailability}
       />
     )
   })
 
   it('should render added resource', () => {
-    const resourceTitle = screen.getByText(mockedLessonData.title)
+    const resourceTitle = screen.getByText(mockedLessonDataOriginal.title)
+    const resourceDescription = screen.getByText(
+      mockedLessonDataOriginal.description
+    )
+
     expect(resourceTitle).toBeInTheDocument()
+    expect(resourceDescription).toBeInTheDocument()
   })
 
   it('should display lesson icon', () => {
@@ -47,7 +72,135 @@ describe('new course section ResourceItem tests', () => {
 
     fireEvent.click(deleteButton)
 
-    expect(mockedDeleteFunc).toHaveBeenCalledTimes(1)
+    expect(mockDeleteResource).toHaveBeenCalledTimes(1)
+  })
+
+  it('should call link resource function', () => {
+    const linkButton = screen.getByLabelText('link')
+    const iconLink = screen.getByTestId('LinkRoundedIcon')
+
+    fireEvent.click(linkButton)
+
+    expect(iconLink).toBeInTheDocument()
+    expect(mockEditResource).toHaveBeenCalledTimes(1)
+  })
+
+  it('should set resourceAvailabilityStatus to Open when resourceAvailability is null or undefined', () => {
+    const availabilityIcon = screen.getByRole('img', {
+      src: '/src/assets/img/cooperation-details/resource-availability/open-icon.svg'
+    })
+    expect(availabilityIcon).toBeInTheDocument()
+  })
+})
+
+describe('ResourceItem tests with isView prop', () => {
+  beforeEach(() => {
+    renderWithProviders(
+      <ResourceItem
+        deleteResource={mockDeleteResource}
+        editResource={mockEditResource}
+        isView
+        resource={mockedLessonDataOriginal}
+        updateAvailability={mockUpdateAvailability}
+      />
+    )
+  })
+
+  it('should render availability icon', () => {
+    const availabilityIcon = screen.getByRole('img', {
+      name: /resource icon/i
+    })
+    expect(availabilityIcon).toBeInTheDocument()
+  })
+
+  it('should not render link and delete icon', () => {
+    expect(screen.queryByLabelText('delete')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('link')).not.toBeInTheDocument()
+  })
+
+  it('should properly render availability status and icon', () => {
+    const option = screen.getByRole('img', {
+      src: '/src/assets/img/cooperation-details/resource-availability/open-icon.svg'
+    })
+
+    expect(option).toBeInTheDocument()
+  })
+})
+
+describe('ResourceItem tests with isCooperation prop', () => {
+  beforeEach(() => {
+    renderWithProviders(
+      <ResourceItem
+        deleteResource={mockDeleteResource}
+        editResource={mockEditResource}
+        isCooperation
+        resource={mockedQuizDataDuplicate}
+        updateAvailability={mockUpdateAvailability}
+      />
+    )
+  })
+
+  it('should render availability selection', () => {
+    const availabilitySelection = screen.getByTestId('ArrowDropDownIcon')
+    expect(availabilitySelection).toBeInTheDocument()
+  })
+
+  it('should properly render availability status and icon', () => {
+    const availabilitySelect = screen.getByTestId('app-select')
+    const option = screen.getByRole('img', {
+      src: '/src/assets/img/cooperation-details/resource-availability/open-icon.svg'
+    })
+
+    expect(availabilitySelect).toBeInTheDocument()
+    expect(option).toBeInTheDocument()
+    expect(availabilitySelect.value).toBe('openFrom')
+  })
+
+  it('should call setOpenFromDate when DatePicker value changes', async () => {
+    const datePickerInput = screen.getByTestId('mock-DatePicker')
+    fireEvent.change(datePickerInput, { target: { value: '2025-08-16' } })
+
+    await waitFor(() => {
+      expect(mockUpdateAvailability).toHaveBeenCalledWith(
+        mockedQuizDataDuplicate,
+        expect.objectContaining({
+          status: 'openFrom',
+          date: '2025-08-16T00:00:00.000Z'
+        })
+      )
+    })
+  })
+
+  it('should call updateAvailability when availability status changes', () => {
+    const availabilitySelect = screen.getByTestId('app-select')
+    fireEvent.change(availabilitySelect, { target: { value: 'open' } })
+
+    expect(mockUpdateAvailability).toHaveBeenCalledWith(
+      mockedQuizDataDuplicate,
+      expect.objectContaining({
+        status: 'open',
+        date: null
+      })
+    )
+  })
+})
+
+describe('ResourceItem tests when isDuplicate=true and resourceType quiz', () => {
+  beforeEach(() => {
+    renderWithProviders(
+      <ResourceItem
+        deleteResource={mockDeleteResource}
+        editResource={mockEditResource}
+        resource={mockedQuizDataDuplicate}
+        updateAvailability={mockUpdateAvailability}
+      />
+    )
+  })
+
+  it('should display quiz icon', () => {
+    const quizIcon = screen.getByTestId('NoteAltOutlinedIcon')
+
+    expect(quizIcon).toBeInTheDocument()
   })
 
   it('should call edit resource function', () => {
@@ -55,24 +208,25 @@ describe('new course section ResourceItem tests', () => {
 
     fireEvent.click(editButton)
 
-    expect(mockedEditFunc).toHaveBeenCalledTimes(1)
+    expect(mockEditResource).toHaveBeenCalledTimes(2)
   })
 })
 
-describe('should render quiz component', () => {
-  it('should display quiz icon', () => {
-    mockedLessonData.resourceType = ResourceType.Quiz
-
+describe('ResourceItem tests when resourceType attachment', () => {
+  beforeEach(() => {
     renderWithProviders(
       <ResourceItem
-        resource={mockedLessonData}
-        setItemToDelete={mockedDeleteFunc}
-        setResourceAvailability={mockedSetResourceAvailability}
+        deleteResource={mockDeleteResource}
+        editResource={mockEditResource}
+        resource={mockedAttachmentDataOriginal}
+        updateAvailability={mockUpdateAvailability}
       />
     )
+  })
 
-    const quizIcon = screen.getByTestId('NoteAltOutlinedIcon')
+  it('should properly display attachment', () => {
+    const attachmentItem = screen.getByText('png')
 
-    expect(quizIcon).toBeInTheDocument()
+    expect(attachmentItem).toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
+++ b/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
@@ -209,7 +209,7 @@ describe('CourseSectionsList tests', () => {
     const addModuleButton = screen.getAllByTestId('Crop75Icon')[itemIndex]
     waitFor(() => fireEvent.click(addModuleButton))
     expect(mockedSectionEventHandler).toHaveBeenCalledWith({
-      index: -1,
+      index: 1,
       type: 'sectionAdded'
     })
   })

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
@@ -1,5 +1,15 @@
 import { ResourcesTypesEnum as ResourceType } from '~/types'
 
+export const mockedEmptySectionsData = []
+
+export const mockedNewEmptySectionsData = [
+  {
+    title: '',
+    description: '',
+    resources: []
+  }
+]
+
 export const mockedCourseData = {
   title: 'Course title',
   description: 'Course description',
@@ -37,5 +47,3 @@ export const mockedSectionsData = [
     id: '17121748017181'
   }
 ]
-
-export const mockedEmptySectionsData = []

--- a/tests/unit/pages/create-course/CreateCourse.spec.constants.js
+++ b/tests/unit/pages/create-course/CreateCourse.spec.constants.js
@@ -1,3 +1,5 @@
+import { ResourcesTypesEnum as ResourceType } from '~/types'
+
 export const mockCategoriesNames = [
   { _id: '64884f33fdc2d1a130c24ac2', name: 'Mathematic' },
   { _id: '660c27618a9fbf234b8bb4cd', name: 'Music' }
@@ -16,7 +18,7 @@ export const mockNewSectionResource = {
   content: '<h4>Lesson New Plan:</h4>',
   attachments: [],
   category: '64884f33fdc2d1a130c24ac2',
-  resourceType: 'lesson'
+  resourceType: ResourceType.Lesson
 }
 
 export const mockUpdatedSectionResource = {
@@ -27,7 +29,7 @@ export const mockUpdatedSectionResource = {
   content: '<h4>Lesson Updated Plan:</h4>',
   attachments: [],
   category: '64884f33fdc2d1a130c24ac2',
-  resourceType: 'lesson'
+  resourceType: ResourceType.Lesson
 }
 
 export const mockCourseResponseData = {
@@ -55,13 +57,13 @@ export const mockCourseResponseData = {
             content: '<h4>Lesson Plan:</h4>',
             attachments: [],
             category: '6684175179e5232bce4579ed',
-            resourceType: 'lesson',
+            resourceType: ResourceType.Lesson,
             availability: {
               status: 'open',
               date: null
             }
           },
-          resourceType: 'lesson'
+          resourceType: ResourceType.Lesson
         },
         {
           resource: {
@@ -72,7 +74,7 @@ export const mockCourseResponseData = {
             items: ['66b67e02b58ba31be667ee43'],
             author: '6658f73f93885febb491e08b',
             category: '6684175179e5232bce4579ed',
-            resourceType: 'quiz',
+            resourceType: ResourceType.Quiz,
             availability: {
               status: 'open',
               date: null
@@ -85,7 +87,7 @@ export const mockCourseResponseData = {
               correctAnswers: false
             }
           },
-          resourceType: 'quiz'
+          resourceType: ResourceType.Quiz
         },
         {
           resource: {
@@ -95,13 +97,13 @@ export const mockCourseResponseData = {
             link: '1723236050559-Exploring Systems of Linear Equations.png',
             size: 39340,
             category: '6684175179e5232bce4579ed',
-            resourceType: 'attachment',
+            resourceType: ResourceType.Attachment,
             availability: {
               status: 'open',
               date: null
             }
           },
-          resourceType: 'attachment'
+          resourceType: ResourceType.Attachment
         }
       ],
       id: '66b6862cb58ba31be667f1a7'
@@ -134,13 +136,13 @@ export const mockNewCourseData = {
             content: '<h4>Lesson Plan:</h4>',
             attachments: [],
             category: '6684175179e5232bce4579ed',
-            resourceType: 'lesson',
+            resourceType: ResourceType.Lesson,
             availability: {
               status: 'open',
               date: null
             }
           },
-          resourceType: 'lesson'
+          resourceType: ResourceType.Lesson
         },
         {
           resource: {
@@ -151,7 +153,7 @@ export const mockNewCourseData = {
             items: ['66b67e02b58ba31be667ee43'],
             author: '6658f73f93885febb491e08b',
             category: '6684175179e5232bce4579ed',
-            resourceType: 'quiz',
+            resourceType: ResourceType.Quiz,
             availability: {
               status: 'open',
               date: null
@@ -164,7 +166,7 @@ export const mockNewCourseData = {
               correctAnswers: false
             }
           },
-          resourceType: 'quiz'
+          resourceType: ResourceType.Quiz
         },
         {
           resource: {
@@ -174,13 +176,13 @@ export const mockNewCourseData = {
             link: '1723236050559-Multiplication Tables Chart.png',
             size: 39340,
             category: '6684175179e5232bce4579ed',
-            resourceType: 'attachment',
+            resourceType: ResourceType.Attachment,
             availability: {
               status: 'open',
               date: null
             }
           },
-          resourceType: 'attachment'
+          resourceType: ResourceType.Attachment
         }
       ],
       id: '66b6862cb58ba31be667f1a7'

--- a/tests/unit/pages/create-course/CreateCourse.spec.jsx
+++ b/tests/unit/pages/create-course/CreateCourse.spec.jsx
@@ -481,10 +481,10 @@ describe('Testing CreateCourse Event Handlers', () => {
             expect.objectContaining({
               resource: expect.objectContaining({
                 _id: expect.any(String),
-                title: mockNewSectionResource.title
+                title: mockNewSectionResource.title,
+                isDuplicate: true
               }),
-              resourceType: mockNewSectionResource.resourceType,
-              isDuplicate: true
+              resourceType: mockNewSectionResource.resourceType
             })
           ])
         })

--- a/tests/unit/pages/create-or-edit-lesson/CreateOrEditLesson.spec.jsx
+++ b/tests/unit/pages/create-or-edit-lesson/CreateOrEditLesson.spec.jsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 
+import { ResourcesTypesEnum as ResourceType } from '~/types'
 import {
   mockAxiosClient,
   renderWithProviders,
@@ -8,12 +9,13 @@ import {
 import { URLs } from '~/constants/request'
 import { createUrlPath } from '~/utils/helper-functions'
 import { authRoutes } from '~/router/constants/authRoutes'
+
 import CreateOrEditLesson from '~/pages/create-or-edit-lesson/CreateOrEditLesson'
 
 const mockNavigate = vi.fn()
 const mockedCategory = { _id: 'categoryId', name: 'categoryName' }
 
-const mockedAttachement = {
+const mockedAttachment = {
   availability: {
     status: 'open',
     date: null
@@ -24,14 +26,14 @@ const mockedAttachement = {
   link: '1722535882408-test.pdf',
   size: 15069,
   category: null,
-  resourceType: 'attachments',
+  resourceType: ResourceType.Attachment,
   createdAt: '2024-08-01T18:11:23.042Z',
   updatedAt: '2024-08-01T18:11:23.042Z'
 }
 
-const mockedAttachementsResponse = {
+const mockedAttachmentsResponse = {
   count: 1,
-  items: [mockedAttachement]
+  items: [mockedAttachment]
 }
 
 vi.mock('react-router-dom', async () => ({
@@ -43,7 +45,7 @@ describe('CreateOrEditLesson component test', () => {
   beforeAll(() => {
     mockAxiosClient
       .onGet(URLs.resources.attachments.get)
-      .reply(200, mockedAttachementsResponse)
+      .reply(200, mockedAttachmentsResponse)
 
     mockAxiosClient
       .onGet(URLs.resources.resourcesCategories.getNames)
@@ -139,19 +141,19 @@ describe('CreateOrEditLesson component test', () => {
   it('should add an attachment', async () => {
     mockAxiosClient
       .onGet(URLs.resources.attachments.get)
-      .reply(200, mockedAttachementsResponse)
+      .reply(200, mockedAttachmentsResponse)
     const attachmentsBtn = screen.getByRole('button', {
       name: 'lesson.labels.attachments'
     })
     fireEvent.click(attachmentsBtn)
 
-    const attachment = await screen.findByText(mockedAttachement.fileName)
+    const attachment = await screen.findByText(mockedAttachment.fileName)
     fireEvent.click(attachment)
 
     const addBtn = screen.getByText('common.add')
     fireEvent.click(addBtn)
 
-    const addedAttachment = screen.getByText(mockedAttachement.fileName)
+    const addedAttachment = screen.getByText(mockedAttachment.fileName)
 
     expect(addedAttachment).toBeInTheDocument()
   })
@@ -159,25 +161,25 @@ describe('CreateOrEditLesson component test', () => {
   it('should remove an attachment', async () => {
     mockAxiosClient
       .onGet(URLs.resources.attachments.get)
-      .reply(200, mockedAttachementsResponse)
+      .reply(200, mockedAttachmentsResponse)
     const attachmentsBtn = screen.getByRole('button', {
       name: 'lesson.labels.attachments'
     })
     fireEvent.click(attachmentsBtn)
 
-    const attachment = await screen.findByText(mockedAttachement.fileName)
+    const attachment = await screen.findByText(mockedAttachment.fileName)
     fireEvent.click(attachment)
 
     const addBtn = screen.getByText('common.add')
     fireEvent.click(addBtn)
 
-    let addedAttachment = screen.getByText(mockedAttachement.fileName)
+    let addedAttachment = screen.getByText(mockedAttachment.fileName)
     expect(addedAttachment).toBeInTheDocument()
 
     const removeAttachmentBtn = screen.getByTestId('CloseIcon')
     fireEvent.click(removeAttachmentBtn)
 
-    addedAttachment = screen.queryByText(mockedAttachement.fileName)
+    addedAttachment = screen.queryByText(mockedAttachment.fileName)
     expect(addedAttachment).not.toBeInTheDocument()
   })
 

--- a/tests/unit/redux/cooperationsSlice.spec.js
+++ b/tests/unit/redux/cooperationsSlice.spec.js
@@ -23,8 +23,8 @@ describe('Test cooperationsSlice', () => {
 
   it('should set sections correctly with setCooperationSections', () => {
     const sections = [
-      { id: '1', resources: [] },
-      { id: '2', resources: [] }
+      { _id: '1', id: '1', resources: [] },
+      { _id: '2', id: '2', resources: [] }
     ]
     const action = setCooperationSections(sections)
     const state = reducer(initialState, action)


### PR DESCRIPTION
## Updated icon display for resources added via Link & Duplicate Copy [ Close #2370 ]
- [x] Updated the icon display logic to distinguish between resources added as links and those added as duplicate copies
- [x] Implemented the design requirements from Figma: [ Figma Requirements](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=13198-77097&t=aGHxWhCi8SY556qb-4)
<img width="1205" alt="Screenshot 2024-08-21 at 22 05 46" src="https://github.com/user-attachments/assets/48d8a755-32cf-4fe8-b25e-38f9c96e0d79">

#### Additionally, I rewrote the spec for `ResourceItem.tsx` container to up the coverage: 
_Coverage before changes_:
<img width="1263" alt="Screenshot 2024-08-21 at 22 10 14" src="https://github.com/user-attachments/assets/047f292c-183e-4da9-878e-5ebbaef0656f">

_Current Test Coverage:_
<img width="1269" alt="Screenshot 2024-08-22 at 01 04 38" src="https://github.com/user-attachments/assets/a3434d35-66ef-46b5-aaf2-652b677b85e0">

