### PR TITLE
The button isn't centered in the pop-up window, after creating new student/tutor account and confirming new email

### DIFF
--- a/src/containers/email-confirm-modal/EmailConfirmModal.styles.js
+++ b/src/containers/email-confirm-modal/EmailConfirmModal.styles.js
@@ -7,6 +7,7 @@ export const styles = {
     borderRadius: '8px'
   },
   button: {
+    margin: '0 auto',
     size: 'large',
     mt: '32px'
   },


### PR DESCRIPTION
Result:
![image](https://github.com/user-attachments/assets/3600c4f3-29ab-4b53-83a0-e35e5ce314c0)
