### PR TITLE
Fix text on the filter drawer on My Courses page

### DIFF
--- a/src/constants/translations/uk/my-courses-page.json
+++ b/src/constants/translations/uk/my-courses-page.json
@@ -32,7 +32,7 @@
   "coursesFilter": {
     "coursesFilterLabel": "Фільтри Курсів",
     "chooseThe": "Обрати ",
-    "choose": "Обрати",
+    "choose": "Обрати ",
     "category": "категорію",
     "subject": "тему",
     "levels": "рівні",


### PR DESCRIPTION
Add space between words(UK translation).

Actual result:
![image](https://github.com/user-attachments/assets/2ca1cf95-2a74-4acc-81aa-5a8857078770)
