### PR TITLE
Added background color utility classes

### DIFF
--- a/src/scss/utilities/_index.scss
+++ b/src/scss/utilities/_index.scss
@@ -1,3 +1,4 @@
 @charset 'UTF-8';
 
+@forward 'background';
 @forward 'spacing';

--- a/src/scss/utilities/background.scss
+++ b/src/scss/utilities/background.scss
@@ -44,6 +44,15 @@ $bg-utilities: (
     class: 'bg-neutral',
     properties: background-color,
     values: map-to-var-map($neutrals, 'neutral')
+  ),
+  'bg': (
+    class: 'bg',
+    properties: background-color,
+    values: (
+      'inherit': 'inherit',
+      'transparent': 'transparent',
+      'current': 'currentColor'
+    )
   )
 );
 

--- a/src/scss/utilities/background.scss
+++ b/src/scss/utilities/background.scss
@@ -1,0 +1,52 @@
+@use '../variables' as *;
+@use '../functions' as *;
+@use '../mixins' as *;
+
+$bg-utilities: (
+  // Background color utilities
+  'bg-blue-gray':
+    (
+      class: 'bg-blue-gray',
+      properties: background-color,
+      values: map-to-var-map($blue-grays, 'blue-gray')
+    ),
+  'bg-turquoise': (
+    class: 'bg-turquoise',
+    properties: background-color,
+    values: map-to-var-map($turquoises, 'turquoise')
+  ),
+  'bg-blue': (
+    class: 'bg-blue',
+    properties: background-color,
+    values: map-to-var-map($blues, 'blue')
+  ),
+  'bg-green': (
+    class: 'bg-green',
+    properties: background-color,
+    values: map-to-var-map($greens, 'green')
+  ),
+  'bg-yellow': (
+    class: 'bg-yellow',
+    properties: background-color,
+    values: map-to-var-map($yellows, 'yellow')
+  ),
+  'bg-purple': (
+    class: 'bg-purple',
+    properties: background-color,
+    values: map-to-var-map($purples, 'purple')
+  ),
+  'bg-red': (
+    class: 'bg-red',
+    properties: background-color,
+    values: map-to-var-map($reds, 'red')
+  ),
+  'bg-neutral': (
+    class: 'bg-neutral',
+    properties: background-color,
+    values: map-to-var-map($neutrals, 'neutral')
+  )
+);
+
+@each $key, $utility in $bg-utilities {
+  @include generate-utilities($utility);
+}


### PR DESCRIPTION
### Added background color utility classes

1. Implemented utility classes for background colors each class corresponds to a specific CSS color variable from our design system:
    - `bg-glue-gray-[shade]` 
    - `bg-turquoise-[shade]`
    - `bg-blue-[shade]`
    - `bg-green-[shade]`
    - `bg-yellow-[shade]`
    - `bg-purple-[shade]`
    - `bg-red-[shade]`
    - `bg-neutral-[shade]`
2. Provided additional utility classes:
    - `bg-inherit` - background-color: inherit;
    - `bg-current` - background-color: currentColor;
    - `bg-transparent` - background-color: transparent;

    #### Example of usage:
```typescript
className="bg-red-500"
className="bg-transparent"
```
