### PR TITLE
Disabled already linked resources in Course/Cooperation in choose resources modals

### DIFF
--- a/src/components/cooperation-section-view/CooperationSectionView.tsx
+++ b/src/components/cooperation-section-view/CooperationSectionView.tsx
@@ -20,7 +20,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
   id
 }) => {
   const { t } = useTranslation()
-  const [isVisible, setIsVisible] = useState(true)
+  const [isVisible, setIsVisible] = useState<boolean>(true)
 
   const resources = useMemo<undefined | ReactNode[]>(
     () =>
@@ -36,7 +36,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
   )
 
   return (
-    <Box sx={styles.root}>
+    <Box key={id} sx={styles.root}>
       <HeaderTextWithDropdown
         isView
         isVisible={isVisible}
@@ -44,7 +44,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
         setIsVisible={setIsVisible}
       />
       {isVisible && (
-        <Box key={id} sx={styles.showBlock}>
+        <Box sx={styles.showBlock}>
           <AppTextField
             InputProps={styles.descriptionInput}
             fullWidth

--- a/src/components/enhanced-table/EnhancedTable.tsx
+++ b/src/components/enhanced-table/EnhancedTable.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SxProps } from '@mui/material'
@@ -13,8 +14,8 @@ import EnhancedTableRow from '~/components/enhanced-table/enhanced-table-row/Enh
 import FilterRow from '~/components/enhanced-table/filter-row/FilterRow'
 import Loader from '~/components/loader/Loader'
 
-import { spliceSx } from '~/utils/helper-functions'
 import { styles } from '~/components/enhanced-table/EnhancedTable.styles'
+import { spliceSx } from '~/utils/helper-functions'
 import {
   TableColumn,
   TableData,
@@ -29,14 +30,16 @@ export interface EnhancedTableProps<I, F> extends Omit<TableProps, 'style'> {
   columns: TableColumn<I>[]
   isSelection?: boolean
   rowActions?: TableRowAction[]
+  onRowClick?: (item: I) => void
   select?: TableSelect<I>
   filter?: TableFilter<F>
   sort: TableSort
   rowsPerPage?: number
   data: TableData<I>
-  onRowClick?: (item: I) => void
+  disableInitialSelectedRows?: boolean
   emptyTableKey?: string
   selectedRows?: I[]
+  initialSelectedRows?: I[]
   style?: {
     root?: SxProps
     tableContainer?: SxProps
@@ -53,27 +56,46 @@ const EnhancedTable = <I extends TableItem, F = undefined>({
   sort,
   rowsPerPage,
   data,
+  disableInitialSelectedRows = false,
   emptyTableKey = 'table.noExactMatches',
   selectedRows = [],
+  initialSelectedRows = [],
   style = {},
   ...props
 }: EnhancedTableProps<I, F>) => {
   const { t } = useTranslation()
   const { items, loading, getData } = data
 
-  const rows = items.map((item) => (
-    <EnhancedTableRow
-      columns={columns}
-      isSelection={isSelection}
-      item={item}
-      key={item._id}
-      onRowClick={onRowClick}
-      refetchData={getData}
-      rowActions={rowActions}
-      select={select}
-      selectedRows={selectedRows}
-    />
-  ))
+  const rows = useMemo(
+    () =>
+      items.map((item) => (
+        <EnhancedTableRow
+          columns={columns}
+          initialSelectedRows={initialSelectedRows}
+          isDisableRow={disableInitialSelectedRows}
+          isSelection={isSelection}
+          item={item}
+          key={item._id}
+          onRowClick={onRowClick}
+          refetchData={getData}
+          rowActions={rowActions}
+          select={select}
+          selectedRows={selectedRows}
+        />
+      )),
+    [
+      items,
+      columns,
+      initialSelectedRows,
+      disableInitialSelectedRows,
+      isSelection,
+      onRowClick,
+      getData,
+      rowActions,
+      select,
+      selectedRows
+    ]
+  )
 
   const tableBody = (
     <TableContainer

--- a/src/components/enhanced-table/enhanced-table-row/EnhancedTableRow.styles.ts
+++ b/src/components/enhanced-table/enhanced-table-row/EnhancedTableRow.styles.ts
@@ -1,11 +1,15 @@
 import palette from '~/styles/app-theme/app.pallete'
 
 export const styles = {
-  row: (isSelected: boolean, isRowOnClick = false) => ({
+  row: (isSelected: boolean, isRowOnClick = false, isDisableRow = false) => ({
     ...(isRowOnClick && { cursor: 'pointer' }),
     ...(isSelected && { background: palette.basic.grey }),
     '&:hover .addCategory': {
       visibility: 'visible'
-    }
+    },
+    ...(isDisableRow && {
+      pointerEvents: 'none',
+      opacity: 0.5
+    })
   })
 }

--- a/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
+++ b/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
@@ -29,13 +29,13 @@ const CooperationActivitiesView: FC<CooperationActivitiesViewProps> = ({
 
   const onEdit = () => {
     setEditMode(true)
-    dispatch(setIsAddedClicked(false))
+    dispatch(setIsAddedClicked(false)) // Why is this needed?
   }
 
   return (
     <Box sx={styles.root}>
       {sections.map((item) => (
-        <CooperationSectionView id={item._id} item={item} key={item._id} />
+        <CooperationSectionView id={item.id} item={item} key={item.id} />
       ))}
 
       {isTutor && (

--- a/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
+++ b/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
@@ -31,16 +31,10 @@ import {
 import { useAppSelector, useAppDispatch } from '~/hooks/use-redux'
 
 const CooperationActivitiesList = () => {
-  const {
-    selectedCourse,
-    isAddedClicked,
-    currentSectionIndex,
-    isNewActivity,
-    sections
-  } = useAppSelector(cooperationsSelector)
+  const { selectedCourse, isAddedClicked, isNewActivity, sections } =
+    useAppSelector(cooperationsSelector)
 
   const dispatch = useAppDispatch()
-  const Id = uuidv4()
 
   // This logic looks very complicated and seems that it doesn't work
   // Why do we need to store some flags for user actions?
@@ -53,7 +47,7 @@ const CooperationActivitiesList = () => {
     if (selectedCourse && !sections.length && isAddedClicked) {
       const allSections = selectedCourse.sections.map((section) => ({
         ...section,
-        id: Id
+        id: uuidv4()
       }))
       setSectionsData(allSections)
     }
@@ -62,7 +56,7 @@ const CooperationActivitiesList = () => {
       const addNewSectionsCourse = (index: number | undefined = undefined) => {
         const newSectionData = selectedCourse.sections.map((section) => ({
           ...section,
-          id: Id
+          id: uuidv4()
         }))
         let newSections
         if (index !== undefined) {
@@ -76,7 +70,7 @@ const CooperationActivitiesList = () => {
         }
         setSectionsData(newSections)
       }
-      addNewSectionsCourse(currentSectionIndex)
+      addNewSectionsCourse(0) // this is a mock and will always insert at the 0 position, but it will change in issue #2064
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAddedClicked])
@@ -106,7 +100,7 @@ const CooperationActivitiesList = () => {
     (index: number | undefined = undefined) => {
       // This logic should be moved to the reducer
       const newSectionData = { ...initialCooperationSectionData }
-      newSectionData.id = Date.now().toString()
+      newSectionData.id = uuidv4()
       const newSections = [...sections]
       newSections.splice(index ?? sections.length, 0, newSectionData)
 

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -48,14 +48,14 @@ import {
 const CooperationDetails = () => {
   const { t } = useTranslation()
   const { id } = useParams()
-  const { isActivityCreated } = useAppSelector(cooperationsSelector)
+  const { isActivityCreated } = useAppSelector(cooperationsSelector) // Why is this needed?
   const navigate = useNavigate()
   const { isDesktop } = useBreakpoints()
   const [activeTab, setActiveTab] = useState<CooperationTabsEnum>(
     CooperationTabsEnum.Activities
   )
-  const [isNotesOpen, setIsNotesOpen] = useState(false)
-  const [editMode, setEditMode] = useState(false)
+  const [isNotesOpen, setIsNotesOpen] = useState<boolean>(false)
+  const [editMode, setEditMode] = useState<boolean>(false)
   const dispatch = useAppDispatch()
 
   const responseError = useCallback(

--- a/src/pages/create-course/CreateCourse.tsx
+++ b/src/pages/create-course/CreateCourse.tsx
@@ -161,7 +161,7 @@ const CreateCourse = () => {
 
   const addNewSection = useCallback(() => {
     const newSectionData = { ...sectionInitialData }
-    newSectionData.id = Date.now().toString()
+    newSectionData.id = uuidv4()
     setSectionsData([...data.sections, newSectionData])
   }, [data.sections, setSectionsData])
 

--- a/src/redux/features/cooperationsSlice.ts
+++ b/src/redux/features/cooperationsSlice.ts
@@ -16,7 +16,6 @@ interface CooperationsState {
   isActivityCreated: boolean // delete it
   isAddedClicked: boolean // delete it
   isNewActivity: boolean // delete it
-  currentSectionIndex?: number // delete it
   sections: CourseSection[]
   resourcesAvailability: ResourcesAvailabilityEnum
 }
@@ -26,7 +25,6 @@ const initialState: CooperationsState = {
   isActivityCreated: false, // delete it
   isAddedClicked: false, // delete it
   isNewActivity: false, // delete it
-  currentSectionIndex: 0, // delete it
   sections: [],
   resourcesAvailability: ResourcesAvailabilityEnum.OpenAll
 }
@@ -63,13 +61,6 @@ const cooperationsSlice = createSlice({
     ) {
       state.isNewActivity = action.payload
     },
-    setCurrentSectionIndex(
-      // delete it
-      state,
-      action: PayloadAction<CooperationsState['currentSectionIndex']>
-    ) {
-      state.currentSectionIndex = action.payload
-    },
 
     setCooperationSections(
       state,
@@ -78,6 +69,7 @@ const cooperationsSlice = createSlice({
       // state.sections = action.payload if courses will be fixed
       state.sections = (action.payload ?? []).map((section) => ({
         ...section,
+        id: section._id ?? uuidv4(),
         resources: section.resources ?? []
       }))
     },
@@ -233,7 +225,6 @@ export const {
   setIsActivityCreated,
   setIsAddedClicked,
   setIsNewActivity,
-  setCurrentSectionIndex,
   setCooperationSections,
   updateCooperationSection,
   deleteCooperationSection,

--- a/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
+++ b/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
@@ -13,8 +13,8 @@ vi.mock('~/components/cooperation-section-view/CooperationSectionView', () => ({
 vi.mock('~/hooks/use-redux', () => ({
   useAppSelector: vi.fn().mockReturnValue({
     sections: [
-      { _id: '1', title: 'Section1' },
-      { _id: '2', title: 'Section2' }
+      { id: '1', title: 'Section1' },
+      { id: '2', title: 'Section2' }
     ],
     userRole: UserRoleEnum.Tutor
   }),

--- a/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
+++ b/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
@@ -209,7 +209,7 @@ describe('CourseSectionsList tests', () => {
     const addModuleButton = screen.getAllByTestId('Crop75Icon')[itemIndex]
     waitFor(() => fireEvent.click(addModuleButton))
     expect(mockedSectionEventHandler).toHaveBeenCalledWith({
-      index: -1,
+      index: 1,
       type: 'sectionAdded'
     })
   })

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
@@ -1,5 +1,15 @@
 import { ResourcesTypesEnum as ResourceType } from '~/types'
 
+export const mockedEmptySectionsData = []
+
+export const mockedNewEmptySectionsData = [
+  {
+    title: '',
+    description: '',
+    resources: []
+  }
+]
+
 export const mockedCourseData = {
   title: 'Course title',
   description: 'Course description',
@@ -37,5 +47,3 @@ export const mockedSectionsData = [
     id: '17121748017181'
   }
 ]
-
-export const mockedEmptySectionsData = []

--- a/tests/unit/redux/cooperationsSlice.spec.js
+++ b/tests/unit/redux/cooperationsSlice.spec.js
@@ -23,8 +23,8 @@ describe('Test cooperationsSlice', () => {
 
   it('should set sections correctly with setCooperationSections', () => {
     const sections = [
-      { id: '1', resources: [] },
-      { id: '2', resources: [] }
+      { _id: '1', id: '1', resources: [] },
+      { _id: '2', id: '2', resources: [] }
     ]
     const action = setCooperationSections(sections)
     const state = reducer(initialState, action)


### PR DESCRIPTION
### Disabled already linked resources in `Course`/`Cooperation` in choosing resources modals [ Close #2376 ]
Users are now prevented from duplicating links when adding resources to a `course` or `cooperation`. The modal for choosing resources to add now disables resources that have already been linked to the course or cooperation, making it easier to manage resources and improving the user experience:

<img width="1405" alt="Screenshot 2024-08-22 at 16 23 19" src="https://github.com/user-attachments/assets/4fb151b1-a3aa-42fe-bf12-1a3ea8838309">

The modal for selecting resources displays a list of available resources, including those already added as links to the course or cooperation. **Resources that have already been added as links are disabled**, allowing users to add only new resources:

<img width="1405" alt="Screenshot 2024-08-22 at 16 22 36" src="https://github.com/user-attachments/assets/b11b8d87-9fdd-442e-9630-b5480ac59a43">