### PR TITLE
Fixed course template duplication issues in Cooperation #2395

### DIFF
--- a/src/redux/features/cooperationsSlice.ts
+++ b/src/redux/features/cooperationsSlice.ts
@@ -75,7 +75,7 @@ const cooperationsSlice = createSlice({
     ) {
       state.sections = (action.payload ?? []).map((section) => ({
         ...section,
-        id: section._id ?? uuidv4(),
+        id: uuidv4(),
         resources: (section.resources ?? []).map((resource) => ({
           ...resource,
           resource: { ...resource.resource, id: uuidv4() }

--- a/tests/unit/redux/cooperationsSlice.spec.js
+++ b/tests/unit/redux/cooperationsSlice.spec.js
@@ -29,12 +29,21 @@ describe('Test cooperationsSlice', () => {
 
   it('should set sections correctly with setCooperationSections', () => {
     const sections = [
-      { _id: '1', id: '1', resources: [] },
-      { _id: '2', id: '2', resources: [] }
+      { _id: '1', resources: [] },
+      { _id: '2', resources: [] }
     ]
     const action = setCooperationSections(sections)
     const state = reducer(initialState, action)
-    expect(state.sections).toEqual(sections)
+
+    expect(state.sections).toEqual(
+      sections.map((section) => ({
+        ...section,
+        id: expect.any(String)
+      }))
+    )
+    state.sections.forEach((section) => {
+      expect(isValidUUID(section.id)).toBe(true)
+    })
   })
 
   it('should set sections and resources correctly with setCooperationSections (with _id)', () => {
@@ -59,19 +68,25 @@ describe('Test cooperationsSlice', () => {
     expect(state.sections).toMatchObject([
       {
         _id: '1',
-        id: '1',
+        id: expect.any(String),
         resources: [
           {
             _id: 'some id',
             resource: {
               id: expect.any(String)
             },
-            resourceType: 'attachment',
+            resourceType: ResourceType.Attachment,
             title: 'Resource 1'
           }
         ]
       }
     ])
+    state.sections.forEach((section) => {
+      expect(isValidUUID(section.id)).toBe(true)
+      section.resources.forEach((resource) => {
+        expect(isValidUUID(resource.resource.id)).toBe(true)
+      })
+    })
   })
 
   it('should set sections and resources correctly with setCooperationSections (without _id)', () => {


### PR DESCRIPTION
### Fixed course template duplication issues in Cooperation [ Close #2395 ]
The following issues, which occurred when adding the same course template twice or more to a `Cooperation`, have been resolved:
- Reordering sections was impossible.
- Deleting sections was impossible.
- Adding or editing resources within sections was impossible.

This issue was due to a warning in the console: "`Encountered two children with the same key`". This indicated that duplicate elements with the same key were present, causing the application to malfunction. This issue severely impacted the ability to manage and organize courses within cooperation, making it unusable:
<img width="1650" alt="Screenshot 2024-08-28 at 17 57 27" src="https://github.com/user-attachments/assets/8fe3216f-8404-431d-a7aa-fe404a687c77">

#

**This fix resolves the issue by generating a unique `id` (using `uuidv4`) for every section added from a course template, ensuring proper course management:**

<img width="1521" alt="Screenshot 2024-08-28 at 18 23 51" src="https://github.com/user-attachments/assets/95636493-653f-459a-8ded-acb6f3e6f81c">
