### PR TITLE
Fixed drag-and-drop functionality and unique ID generation

### DIFF
--- a/src/components/cooperation-section-view/CooperationSectionView.tsx
+++ b/src/components/cooperation-section-view/CooperationSectionView.tsx
@@ -20,7 +20,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
   id
 }) => {
   const { t } = useTranslation()
-  const [isVisible, setIsVisible] = useState(true)
+  const [isVisible, setIsVisible] = useState<boolean>(true)
 
   const resources = useMemo<undefined | ReactNode[]>(
     () =>
@@ -36,7 +36,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
   )
 
   return (
-    <Box sx={styles.root}>
+    <Box key={id} sx={styles.root}>
       <HeaderTextWithDropdown
         isView
         isVisible={isVisible}
@@ -44,7 +44,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
         setIsVisible={setIsVisible}
       />
       {isVisible && (
-        <Box key={id} sx={styles.showBlock}>
+        <Box sx={styles.showBlock}>
           <AppTextField
             InputProps={styles.descriptionInput}
             fullWidth

--- a/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
+++ b/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
@@ -29,13 +29,13 @@ const CooperationActivitiesView: FC<CooperationActivitiesViewProps> = ({
 
   const onEdit = () => {
     setEditMode(true)
-    dispatch(setIsAddedClicked(false))
+    dispatch(setIsAddedClicked(false)) // Why is this needed?
   }
 
   return (
     <Box sx={styles.root}>
       {sections.map((item) => (
-        <CooperationSectionView id={item._id} item={item} key={item._id} />
+        <CooperationSectionView id={item.id} item={item} key={item.id} />
       ))}
 
       {isTutor && (

--- a/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
+++ b/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
@@ -31,16 +31,10 @@ import {
 import { useAppSelector, useAppDispatch } from '~/hooks/use-redux'
 
 const CooperationActivitiesList = () => {
-  const {
-    selectedCourse,
-    isAddedClicked,
-    currentSectionIndex,
-    isNewActivity,
-    sections
-  } = useAppSelector(cooperationsSelector)
+  const { selectedCourse, isAddedClicked, isNewActivity, sections } =
+    useAppSelector(cooperationsSelector)
 
   const dispatch = useAppDispatch()
-  const Id = uuidv4()
 
   // This logic looks very complicated and seems that it doesn't work
   // Why do we need to store some flags for user actions?
@@ -53,7 +47,7 @@ const CooperationActivitiesList = () => {
     if (selectedCourse && !sections.length && isAddedClicked) {
       const allSections = selectedCourse.sections.map((section) => ({
         ...section,
-        id: Id
+        id: uuidv4()
       }))
       setSectionsData(allSections)
     }
@@ -62,7 +56,7 @@ const CooperationActivitiesList = () => {
       const addNewSectionsCourse = (index: number | undefined = undefined) => {
         const newSectionData = selectedCourse.sections.map((section) => ({
           ...section,
-          id: Id
+          id: uuidv4()
         }))
         let newSections
         if (index !== undefined) {
@@ -76,7 +70,7 @@ const CooperationActivitiesList = () => {
         }
         setSectionsData(newSections)
       }
-      addNewSectionsCourse(currentSectionIndex)
+      addNewSectionsCourse(0) // this is a mock and will always insert at the 0 position, but it will change in issue #2064
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAddedClicked])
@@ -106,7 +100,7 @@ const CooperationActivitiesList = () => {
     (index: number | undefined = undefined) => {
       // This logic should be moved to the reducer
       const newSectionData = { ...initialCooperationSectionData }
-      newSectionData.id = Date.now().toString()
+      newSectionData.id = uuidv4()
       const newSections = [...sections]
       newSections.splice(index ?? sections.length, 0, newSectionData)
 

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -48,14 +48,14 @@ import {
 const CooperationDetails = () => {
   const { t } = useTranslation()
   const { id } = useParams()
-  const { isActivityCreated } = useAppSelector(cooperationsSelector)
+  const { isActivityCreated } = useAppSelector(cooperationsSelector) // Why is this needed?
   const navigate = useNavigate()
   const { isDesktop } = useBreakpoints()
   const [activeTab, setActiveTab] = useState<CooperationTabsEnum>(
     CooperationTabsEnum.Activities
   )
-  const [isNotesOpen, setIsNotesOpen] = useState(false)
-  const [editMode, setEditMode] = useState(false)
+  const [isNotesOpen, setIsNotesOpen] = useState<boolean>(false)
+  const [editMode, setEditMode] = useState<boolean>(false)
   const dispatch = useAppDispatch()
 
   const responseError = useCallback(

--- a/src/pages/create-course/CreateCourse.tsx
+++ b/src/pages/create-course/CreateCourse.tsx
@@ -161,7 +161,7 @@ const CreateCourse = () => {
 
   const addNewSection = useCallback(() => {
     const newSectionData = { ...sectionInitialData }
-    newSectionData.id = Date.now().toString()
+    newSectionData.id = uuidv4()
     setSectionsData([...data.sections, newSectionData])
   }, [data.sections, setSectionsData])
 

--- a/src/redux/features/cooperationsSlice.ts
+++ b/src/redux/features/cooperationsSlice.ts
@@ -16,7 +16,6 @@ interface CooperationsState {
   isActivityCreated: boolean // delete it
   isAddedClicked: boolean // delete it
   isNewActivity: boolean // delete it
-  currentSectionIndex?: number // delete it
   sections: CourseSection[]
   resourcesAvailability: ResourcesAvailabilityEnum
 }
@@ -26,7 +25,6 @@ const initialState: CooperationsState = {
   isActivityCreated: false, // delete it
   isAddedClicked: false, // delete it
   isNewActivity: false, // delete it
-  currentSectionIndex: 0, // delete it
   sections: [],
   resourcesAvailability: ResourcesAvailabilityEnum.OpenAll
 }
@@ -63,13 +61,6 @@ const cooperationsSlice = createSlice({
     ) {
       state.isNewActivity = action.payload
     },
-    setCurrentSectionIndex(
-      // delete it
-      state,
-      action: PayloadAction<CooperationsState['currentSectionIndex']>
-    ) {
-      state.currentSectionIndex = action.payload
-    },
 
     setCooperationSections(
       state,
@@ -78,6 +69,7 @@ const cooperationsSlice = createSlice({
       // state.sections = action.payload if courses will be fixed
       state.sections = (action.payload ?? []).map((section) => ({
         ...section,
+        id: section._id ?? uuidv4(),
         resources: section.resources ?? []
       }))
     },
@@ -233,7 +225,6 @@ export const {
   setIsActivityCreated,
   setIsAddedClicked,
   setIsNewActivity,
-  setCurrentSectionIndex,
   setCooperationSections,
   updateCooperationSection,
   deleteCooperationSection,

--- a/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
+++ b/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
@@ -13,8 +13,8 @@ vi.mock('~/components/cooperation-section-view/CooperationSectionView', () => ({
 vi.mock('~/hooks/use-redux', () => ({
   useAppSelector: vi.fn().mockReturnValue({
     sections: [
-      { _id: '1', title: 'Section1' },
-      { _id: '2', title: 'Section2' }
+      { id: '1', title: 'Section1' },
+      { id: '2', title: 'Section2' }
     ],
     userRole: UserRoleEnum.Tutor
   }),

--- a/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
+++ b/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
@@ -209,7 +209,7 @@ describe('CourseSectionsList tests', () => {
     const addModuleButton = screen.getAllByTestId('Crop75Icon')[itemIndex]
     waitFor(() => fireEvent.click(addModuleButton))
     expect(mockedSectionEventHandler).toHaveBeenCalledWith({
-      index: -1,
+      index: 1,
       type: 'sectionAdded'
     })
   })

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
@@ -1,5 +1,15 @@
 import { ResourcesTypesEnum as ResourceType } from '~/types'
 
+export const mockedEmptySectionsData = []
+
+export const mockedNewEmptySectionsData = [
+  {
+    title: '',
+    description: '',
+    resources: []
+  }
+]
+
 export const mockedCourseData = {
   title: 'Course title',
   description: 'Course description',
@@ -37,5 +47,3 @@ export const mockedSectionsData = [
     id: '17121748017181'
   }
 ]
-
-export const mockedEmptySectionsData = []

--- a/tests/unit/redux/cooperationsSlice.spec.js
+++ b/tests/unit/redux/cooperationsSlice.spec.js
@@ -23,8 +23,8 @@ describe('Test cooperationsSlice', () => {
 
   it('should set sections correctly with setCooperationSections', () => {
     const sections = [
-      { id: '1', resources: [] },
-      { id: '2', resources: [] }
+      { _id: '1', id: '1', resources: [] },
+      { _id: '2', id: '2', resources: [] }
     ]
     const action = setCooperationSections(sections)
     const state = reducer(initialState, action)


### PR DESCRIPTION
## Fixed drag-and-drop functionality and unique ID generation issues [ Close #2381 ]
The drag-and-drop functionality for rearranging sections in `Courses` and `Cooperations` is now working properly. Additionally, when a course or cooperation has more than two sections, the generated IDs are unique, which resolves the issue where deleting one section would lead to the deletion of all sections within the course or cooperation
 
The implemented changes now properly handle unique IDs and correctly update the order of sections.
<img width="1330" alt="Screenshot 2024-08-25 at 17 49 11" src="https://github.com/user-attachments/assets/cee5dc66-1995-434b-b248-0948af838a84">

- [x] Fixed implementation of the drag and drop functionality for rearranging sections in `Course`:
<img width="1271" alt="Screenshot 2024-08-22 at 17 46 24" src="https://github.com/user-attachments/assets/7f135bbf-9439-4804-bf36-29287a73bbea">

#

- [x] Fixed implementation of the drag and drop functionality for rearranging sections in `Cooperation`:
<img width="1145" alt="cooperation section id" src="https://github.com/user-attachments/assets/7662e4c4-6ef0-4b1e-8672-d36a60dcba0a">

#

- [x] Fixed issue with deleting one of the sections that cause deleting all sections in `Course` and `Cooperation`.
<img width="1649" alt="cooperation section deleting" src="https://github.com/user-attachments/assets/4a8a3001-c4a5-4750-8cea-6077a52666ac">

#

- [x] Ensured that unique IDs are assigned to each section, even when there are multiple sections within a `Course` or `Cooperation`. Specifically, the ID is assigned to each section when it is **created** and **updated** as necessary.

#

- [x] Fixed the **issue where the same unique 'key' is assigned to each child in the list during edit mode** of `Cooperation`. This fix prevents the screen from freezing and ensures that users can change the order of sections, delete them, or access other functionality as intended.
<img width="1618" alt="Screenshot 2024-08-24 at 00 19 26" src="https://github.com/user-attachments/assets/35db4dc7-b965-4a34-bcc8-db7b13d136b0">

#### Additionally, I rewrote the spec for `CooperationActivitiesList.tsx` container to up the coverage: 
_Coverage before changes_:
<img width="1294" alt="Screenshot 2024-07-29 at 20 11 16" src="https://github.com/user-attachments/assets/6a4a458f-c5a0-4c28-8fb5-b79ee76a3c94">

_Current Test Coverage:_
<img width="1285" alt="Screenshot 2024-08-24 at 17 58 12" src="https://github.com/user-attachments/assets/af365dcf-0230-451a-80e9-56b1fa5c6cbe">
