### PR TITLE
Resolved BSONTypeError when adding duplicate resources to Course/Cooperation

### DIFF
--- a/src/components/cooperation-section-view/CooperationSectionView.tsx
+++ b/src/components/cooperation-section-view/CooperationSectionView.tsx
@@ -11,14 +11,10 @@ import { styles } from '~/components/cooperation-section-view/CooperationSection
 import { CourseSection, TextFieldVariantEnum } from '~/types'
 
 interface CooperationSectionViewProps {
-  id?: string
   item: CourseSection
 }
 
-const CooperationSectionView: FC<CooperationSectionViewProps> = ({
-  item,
-  id
-}) => {
+const CooperationSectionView: FC<CooperationSectionViewProps> = ({ item }) => {
   const { t } = useTranslation()
   const [isVisible, setIsVisible] = useState<boolean>(true)
 
@@ -27,7 +23,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
       item.resources?.map(({ resource, resourceType }) => (
         <ResourceItem
           isView
-          key={resource._id}
+          key={resource.id}
           resource={resource}
           resourceType={resourceType}
         />
@@ -36,7 +32,7 @@ const CooperationSectionView: FC<CooperationSectionViewProps> = ({
   )
 
   return (
-    <Box key={id} sx={styles.root}>
+    <Box sx={styles.root}>
       <HeaderTextWithDropdown
         isView
         isVisible={isVisible}

--- a/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
+++ b/src/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx
@@ -22,8 +22,8 @@ interface CooperationActivitiesViewProps {
 const CooperationActivitiesView: FC<CooperationActivitiesViewProps> = ({
   setEditMode
 }) => {
-  const { sections } = useAppSelector(cooperationsSelector)
   const dispatch = useAppDispatch()
+  const { sections } = useAppSelector(cooperationsSelector)
   const { userRole } = useAppSelector((state) => state.appMain)
   const isTutor = userRole === UserRoleEnum.Tutor
 
@@ -35,7 +35,7 @@ const CooperationActivitiesView: FC<CooperationActivitiesViewProps> = ({
   return (
     <Box sx={styles.root}>
       {sections.map((item) => (
-        <CooperationSectionView id={item.id} item={item} key={item.id} />
+        <CooperationSectionView item={item} key={item.id} />
       ))}
 
       {isTutor && (

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -126,7 +126,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
       resourceEventHandler?.({
         type: CourseResourceEventType.ResourceUpdated,
         sectionId: sectionData.id,
-        resourceId: resource._id,
+        resourceId: resource.id,
         resource: {
           availability
         }
@@ -139,7 +139,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
     resourceEventHandler?.({
       type: CourseResourceEventType.ResourceRemoved,
       sectionId: sectionData.id,
-      resourceId: resource._id
+      resourceId: resource.id
     })
   }
 

--- a/src/containers/course-section/resources-list/ResourcesList.tsx
+++ b/src/containers/course-section/resources-list/ResourcesList.tsx
@@ -41,12 +41,12 @@ const ResourcesList: FC<ResourcesListProps> = ({
     handleDragEnd,
     handleDragStart,
     sensors
-  } = useDndSensor({ items, setItems: sortResources, idProp: '_id' })
+  } = useDndSensor({ items, setItems: sortResources, idProp: 'id' })
 
   const renderItem = (item: CourseResource, isDragOver = false) => (
     <SortableWrapper
-      id={item._id}
-      key={item._id}
+      id={item.id}
+      key={item.id}
       onDragEndStyles={styles.section(isDragOver)}
       onDragStartStyles={styles.section(true)}
     >
@@ -66,7 +66,7 @@ const ResourcesList: FC<ResourcesListProps> = ({
   const resourceListContent = enabled && (
     <>
       <SortableContext
-        items={items.map((item) => item._id)}
+        items={items.map((item) => item.id)}
         strategy={verticalListSortingStrategy}
       >
         <Box sx={styles.root}>{resourceItems}</Box>

--- a/src/containers/course-sections-list/CourseSectionsList.tsx
+++ b/src/containers/course-sections-list/CourseSectionsList.tsx
@@ -177,7 +177,10 @@ const CourseSectionsList: FC<CourseSectionsListProps> = ({
 
   const courseSectionContent = enabled && (
     <>
-      <SortableContext items={items} strategy={verticalListSortingStrategy}>
+      <SortableContext
+        items={items.map((item) => item.id)}
+        strategy={verticalListSortingStrategy}
+      >
         {sectionItems}
       </SortableContext>
       <DragOverlay>

--- a/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.constants.ts
+++ b/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.constants.ts
@@ -1,8 +1,0 @@
-import { CourseSection } from '~/types'
-
-export const initialCooperationSectionData: CourseSection = {
-  id: '',
-  title: '',
-  description: '',
-  resources: []
-}

--- a/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
+++ b/src/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.tsx
@@ -5,7 +5,6 @@ import Box from '@mui/material/Box'
 
 import Loader from '~/components/loader/Loader'
 import CourseSectionsList from '~/containers/course-sections-list/CourseSectionsList'
-import { initialCooperationSectionData } from '~/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.constants'
 
 import {
   CourseSection,
@@ -21,6 +20,7 @@ import {
   deleteCooperationSection,
   deleteResource,
   setCooperationSections,
+  addNewCooperationSection,
   setIsNewActivity,
   addSectionResources,
   updateCooperationSection,
@@ -31,18 +31,17 @@ import {
 import { useAppSelector, useAppDispatch } from '~/hooks/use-redux'
 
 const CooperationActivitiesList = () => {
-  const { selectedCourse, isAddedClicked, isNewActivity, sections } =
-    useAppSelector(cooperationsSelector)
-
   const dispatch = useAppDispatch()
+  const { selectedCourse, isAddedClicked, sections } =
+    useAppSelector(cooperationsSelector)
 
   // This logic looks very complicated and seems that it doesn't work
   // Why do we need to store some flags for user actions?
   // isAddedClicked works even when we don't click, that adds unnecessary sections
   useEffect(() => {
-    if (!sections?.length && !isAddedClicked && isNewActivity) {
-      addNewSection()
-    }
+    // if (!sections?.length && !isAddedClicked && isNewActivity) { // commented because this if causes adding two sections
+    //   dispatch(addNewCooperationSection({ index: 0 })) // should check and rewrite this logic
+    // }
 
     if (selectedCourse && !sections.length && isAddedClicked) {
       const allSections = selectedCourse.sections.map((section) => ({
@@ -96,19 +95,6 @@ const CooperationActivitiesList = () => {
     )
   }
 
-  const addNewSection = useCallback(
-    (index: number | undefined = undefined) => {
-      // This logic should be moved to the reducer
-      const newSectionData = { ...initialCooperationSectionData }
-      newSectionData.id = uuidv4()
-      const newSections = [...sections]
-      newSections.splice(index ?? sections.length, 0, newSectionData)
-
-      setSectionsData(newSections)
-    },
-    [sections, setSectionsData]
-  )
-
   const deleteSection = useCallback(
     (sectionId: string) => {
       dispatch(setIsNewActivity(false)) // Why do we need this flag here? (moved from the child component)
@@ -121,7 +107,7 @@ const CooperationActivitiesList = () => {
     (event) => {
       switch (event.type) {
         case CourseSectionEventType.SectionAdded:
-          addNewSection(event.index)
+          dispatch(addNewCooperationSection({ index: event.index }))
           break
         case CourseSectionEventType.SectionRemoved:
           deleteSection(event.sectionId)
@@ -131,7 +117,7 @@ const CooperationActivitiesList = () => {
           break
       }
     },
-    [addNewSection, deleteSection, setSectionsData]
+    [dispatch, deleteSection, setSectionsData]
   )
 
   const resourceEventHandler = useCallback<ResourceEventHandler>(

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -46,17 +46,17 @@ import {
 } from '~/redux/features/cooperationsSlice'
 
 const CooperationDetails = () => {
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
   const { t } = useTranslation()
   const { id } = useParams()
-  const { isActivityCreated } = useAppSelector(cooperationsSelector) // Why is this needed?
-  const navigate = useNavigate()
   const { isDesktop } = useBreakpoints()
+  const { isActivityCreated } = useAppSelector(cooperationsSelector) // Why is this needed?
   const [activeTab, setActiveTab] = useState<CooperationTabsEnum>(
     CooperationTabsEnum.Activities
   )
   const [isNotesOpen, setIsNotesOpen] = useState<boolean>(false)
   const [editMode, setEditMode] = useState<boolean>(false)
-  const dispatch = useAppDispatch()
 
   const responseError = useCallback(
     () => navigate(errorRoutes.notFound.path),
@@ -75,7 +75,7 @@ const CooperationDetails = () => {
 
   useEffect(() => {
     dispatch(setCooperationSections(response.sections))
-    response.sections && response.sections.length && setEditMode(true)
+    setEditMode(Boolean(response?.sections?.length))
   }, [response.sections, dispatch])
 
   const handleEditMode = useCallback(() => {

--- a/src/containers/my-cooperations/empty-cooperation-activities/EmptyCooperationTutorControls.tsx
+++ b/src/containers/my-cooperations/empty-cooperation-activities/EmptyCooperationTutorControls.tsx
@@ -47,8 +47,8 @@ const EmptyCooperationTutorControls: FC = () => {
 
   const handleFromScratch = () => {
     closeMenu()
-    dispatch(setIsActivityCreated(true))
-    dispatch(setIsNewActivity(true))
+    dispatch(setIsActivityCreated(true)) // should delete it
+    dispatch(setIsNewActivity(true)) // should delete it
   }
 
   const menuItems = [

--- a/src/pages/create-course/CreateCourse.tsx
+++ b/src/pages/create-course/CreateCourse.tsx
@@ -212,14 +212,17 @@ const CreateCourse = () => {
       const newResources = resources
         .filter((resource) => {
           return !section.resources.some(
-            (item) => item.resource._id === resource._id && !isDuplicate
+            (item) => item.resource.id === resource.id && !isDuplicate
           )
         })
         .map((resource) => {
+          const { _id, ...newDuplicateResource } = resource
           return {
-            resource: isDuplicate
-              ? { ...resource, _id: uuidv4(), isDuplicate: true }
-              : resource,
+            resource: {
+              ...newDuplicateResource,
+              id: uuidv4(),
+              ...(isDuplicate ? { _id: '', isDuplicate: true } : { _id })
+            },
             resourceType: resource.resourceType
           }
         })
@@ -237,19 +240,19 @@ const CreateCourse = () => {
       resource
     }: {
       sectionId: CourseSection['id']
-      resourceId: CourseResource['_id']
+      resourceId: CourseResource['id']
       resource: Partial<CourseResource>
     }) => {
       const section = data.sections.find((section) => section.id === sectionId)
       if (!section) return
 
       const currentResource = section.resources.find(
-        (item) => item.resource._id === resourceId
+        (item) => item.resource.id === resourceId
       )
       if (!currentResource) return
 
       const newSectionResources = section.resources.map((item) =>
-        item.resource._id === resourceId
+        item.resource.id === resourceId
           ? { ...currentResource, ...resource }
           : item
       )
@@ -265,13 +268,13 @@ const CreateCourse = () => {
       resourceId
     }: {
       sectionId: CourseSection['id']
-      resourceId: CourseResource['_id']
+      resourceId: CourseResource['id']
     }) => {
       const section = data.sections.find((section) => section.id === sectionId)
       if (!section) return
 
       const newSectionResources = section.resources.filter(
-        (resource) => resource.resource._id !== resourceId
+        (resource) => resource.resource.id !== resourceId
       )
       handleSectionChange(sectionId, 'resources', newSectionResources)
     },
@@ -341,6 +344,11 @@ const CreateCourse = () => {
       if (item._id) {
         item.id = item._id
       }
+    })
+    course.sections.forEach((section) => {
+      section.resources?.forEach((resource) => {
+        resource.resource.id ||= uuidv4()
+      })
     })
     for (const key in data) {
       const validKey = key as keyof CourseForm

--- a/src/types/my-resources/interfaces/myResources.interface.ts
+++ b/src/types/my-resources/interfaces/myResources.interface.ts
@@ -8,6 +8,7 @@ import {
 } from '~/types'
 
 export interface ResourceBase {
+  id: string
   description: string
   resourceType: ResourceType
   availability?: ResourceAvailability

--- a/src/utils/validations/isValidUUID.js
+++ b/src/utils/validations/isValidUUID.js
@@ -1,0 +1,6 @@
+export const isValidUUID = (uuid) => {
+  const s = '' + uuid
+  const regex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+  return regex.test(s)
+}

--- a/tests/unit/components/cooperation-section-view/CooperationSectionView.spec.jsx
+++ b/tests/unit/components/cooperation-section-view/CooperationSectionView.spec.jsx
@@ -37,7 +37,7 @@ describe('CooperationSectionView', () => {
   }
 
   beforeEach(() => {
-    render(<CooperationSectionView id={mockSection._id} item={mockSection} />)
+    render(<CooperationSectionView item={mockSection} />)
   })
 
   it('should render resource title and description', () => {

--- a/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
+++ b/tests/unit/containers/cooperation-details/cooperation-activities-view/ CooperationActivitiesView.spec.jsx
@@ -5,8 +5,8 @@ import { UserRoleEnum } from '~/types'
 import CooperationActivitiesView from '~/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView.tsx'
 
 vi.mock('~/components/cooperation-section-view/CooperationSectionView', () => ({
-  default: ({ id, item }) => (
-    <div data-testid={`section-${id}`}>{item.title}</div>
+  default: ({ item }) => (
+    <div data-testid={`section-${item.id}`}>{item.title}</div>
   )
 }))
 

--- a/tests/unit/containers/course-section/CourseSectionContainer.spec.constants.js
+++ b/tests/unit/containers/course-section/CourseSectionContainer.spec.constants.js
@@ -12,6 +12,7 @@ export const mockedSectionData = {
           date: null
         },
         _id: '64cd12f1fad091e0sfe12134',
+        id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
         title: 'Lesson1',
         author: 'some author',
         content: 'Content',
@@ -29,6 +30,7 @@ export const mockedSectionData = {
           date: null
         },
         _id: '64fb2c33eba89699411d22bb',
+        id: '9b2e3d7e-1c4b-4f3b-8f8e-2d3b2c3d4e5f',
         title: 'Quiz',
         description: '',
         items: [],
@@ -47,6 +49,7 @@ export const mockedSectionData = {
           date: null
         },
         _id: '64cd12f1fad091e0ee719830',
+        id: 'd2c3b4e5-6f7a-8b9c-0d1e-2f3b4c5d6e7f',
         author: '6494128829631adbaf5cf615',
         fileName: 'spanish.pdf',
         link: 'link',

--- a/tests/unit/containers/course-section/CourseSectionContainer.spec.jsx
+++ b/tests/unit/containers/course-section/CourseSectionContainer.spec.jsx
@@ -176,7 +176,7 @@ describe('CourseSectionContainer tests', () => {
         }
       },
       resourceId:
-        mockedSectionData.resources[activityIndexToChange].resource._id,
+        mockedSectionData.resources[activityIndexToChange].resource.id,
       sectionId: 1,
       type: 'resourceUpdated'
     })
@@ -279,7 +279,7 @@ describe('CourseSectionContainer tests', () => {
       act(() => fireEvent.click(lessonDelete))
     })
     expect(mockedResourceEventHandler).toHaveBeenCalledWith({
-      resourceId: mockedSectionData.resources[0].resource._id,
+      resourceId: mockedSectionData.resources[0].resource.id,
       sectionId: 1,
       type: 'resourceRemoved'
     })
@@ -291,7 +291,7 @@ describe('CourseSectionContainer tests', () => {
       act(() => fireEvent.click(quizDelete))
     })
     expect(mockedResourceEventHandler).toHaveBeenCalledWith({
-      resourceId: mockedSectionData.resources[1].resource._id,
+      resourceId: mockedSectionData.resources[1].resource.id,
       sectionId: 1,
       type: 'resourceRemoved'
     })
@@ -304,7 +304,7 @@ describe('CourseSectionContainer tests', () => {
       act(() => fireEvent.click(attachmentDelete))
     })
     expect(mockedResourceEventHandler).toHaveBeenCalledWith({
-      resourceId: mockedSectionData.resources[2].resource._id,
+      resourceId: mockedSectionData.resources[2].resource.id,
       sectionId: 1,
       type: 'resourceRemoved'
     })
@@ -346,7 +346,7 @@ describe('Testing CourseSectionContainer Event Handlers', () => {
     expect(mockedResourceEventHandler).toHaveBeenCalledWith({
       type: CourseResourceEventType.ResourceUpdated,
       sectionId: mockSectionId,
-      resourceId: updatedResource._id,
+      resourceId: updatedResource.id,
       resource: {
         availability: {
           ...updatedResource.availability,
@@ -397,7 +397,7 @@ describe('Testing CourseSectionContainer Event Handlers', () => {
           payload: {
             type: CourseResourceEventType.ResourceRemoved,
             sectionId: mockSectionId,
-            resourceId: mockedSectionData.resources[0]._id
+            resourceId: mockedSectionData.resources[0].id
           }
         })
       }
@@ -409,7 +409,7 @@ describe('Testing CourseSectionContainer Event Handlers', () => {
         expect.objectContaining({
           type: CourseResourceEventType.ResourceRemoved,
           sectionId: mockSectionId,
-          resourceId: mockedSectionData.resources[0]._id
+          resourceId: mockedSectionData.resources[0].id
         })
       )
     })

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants.js
@@ -31,6 +31,7 @@ export const mockedSectionsData = [
       {
         resource: {
           _id: '66183816fb40f35f91bb77ce',
+          id: 'a1b2c3d4-5e6f-7a8b-9c0d-1e2f3b4c5d6e',
           title: 'Lesson 1',
           description: 'Lesson 1 description',
           content: 'Lesson 1 content'

--- a/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.jsx
@@ -5,8 +5,7 @@ import { CourseResourceEventType, CourseSectionEventType } from '~/types'
 import {
   mockedCourseData,
   mockedSectionsData,
-  mockedEmptySectionsData,
-  mockedNewEmptySectionsData
+  mockedEmptySectionsData
 } from '~tests/unit/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList.spec.constants'
 
 import CooperationActivitiesList from '~/containers/my-cooperations/cooperation-activities-list/CooperationActivitiesList'
@@ -104,14 +103,10 @@ describe('CooperationActivitiesList with section data', () => {
 
     await waitFor(() => {
       expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'cooperationsSlice/setCooperationSections',
-        payload: [
-          expect.objectContaining({
-            ...mockedNewEmptySectionsData[0],
-            id: expect.any(String)
-          }),
-          ...mockedSectionsData
-        ]
+        type: 'cooperationsSlice/addNewCooperationSection',
+        payload: {
+          index: 0
+        }
       })
     })
   })
@@ -126,7 +121,7 @@ describe('CooperationActivitiesList with section data', () => {
       expect(mockDispatch).toHaveBeenCalledWith({
         type: 'cooperationsSlice/deleteResource',
         payload: {
-          resourceId: mockedSectionsData[0].resources[0].resource._id,
+          resourceId: mockedSectionsData[0].resources[0].resource.id,
           sectionId: mockedSectionsData[0].id
         }
       })
@@ -164,14 +159,10 @@ describe('CooperationActivitiesList with section data', () => {
 
     await waitFor(() => {
       expect(mockDispatch).toHaveBeenCalledWith({
-        type: 'cooperationsSlice/setCooperationSections',
-        payload: [
-          expect.objectContaining({
-            ...mockedNewEmptySectionsData[0],
-            id: expect.any(String)
-          }),
-          ...mockedSectionsData
-        ]
+        type: 'cooperationsSlice/addNewCooperationSection',
+        payload: {
+          index: 0
+        }
       })
     })
   })

--- a/tests/unit/pages/create-course/CreateCourse.spec.constants.js
+++ b/tests/unit/pages/create-course/CreateCourse.spec.constants.js
@@ -12,6 +12,7 @@ export const mockSubjectsNames = [
 
 export const mockNewSectionResource = {
   _id: '66b67d84b58ba31be667ee9d',
+  id: 'e7f8a9b0-c1d2-3e4f-5a6b-7c8d9e0f1a2b',
   author: '6658f73f93885febb491e08b',
   title: 'New Lesson',
   description: 'New lesson description',
@@ -106,7 +107,8 @@ export const mockCourseResponseData = {
           resourceType: ResourceType.Attachment
         }
       ],
-      id: '66b6862cb58ba31be667f1a7'
+      _id: '66b6862cb58ba31be667f1a7',
+      id: 'a1b2c3d4-5e6f-7a8b-9c0d-1e2f3b4c5d6e'
     }
   ]
 }
@@ -185,7 +187,8 @@ export const mockNewCourseData = {
           resourceType: ResourceType.Attachment
         }
       ],
-      id: '66b6862cb58ba31be667f1a7'
+      _id: '66b6862cb58ba31be667f1a7',
+      id: 'a1b2c3d4-5e6f-7a8b-9c0d-1e2f3b4c5d6e'
     }
   ]
 }

--- a/tests/unit/pages/create-course/CreateCourse.spec.jsx
+++ b/tests/unit/pages/create-course/CreateCourse.spec.jsx
@@ -176,15 +176,12 @@ describe('CreateCourse with params id', () => {
     mockDispatch.mockReset()
   })
 
-  it('should render "Cancel", "Save" and "Add Section" buttons', () => {
-    const cancelButton = screen.getByText('common.cancel')
-    expect(cancelButton).toBeInTheDocument()
-
-    const saveButton = screen.getByText('common.save')
-    expect(saveButton).toBeInTheDocument()
-
-    const addSectionButton = screen.getByText('course.addSectionBtn')
-    expect(addSectionButton).toBeInTheDocument()
+  it('should render "Cancel", "Save" and "Add Section" buttons', async () => {
+    await waitFor(() => {
+      expect(screen.getByText('common.cancel')).toBeInTheDocument()
+      expect(screen.getByText('common.save')).toBeInTheDocument()
+      expect(screen.getByText('course.addSectionBtn')).toBeInTheDocument()
+    })
   })
 
   it('should navigate back to courses when "Cancel" is clicked', () => {
@@ -333,9 +330,9 @@ describe('CreateCourse with params id', () => {
       `${URLs.courses.patch}/${mockCourseResponseData._id}`
     )
     await waitFor(() => {
-      const textareas = screen.getAllByRole('textbox')
-      expect(textareas[0].value).toBe(mockUpdatedCourseData.title)
-      expect(textareas[1].value).toBe(mockUpdatedCourseData.description)
+      const textAreas = screen.getAllByRole('textbox')
+      expect(textAreas[0].value).toBe(mockUpdatedCourseData.title)
+      expect(textAreas[1].value).toBe(mockUpdatedCourseData.description)
     })
 
     await waitFor(() => {
@@ -375,9 +372,9 @@ describe('CreateCourse without params id', () => {
     expect(mockAxiosClient.history.post.length).toBe(1)
     expect(mockAxiosClient.history.post[0].url).toBe(URLs.courses.create)
     await waitFor(() => {
-      const textareas = screen.getAllByRole('textbox')
-      expect(textareas[0].value).toBe(mockNewCourseData.title)
-      expect(textareas[1].value).toBe(mockNewCourseData.description)
+      const textAreas = screen.getAllByRole('textbox')
+      expect(textAreas[0].value).toBe(mockNewCourseData.title)
+      expect(textAreas[1].value).toBe(mockNewCourseData.description)
     })
 
     await waitFor(() => {
@@ -429,12 +426,13 @@ describe('Testing CreateCourse Event Handlers', () => {
       expect(mockHandleNonInputValueChange).toHaveBeenCalled(1)
       expect(mockHandleNonInputValueChange).toHaveBeenCalledWith('sections', [
         {
+          _id: mockNewCourseData.sections[0]._id,
+          id: mockSectionId,
           description: mockNewCourseData.sections[0].description,
-          id: mockNewCourseData.sections[0].id,
           resources: [
             ...mockNewCourseData.sections[0].resources,
             {
-              resource: mockNewSectionResource,
+              resource: { ...mockNewSectionResource, id: expect.any(String) },
               resourceType: mockNewSectionResource.resourceType
             }
           ],
@@ -502,7 +500,7 @@ describe('Testing CreateCourse Event Handlers', () => {
           payload: {
             type: CourseResourceEventType.ResourceUpdated,
             sectionId: mockSectionId,
-            resourceId: mockUpdatedSectionResource._id,
+            resourceId: mockUpdatedSectionResource.id,
             resource: mockUpdatedSectionResource
           }
         })

--- a/tests/unit/utils/validations/isValidUUID.spec.js
+++ b/tests/unit/utils/validations/isValidUUID.spec.js
@@ -1,0 +1,27 @@
+import { isValidUUID } from '~/utils/validations/isValidUUID'
+
+describe('isValidUUID', () => {
+  test('returns true for valid UUID v4', () => {
+    expect(isValidUUID('3b17ccb0-ea8b-4685-b576-0b5de7b3f0ef')).toBe(true)
+    expect(isValidUUID('550e8400-e29b-41d4-a716-446655440000')).toBe(true)
+  })
+
+  test('returns false for invalid UUIDs', () => {
+    expect(isValidUUID('123e4567-e89b-12d3-a456-42661417400')).toBe(false)
+    expect(isValidUUID('123e4567-e89b-12d3-a456-4266141740000')).toBe(false)
+    expect(isValidUUID('123e4567-e89b-12d3-a456-42661417400z')).toBe(false)
+    expect(isValidUUID('123e4567-e89b-12d3-a456-42661417400G')).toBe(false)
+    expect(isValidUUID('123e4567-e89b-12d3-a456-42661417400-')).toBe(false)
+    expect(isValidUUID('123e4567-e89b-12d3-a456-42661417400')).toBe(false)
+    expect(isValidUUID('550e8400-e29b-41d4-a716-44665544000')).toBe(false)
+    expect(isValidUUID('550e8400-e29b-41d4-a716-4466554400000')).toBe(false)
+  })
+
+  test('returns false for non-UUID strings', () => {
+    expect(isValidUUID('')).toBe(false)
+    expect(isValidUUID(null)).toBe(false)
+    expect(isValidUUID(undefined)).toBe(false)
+    expect(isValidUUID('not-a-uuid')).toBe(false)
+    expect(isValidUUID('12345678-1234-1234-1234-123456789012')).toBe(false)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,7 +21,13 @@ export default defineConfig({
     coverage: {
       all: true,
       reporter: ['lcov', 'text'],
-      include: ['src/**/*.jsx', 'src/**/*.tsx'],
+      include: [
+        'src/**/*.jsx',
+        'src/**/*.tsx',
+        'src/utils/**/*.ts',
+        'src/utils/**/*.js',
+        'src/redux/**/*.ts'
+      ],
       exclude: ['src/stories', './tests/setup-tests.js'],
       reportsDirectory: './tests/coverage'
     },


### PR DESCRIPTION
## Fixed "Cast to ObjectId failed" error when adding duplicate resource to `Course` & `Cooperation` [ Close #2389 ]
Previously, when adding a resource as a duplicate copy to a `Course` or `Cooperation` and trying to `Save`, a "`Cast to ObjectId failed`" error occurs due to a `BSONTypeError`. This issue prevented the resource from being properly saved in the database :
<img width="1595" alt="Screenshot 2024-08-24 at 18 51 27" src="https://github.com/user-attachments/assets/58874987-3d5c-41d6-a0a6-6dc92a674af9">

### To resolve the "`Cast to ObjectId failed`" error when adding duplicate resources, the following changes were implemented:
<img width="1400" alt="Screenshot 2024-08-26 at 16 45 38" src="https://github.com/user-attachments/assets/c692a7e9-de1b-4f00-a34b-d5e019b01ef6">

To resolve this issue, it _was decided not to generate `_id` using `uuidv4()` for new resources_, as was previously implemented. Since we use the `useDndSensor` hook, which only accepts an `id`, we need to generate an `id` for every resource added to a `Cooperation` or `Course`.

### Resource Addition Scenarios:

- [x] **Resource added as a link**: In addition to the existing external `_id`, we generate a new `id` using `uuidv4()`.
- [x]  **Resource added as a duplicate copy**: We generate a new `id` using `uuidv4()` and reset the existing external `_id` to _an empty string_ (this was necessary due to multiple type errors when setting `_id` as optional and always deleting). We also set `isDuplicate` to `true`.
<img width="1593" alt="payload - course" src="https://github.com/user-attachments/assets/3d0907c3-f143-4e72-bbbd-d416f8625b2c">

### In response, we receive:

- [x] **Resource added as a link**:  The generated `id` created by `uuidv4()` and the external `_id`.
- [x]  **Resource added as a duplicate copy**:  The generated `id` created by `uuidv4()` and the external `_id` of the recently created resource in the proper entity (`Lesson`, `Quiz`, or `Attachment`).
<img width="1446" alt="Screenshot 2024-08-26 at 17 27 55" src="https://github.com/user-attachments/assets/14c6cb19-c68e-4e6b-8a68-0e0ea236ee28">

## Additionally: 
- [x] Created a utility function `isValidUUID` for testing purposes to verify the validity of the generated `id`.
- [x] Rewrote tests to improve coverage of the code.

_Current Test Coverage:_
<img width="1236" alt="Screenshot 2024-08-26 at 13 26 58" src="https://github.com/user-attachments/assets/0c3df8b7-22c2-4217-a57d-9e437bd13512">
<img width="1236" alt="Screenshot 2024-08-26 at 14 02 31" src="https://github.com/user-attachments/assets/c907b876-2a81-451c-94af-ed29635473f8">

