### PR TITLE
Fix pagination Find offers page

### DIFF
--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, ChangeEvent, useState, useMemo } from 'react'
+import {
+  useCallback,
+  useEffect,
+  ChangeEvent,
+  useState,
+  useMemo,
+  useRef
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -111,10 +118,15 @@ const FindOffers = () => {
 
   const defaultParams = { page: defaultFilters(oppositeRole).page }
 
+  const pageWrapperRef = useRef<HTMLDivElement>(null)
+
   const handlePageChange = (_: ChangeEvent<unknown>, page: number) => {
     filterQueryActions.updateFiltersInQuery({ page })
-  }
 
+    if (pageWrapperRef.current) {
+      pageWrapperRef.current.scrollIntoView()
+    }
+  }
   const handleShowingTutorOffers = () => {
     const updatedRole = getOpositeRole(filters.authorRole)
     filterQueryActions.updateFiltersInQuery({
@@ -124,7 +136,7 @@ const FindOffers = () => {
   }
 
   return (
-    <PageWrapper>
+    <PageWrapper ref={pageWrapperRef}>
       <OfferRequestBlock />
       <TitleWithDescription
         description={t('findOffers.titleWithDescription.description')}

--- a/tests/unit/pages/find-offers/FindOffers.spec.jsx
+++ b/tests/unit/pages/find-offers/FindOffers.spec.jsx
@@ -42,6 +42,8 @@ const filterQueryMock = {
   }
 }
 
+const scrollIntoViewMock = vi.fn()
+
 describe('FindOffers component', () => {
   const desktopData = {
     isLaptopAndAbove: true,
@@ -49,6 +51,7 @@ describe('FindOffers component', () => {
     isTablet: false
   }
   beforeEach(async () => {
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock
     await waitFor(() => {
       useFilterQuery.mockReturnValue(filterQueryMock)
       useBreakpoints.mockImplementation(() => desktopData)
@@ -133,6 +136,7 @@ describe('FindOffers component', () => {
 
     fireEvent.click(secondPage)
 
+    expect(scrollIntoViewMock).toHaveBeenCalled()
     expect(
       filterQueryMock.filterQueryActions.updateFiltersInQuery
     ).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
After pressing to the next page showing bottom of the next page .
The top of the page should be displayed

**Before:**

https://github.com/user-attachments/assets/17edc93a-99cb-47dc-bb36-f0689e47a8d1

**After:**

https://github.com/user-attachments/assets/46b51896-4e2d-4799-983a-f94cf1960165

