### PR TITLE
Added spacing utility classes

### DIFF
--- a/src/components/app-button/AppButton.scss
+++ b/src/components/app-button/AppButton.scss
@@ -57,28 +57,28 @@
 %size-small {
   font-size: var(--#{$prefix}font-size-sm);
   line-height: var(--#{$prefix}line-height-sm);
-  padding: var(--#{$prefix}space-sm);
-  column-gap: var(--#{$prefix}space-sm);
+  padding: var(--#{$prefix}space-1);
+  column-gap: var(--#{$prefix}space-1);
 }
 
 %size-medium {
-  padding: var(--#{$prefix}space-sm) var(--#{$prefix}space-md);
-  column-gap: var(--#{$prefix}space-sm);
+  padding: var(--#{$prefix}space-1) var(--#{$prefix}space-1-5);
+  column-gap: var(--#{$prefix}space-1);
 }
 
 %size-large {
-  padding: var(--#{$prefix}space-md) var(--#{$prefix}space-lg);
-  column-gap: var(--#{$prefix}space-md);
+  padding: var(--#{$prefix}space-1-5) var(--#{$prefix}space-2);
+  column-gap: var(--#{$prefix}space-1-5);
 }
 
 %size-extra-large {
-  padding: var(--#{$prefix}space-lg);
-  column-gap: var(--#{$prefix}space-md);
+  padding: var(--#{$prefix}space-2);
+  column-gap: var(--#{$prefix}space-1-5);
 }
 
 %size-xxl {
-  padding: var(--#{$prefix}space-md) var(--#{$prefix}space-2xl);
-  column-gap: var(--#{$prefix}space-md);
+  padding: var(--#{$prefix}space-1-5) var(--#{$prefix}space-4);
+  column-gap: var(--#{$prefix}space-1-5);
 }
 
 %variant-contained {

--- a/src/scss/_functions.scss
+++ b/src/scss/_functions.scss
@@ -1,0 +1,47 @@
+@use 'variables' as gv;
+@use 'sass:map';
+
+/**
+ * @function build-var-name
+ * Constructs a CSS variable name with an optional suffix, prefixed by a global prefix.
+ */
+
+@function build-var-name($name, $suffix) {
+  @if $suffix != null and $suffix != '' {
+    @return '--#{gv.$prefix}#{$name}-#{$suffix}';
+  }
+  @return '--#{gv.$prefix}#{$name}';
+}
+
+/**
+ * @function get-var
+ * Retrieves the value of a CSS variable by constructing its name using a base name and optional suffix.
+ */
+
+@function get-var($name, $suffix) {
+  $var-name: build-var-name($name, $suffix);
+  @return var(#{$var-name});
+}
+
+/**
+ * @function map-to-var-map
+ * Converts a map's values into CSS variables, constructing variable names using a base name and each key as a suffix.
+ */
+
+@function map-to-var-map($map, $var-name) {
+  $new-map: ();
+
+  @each $key, $value in $map {
+    $new-key: $key;
+    $new-value: get-var($var-name, $key);
+
+    $new-map: map.merge(
+      $new-map,
+      (
+        $new-key: $new-value
+      )
+    );
+  }
+
+  @return $new-map;
+}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -1,4 +1,5 @@
 @use 'variables' as *;
+@use 'functions' as *;
 @use 'sass:map';
 @use 'sass:math';
 
@@ -13,9 +14,57 @@
  *
  */
 
-@mixin generate-css-variables($map, $prefix: '') {
-  @each $key, $value in $map {
-    --#{$prefix}#{$key}: #{$value};
+/*=============================================
+ =                CSS variables               =
+ =============================================*/
+
+/**
+ * @mixin register-var
+ * Registers a CSS variable with a specified value, constructing its name using a base name and optional suffix.
+ */
+
+@mixin register-var($name, $suffix, $value) {
+  $var-name: build-var-name($name, $suffix);
+
+  #{$var-name}: #{$value};
+}
+
+/**
+ * @mixin register-vars
+ * Registers multiple CSS variables using a map of suffixes and values, optionally specifying a base name.
+ */
+
+@mixin register-vars($vars, $name) {
+  @each $suffix, $value in $vars {
+    @include register-var($name, $suffix, $value);
+  }
+}
+
+/*=============================================
+ =                Utility classes             =
+ =============================================*/
+
+/**
+ * @mixin generate-utilities
+ * This mixin generates utility classes based on a provided configuration map.
+ *
+ * @param {Map} $utility - A map containing the configuration for utility classes.
+ *   - 'values': A map where keys are the utility class suffixes and values are the corresponding property values.
+ *   - 'class': The base class name for the utility classes.
+ *   - 'properties': A list of CSS properties that will be set using the values from the 'values' map.
+ */
+
+@mixin generate-utilities($utility) {
+  $values: map.get($utility, 'values');
+  $class: map.get($utility, 'class');
+  $properties: map.get($utility, 'properties');
+
+  @each $key, $value in $values {
+    .#{$class}-#{$key} {
+      @each $property in $properties {
+        #{$property}: #{$value};
+      }
+    }
   }
 }
 

--- a/src/scss/_root.scss
+++ b/src/scss/_root.scss
@@ -3,35 +3,32 @@
 
 :root {
   // Colors
-  @include generate-css-variables($blue-grays, '#{$prefix}blue-gray-');
-  @include generate-css-variables($turquoises, '#{$prefix}turquoise-');
-  @include generate-css-variables($blues, '#{$prefix}blue-');
-  @include generate-css-variables($greens, '#{$prefix}green-');
-  @include generate-css-variables($yellows, '#{$prefix}yellow-');
-  @include generate-css-variables($purples, '#{$prefix}purple-');
-  @include generate-css-variables($reds, '#{$prefix}red-');
-  @include generate-css-variables($neutrals, '#{$prefix}neutral-');
+  @include register-vars($blue-grays, 'blue-gray');
+  @include register-vars($turquoises, 'turquoise');
+  @include register-vars($blues, 'blue');
+  @include register-vars($greens, 'green');
+  @include register-vars($yellows, 'yellow');
+  @include register-vars($purples, 'purple');
+  @include register-vars($reds, 'red');
+  @include register-vars($neutrals, 'neutral');
 
   // Breakpoints
-  @include generate-css-variables($breakpoints, '#{$prefix}breakpoint-');
+  @include register-vars($breakpoints, 'breakpoint');
 
   // Borders
-  @include generate-css-variables($border-radiuses, '#{$prefix}border-radius-');
-  @include generate-css-variables($border-widths, '#{$prefix}border-width-');
+  @include register-vars($border-radiuses, 'border-radius');
+  @include register-vars($border-widths, 'border-width');
 
   // Typography
-  @include generate-css-variables($font-families, '#{$prefix}font-family-');
-  @include generate-css-variables($font-sizes, '#{$prefix}font-size-');
-  @include generate-css-variables($font-weights, '#{$prefix}font-weight-');
-  @include generate-css-variables($line-heights, '#{$prefix}line-height-');
-  @include generate-css-variables(
-    $letter-spacings,
-    '#{$prefix}letter-spacing-'
-  );
+  @include register-vars($font-families, 'font-family');
+  @include register-vars($font-sizes, 'font-size');
+  @include register-vars($font-weights, 'font-weight');
+  @include register-vars($line-heights, 'line-height');
+  @include register-vars($letter-spacings, 'letter-spacing');
 
   // Spacing
-  @include generate-css-variables($spaces, '#{$prefix}space-');
+  @include register-vars($spaces, 'space');
 
   // Shadows
-  @include generate-css-variables($box-shadows, '#{$prefix}box-shadow-');
+  @include register-vars($box-shadows, 'box-shadow');
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -384,42 +384,46 @@ $breakpoints: (
 =                  SPACING                   =
 =============================================*/
 
-$space-2xs: 2px !default;
-$space-xs: 4px !default;
-$space-sm: 8px !default;
-$space-md: 12px !default;
-$space-lg: 16px !default;
-$space-xl: 24px !default;
-$space-2xl: 32px !default;
-$space-3xl: 40px !default;
-$space-4xl: 48px !default;
-$space-5xl: 56px !default;
-$space-6xl: 64px !default;
-$space-7xl: 72px !default;
-$space-8xl: 80px !default;
-$space-9xl: 88px !default;
-$space-10xl: 96px !default;
-$space-11xl: 104px !default;
-$space-12xl: 112px !default;
+$space-baseline: 8px !default;
+
+$space-0: 0 !default;
+$space-0-25: $space-baseline * 0.25 !default;
+$space-0-5: $space-baseline * 0.5 !default;
+$space-1: $space-baseline !default;
+$space-1-5: $space-baseline * 1.5 !default;
+$space-2: $space-baseline * 2 !default;
+$space-3: $space-baseline * 3 !default;
+$space-4: $space-baseline * 4 !default;
+$space-5: $space-baseline * 5 !default;
+$space-6: $space-baseline * 6 !default;
+$space-7: $space-baseline * 7 !default;
+$space-8: $space-baseline * 8 !default;
+$space-9: $space-baseline * 9 !default;
+$space-10: $space-baseline * 10 !default;
+$space-11: $space-baseline * 11 !default;
+$space-12: $space-baseline * 12 !default;
+$space-13: $space-baseline * 13 !default;
+$space-14: $space-baseline * 14 !default;
 
 $spaces: (
-  2xs: $space-2xs,
-  xs: $space-xs,
-  sm: $space-sm,
-  md: $space-md,
-  lg: $space-lg,
-  xl: $space-xl,
-  2xl: $space-2xl,
-  3xl: $space-3xl,
-  4xl: $space-4xl,
-  5xl: $space-5xl,
-  6xl: $space-6xl,
-  7xl: $space-7xl,
-  8xl: $space-8xl,
-  9xl: $space-9xl,
-  10xl: $space-10xl,
-  11xl: $space-11xl,
-  12xl: $space-12xl
+  0: $space-0,
+  '0-25': $space-0-25,
+  '0-5': $space-0-5,
+  1: $space-1,
+  '1-5': $space-1-5,
+  2: $space-2,
+  3: $space-3,
+  4: $space-4,
+  5: $space-5,
+  6: $space-6,
+  7: $space-7,
+  8: $space-8,
+  9: $space-9,
+  10: $space-10,
+  11: $space-11,
+  12: $space-12,
+  13: $space-13,
+  14: $space-14
 ) !default;
 
 /*=============================================

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -1,8 +1,11 @@
 @charset 'UTF-8';
 
 @forward 'mixins';
+@forward 'functions';
 @forward 'variables';
 @forward 'root';
 @forward 'reset';
+
+@forward 'utilities/index';
 
 @import 'https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,100..900&family=Rubik:wght@300..900&display=swap';

--- a/src/scss/utilities.scss
+++ b/src/scss/utilities.scss
@@ -1,4 +1,5 @@
 @charset 'UTF-8';
 
 @forward 'mixins';
+@forward 'functions';
 @forward 'variables';

--- a/src/scss/utilities/_index.scss
+++ b/src/scss/utilities/_index.scss
@@ -1,0 +1,3 @@
+@charset 'UTF-8';
+
+@forward 'spacing';

--- a/src/scss/utilities/spacing.scss
+++ b/src/scss/utilities/spacing.scss
@@ -90,79 +90,37 @@ $spacing-utilities: (
     (
       class: 'p',
       properties: padding,
-      values:
-        map.merge(
-          $space-var-map,
-          (
-            'auto': 'auto'
-          )
-        )
+      values: $space-var-map
     ),
   'padding-x': (
     class: 'px',
     properties: padding-right padding-left,
-    values:
-      map.merge(
-        $space-var-map,
-        (
-          'auto': 'auto'
-        )
-      )
+    values: $space-var-map
   ),
   'padding-y': (
     class: 'py',
     properties: padding-top padding-bottom,
-    values:
-      map.merge(
-        $space-var-map,
-        (
-          'auto': 'auto'
-        )
-      )
+    values: $space-var-map
   ),
   'padding-top': (
     class: 'pt',
     properties: padding-top,
-    values:
-      map.merge(
-        $space-var-map,
-        (
-          'auto': 'auto'
-        )
-      )
+    values: $space-var-map
   ),
   'padding-right': (
     class: 'pr',
     properties: padding-right,
-    values:
-      map.merge(
-        $space-var-map,
-        (
-          'auto': 'auto'
-        )
-      )
+    values: $space-var-map
   ),
   'padding-bottom': (
     class: 'pb',
     properties: padding-bottom,
-    values:
-      map.merge(
-        $space-var-map,
-        (
-          'auto': 'auto'
-        )
-      )
+    values: $space-var-map
   ),
   'padding-left': (
     class: 'pl',
     properties: padding-left,
-    values:
-      map.merge(
-        $space-var-map,
-        (
-          'auto': 'auto'
-        )
-      )
+    values: $space-var-map
   )
 );
 

--- a/src/scss/utilities/spacing.scss
+++ b/src/scss/utilities/spacing.scss
@@ -1,0 +1,171 @@
+@use '../variables' as *;
+@use '../functions' as *;
+@use '../mixins' as *;
+@use 'sass:map';
+
+$space-var-map: map-to-var-map($spaces, 'space');
+
+$spacing-utilities: (
+  // Margin utilities
+  'margin':
+    (
+      class: 'm',
+      properties: margin,
+      values:
+        map.merge(
+          $space-var-map,
+          (
+            'auto': 'auto'
+          )
+        )
+    ),
+  'margin-x': (
+    class: 'mx',
+    properties: margin-right margin-left,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'margin-y': (
+    class: 'my',
+    properties: margin-top margin-bottom,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'margin-top': (
+    class: 'mt',
+    properties: margin-top,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'margin-right': (
+    class: 'mr',
+    properties: margin-right,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'margin-bottom': (
+    class: 'mb',
+    properties: margin-bottom,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'margin-left': (
+    class: 'ml',
+    properties: margin-left,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  // Padding utilities
+  'padding':
+    (
+      class: 'p',
+      properties: padding,
+      values:
+        map.merge(
+          $space-var-map,
+          (
+            'auto': 'auto'
+          )
+        )
+    ),
+  'padding-x': (
+    class: 'px',
+    properties: padding-right padding-left,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'padding-y': (
+    class: 'py',
+    properties: padding-top padding-bottom,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'padding-top': (
+    class: 'pt',
+    properties: padding-top,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'padding-right': (
+    class: 'pr',
+    properties: padding-right,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'padding-bottom': (
+    class: 'pb',
+    properties: padding-bottom,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  ),
+  'padding-left': (
+    class: 'pl',
+    properties: padding-left,
+    values:
+      map.merge(
+        $space-var-map,
+        (
+          'auto': 'auto'
+        )
+      )
+  )
+);
+
+@each $key, $utility in $spacing-utilities {
+  @include generate-utilities($utility);
+}


### PR DESCRIPTION
### Added spacing utility classes

1. Implemented classes for the spacing sizes (in pixels) in our [design system](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=19221-83833&t=cYz7glelRkcnqB4P-4).
2. Provided utility classes for margins
    - `m` - margin
    - `mx` - margin-left, margin-right
    - `my` - margin-top, margin-bottom
    - `mt` - margin-top
    - `mr` - margin-right
    - `mb` - margin-bottom 
    - `ml` - margin-left
3. Provided utility classes for paddings
    - `p` - padding
    - `px` - padding-left, padding-right
    - `py` - padding-top, padding-bottom
    - `pt` - padding-top
    - `pr` - padding-right
    - `pb` - padding-bottom 
    - `pl` - padding-left
    #### Example of usage:
```typescript
className="m-1-5 px-3 py-0-5"
```
4. Created mixin `generate-utilities` that generates utility classes based on a provided configuration map. Our utility classes can be easily scaled with this mixin

### Additional
1. Reorganized creation of CSS variables by replacing `generate-css-variables($map, $prefix)` with `register-vars($vars, $name)`
2. Created `get-var($name, $suffix)` function that retrieves the value of a CSS variable by constructing its name using a base name and optional suffix. 
#### These changes will reduce the amount of boilerplate code when working with CSS variables.