### PR TITLE
Fixed all of the warnings during tests run

### DIFF
--- a/src/components/app-select/AppSelect.tsx
+++ b/src/components/app-select/AppSelect.tsx
@@ -35,7 +35,7 @@ const AppSelect = <T,>({
   const fieldsList = fields.map(({ title, value }) => {
     if (typeof value === 'string' || typeof value === 'number') {
       return (
-        <MenuItem key={title} value={value}>
+        <MenuItem key={title + value} value={value}>
           {t(title)}
         </MenuItem>
       )

--- a/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category/ProfessionalCategory.tsx
@@ -113,14 +113,16 @@ const ProfessionalCategory: FC<ProfessionalCategoryProps> = ({
             )
           }
         >
-          <IconButton
-            data-testid='delete-professional-category-button'
-            disabled={item.isDeletionBlocked}
-            onClick={handleDeleteButtonClick}
-            sx={styles.toolbar.deleteButton}
-          >
-            <DeleteIcon />
-          </IconButton>
+          <Box component='span'>
+            <IconButton
+              data-testid='delete-professional-category-button'
+              disabled={item.isDeletionBlocked}
+              onClick={handleDeleteButtonClick}
+              sx={styles.toolbar.deleteButton}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Box>
         </Tooltip>
       </Box>
       <Box component={ComponentEnum.Dl} sx={styles.description.grid}>

--- a/src/containers/user-profile/comments-with-rating-block/CommentsWithRatingBlock.constants.ts
+++ b/src/containers/user-profile/comments-with-rating-block/CommentsWithRatingBlock.constants.ts
@@ -132,14 +132,14 @@ export const responseMockStudents: { items: MockReview[] } = {
     {
       ...mockResponseItemBase,
       author: tutorMockAuthor,
-      _id: '6400f540307bdcc5da14aa5x',
+      _id: '6400f540307bdcc5da14aa5t',
       comment: 'Exercitation veniam consequat sunt nostrud amet.',
       rating: 3
     },
     {
       ...mockResponseItemBase,
       author: tutorMockAuthor,
-      _id: '6400f540307sfcc5da14aa5o',
+      _id: '6400f540307bdcc5da14aa5u',
       comment:
         'The classes are relaxed and I like that she is responsible for her learning.',
       rating: 4

--- a/src/pages/subjects/Subjects.tsx
+++ b/src/pages/subjects/Subjects.tsx
@@ -148,6 +148,9 @@ const Subjects = () => {
 
   const handleOpenModal = () => openModal({ component: <CreateSubjectModal /> })
 
+  const getOptionLabel = (option: string | Pick<SubjectInterface, 'name'>) =>
+    typeof option === 'string' ? option : option.name
+
   return (
     <PageWrapper>
       <OfferRequestBlock />
@@ -175,6 +178,7 @@ const Subjects = () => {
       <AppToolbar sx={styles.searchToolbar}>
         {!breakpoints.isMobile && autoCompleteCategories}
         <SearchAutocomplete
+          getOptionLabel={getOptionLabel}
           loading={subjectNamesLoading}
           onFocus={getSubjectNames}
           onSearchChange={resetData}

--- a/tests/unit/components/changing-confirm/ChangingConfirm.spec.jsx
+++ b/tests/unit/components/changing-confirm/ChangingConfirm.spec.jsx
@@ -15,8 +15,8 @@ describe('ChangeConfirm component tests', () => {
   const props = {
     title: 'Course Title',
     courseList: [
-      { title: 'Course 1', subTitle: 'subtitle1' },
-      { title: 'Course 2', subTitle: 'subtitle2' }
+      { title: 'Course 1', subTitle: 'subtitle1', id: "1" },
+      { title: 'Course 2', subTitle: 'subtitle2', id: "2" }
     ],
     open: true,
     onClose: () => {}

--- a/tests/unit/components/cooperation-section-view/CooperationSectionView.spec.jsx
+++ b/tests/unit/components/cooperation-section-view/CooperationSectionView.spec.jsx
@@ -10,7 +10,7 @@ describe('CooperationSectionView', () => {
     resources: [
       {
         resource: {
-          _id: '662ba5f9f3edc14ca7b2336f',
+          id: '662ba5f9f3edc14ca7b2336f',
           title: 'The newest',
           description:
             'The newestThe newestThe newestThe newestThe newestThe newestThe newest',

--- a/tests/unit/containers/course-section/resources-list/ResourcesList.spec.jsx
+++ b/tests/unit/containers/course-section/resources-list/ResourcesList.spec.jsx
@@ -6,7 +6,7 @@ import { ResourcesTypesEnum as ResourceType } from '~/types'
 
 const mockedLessonData = [
   {
-    _id: '1',
+    id: '1',
     title: 'Lesson1',
     author: 'some author',
     content: 'Content',
@@ -16,7 +16,7 @@ const mockedLessonData = [
     resourceType: ResourceType.Lesson
   },
   {
-    _id: '2',
+    id: '2',
     title: 'Lesson2',
     author: 'new author',
     content: 'Content',

--- a/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
+++ b/tests/unit/containers/course-sections-list/CourseSectionsList.spec.jsx
@@ -23,7 +23,7 @@ const mockedCourseSectionData = Array(5)
             status: 'open',
             date: null
           },
-          _id: '64cd12f1fad091e0sfe12134',
+          id: '64cd12f1fad091e0sfe12134',
           title: 'Lesson1',
           author: 'some author',
           content: 'Content',
@@ -39,7 +39,7 @@ const mockedCourseSectionData = Array(5)
             status: 'open',
             date: null
           },
-          _id: '64fb2c33eba89699411d22bb',
+          id: '64fb2c33eba89699411d22bb',
           title: 'Quiz',
           description: '',
           items: [],
@@ -56,7 +56,7 @@ const mockedCourseSectionData = Array(5)
             status: 'open',
             date: null
           },
-          _id: '64cd12f1fad091e0ee719830',
+          id: '64cd12f1fad091e0ee719830',
           author: '6494128829631adbaf5cf615',
           fileName: 'spanish.pdf',
           link: 'link',

--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -84,15 +84,15 @@ describe('AddProfessionalCategoryModal without initial value', () => {
     expect(professionalSubject).toHaveValue(professionalSubjectTemplate.name)
   })
 
-  it('should add one more subject group if "Add one more subject" button is clicked', () => {
+  it('should add one more subject group if "Add one more subject" button is clicked', async () => {
     const button = screen.getByText(
       /editProfilePage.profile.professionalTab.addCategoryModal.addSubjectBtn/
     )
 
     expect(button).toBeInTheDocument()
 
-    fireEvent.click(button)
-    fireEvent.click(button)
+    await act(() => fireEvent.click(button))
+    await act(() => fireEvent.click(button))
 
     const professionalSubjects = screen.getAllByLabelText(
       /editProfilePage.profile.professionalTab.subject/

--- a/tests/unit/containers/find-offer/offer-search-toolbar/offerSearchToolbar.spec.jsx
+++ b/tests/unit/containers/find-offer/offer-search-toolbar/offerSearchToolbar.spec.jsx
@@ -12,6 +12,10 @@ const filterActions = {
 const filters = defaultFilters('student')
 const resetPage = vi.fn()
 
+vi.mock('~/hooks/use-axios', () => ({
+  default: () => ({ loading: false, response: [], fetchData: () => {} })
+}))
+
 useBreakpoints.mockImplementation(() => ({ isLaptopAndAbove: true }))
 
 describe('OfferSearchToolbar', () => {

--- a/tests/unit/containers/guest-home-page/signup-dialog/SignupDialog.spec.jsx
+++ b/tests/unit/containers/guest-home-page/signup-dialog/SignupDialog.spec.jsx
@@ -1,9 +1,8 @@
 import { expect, vi } from 'vitest'
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor, renderHook } from '@testing-library/react'
 import SignupDialog from '~/containers/guest-home-page/signup-dialog/SignupDialog'
 import { renderWithProviders } from '~tests/test-utils'
 import { student } from '~/constants'
-import { renderHook } from '@testing-library/react-hooks'
 import useBreakpoints from '~/hooks/use-breakpoints'
 
 const mockSelector = vi.fn()
@@ -137,6 +136,7 @@ describe('Signup dialog test', () => {
       expect(signUp).toHaveBeenCalledTimes(1)
     })
   })
+
   it('isDesktop', () => {
     useBreakpoints.mockImplementation(() => ({
       isDesktop: true,

--- a/tests/unit/containers/my-cooperations/cooperation-notes/create-or-edit-note/CreateOrEditNote.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-notes/create-or-edit-note/CreateOrEditNote.spec.jsx
@@ -1,4 +1,6 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import { beforeEach } from 'vitest'
 import CreateOrEditNote from '~/containers/my-cooperations/cooperation-notes/create-or-edit-note/CreateOrEditNote'
 import { renderWithProviders } from '~tests/test-utils'
 
@@ -7,10 +9,12 @@ const addNewNoteMock = vi.fn()
 const noteMock = { text: 'noteText', isPrivate: true }
 
 describe('CreateOrEditNote component', () => {
-  beforeEach(() => {
-    renderWithProviders(
-      <CreateOrEditNote onSubmit={addNewNoteMock} onSubmitLoading={false} />
-    )
+  beforeEach(async () => {
+    await waitFor(() => {
+      renderWithProviders(
+        <CreateOrEditNote onSubmit={addNewNoteMock} onSubmitLoading={false} />
+      )
+    })
   })
 
   it('should render component', () => {
@@ -43,15 +47,19 @@ describe('CreateOrEditNote component', () => {
 })
 
 describe('CreateOrEditNote component with initial note', () => {
-  it('should set note as initial data to form', () => {
-    renderWithProviders(
-      <CreateOrEditNote
-        note={noteMock}
-        onSubmit={addNewNoteMock}
-        onSubmitLoading={false}
-      />
-    )
+  beforeEach(async () => {
+    await waitFor(() => {
+      renderWithProviders(
+        <CreateOrEditNote
+          note={noteMock}
+          onSubmit={addNewNoteMock}
+          onSubmitLoading={false}
+        />
+      )
+    })
+  })
 
+  it('should set note as initial data to form', () => {
     const noteText = screen.getByText(noteMock.text)
 
     expect(noteText).toBeInTheDocument()

--- a/tests/unit/containers/my-courses/add-course-with-input/AddCourseWithInput.spec.jsx
+++ b/tests/unit/containers/my-courses/add-course-with-input/AddCourseWithInput.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, act } from '@testing-library/react'
 import { renderWithProviders } from '~tests/test-utils'
 import AddCourseWithInput from '~/containers/my-courses/add-course-with-input/AddCourseWithInput'
 
@@ -16,6 +16,7 @@ describe('AddCourseWithInput test', () => {
       <AddCourseWithInput
         filterActions={mockedFilterActions}
         filters={mockedFilters}
+        sort=""
       />
     )
   })
@@ -42,11 +43,11 @@ describe('AddCourseWithInput test', () => {
     expect(mockedFilterActions.updateFiltersInQuery).toHaveBeenCalled()
   })
 
-  it('should render filters', () => {
+  it('should render filters', async () => {
     const filters = screen.getByText('filters.filtersListTitle')
 
     expect(filters).toBeInTheDocument()
-    fireEvent.click(filters)
+    await act(() => fireEvent.click(filters))
     const filtersModal = screen.getByRole('presentation')
     expect(filtersModal).toBeInTheDocument()
   })

--- a/tests/unit/containers/my-courses/course-toolbar/CourseToolbar.spec.jsx
+++ b/tests/unit/containers/my-courses/course-toolbar/CourseToolbar.spec.jsx
@@ -4,6 +4,7 @@ import CourseToolbar from '~/containers/my-courses/course-toolbar/CourseToolbar'
 import { URLs } from '~/constants/request'
 import { ProficiencyLevelEnum } from '~/types'
 import { proficiencyLevelLabels } from '~/constants/labels'
+import { act } from 'react-dom/test-utils'
 
 const mockData = {
   title: '',
@@ -139,8 +140,10 @@ describe('CourseToolbar', () => {
   })
 
   describe('with single render', () => {
-    beforeEach(() => {
-      render(getCourseToolbarElement())
+    beforeEach(async () => {
+      await waitFor(() => {
+        render(getCourseToolbarElement())
+      })
     })
 
     it('should render correctly', () => {

--- a/tests/unit/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.spec.jsx
+++ b/tests/unit/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.spec.jsx
@@ -56,8 +56,8 @@ const setup = async (filters) => {
 
 describe('CoursesFiltersDrawer', () => {
   describe('with default filters', () => {
-    beforeEach(() => {
-      setup(defaultFilters)
+    beforeEach(async () => {
+      await setup(defaultFilters)
     })
 
     it('renders filter titles correctly', async () => {

--- a/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
+++ b/tests/unit/containers/navigation-icons/AccountIcon.spec.jsx
@@ -14,20 +14,20 @@ vi.mock('~/services/user-service', () => ({
 
 describe('AccountIcon test with user role', () => {
   const preloadedState = { appMain: { userRole: 'tutor' } }
-  beforeEach(() => {
-    renderWithProviders(<AccountIcon openMenu={mockOpenMenu} />, {
-      preloadedState
+  beforeEach(async () => {
+    await waitFor(() => {
+      renderWithProviders(<AccountIcon openMenu={mockOpenMenu} />, {
+        preloadedState
+      })
     })
   })
 
-  it('should render click menu icon and open account menu after click on it', async () => {
-    const AccountIconButton = await screen.findByAltText('User Avatar')
+  it('should render click menu icon and open account menu after click on it', () => {
+    const AccountIconButton = screen.getByAltText('User Avatar')
     expect(AccountIconButton).toBeInTheDocument()
 
     fireEvent.click(AccountIconButton)
 
-    await waitFor(() => {
-      expect(mockOpenMenu).toHaveBeenCalled()
-    })
+    expect(mockOpenMenu).toHaveBeenCalled()
   })
 })

--- a/tests/unit/containers/navigation-icons/NavigationIcons.spec.jsx
+++ b/tests/unit/containers/navigation-icons/NavigationIcons.spec.jsx
@@ -42,9 +42,14 @@ describe('test with guest role', () => {
 
 describe('test with student role', () => {
   const preloadedState = { appMain: { userRole: 'student' } }
-  beforeEach(() => {
-    renderWithProviders(<NavigationIcons setSidebarOpen={setIsSidebarOpen} />, {
-      preloadedState
+  beforeEach(async () => {
+    await waitFor(() => {
+      renderWithProviders(
+        <NavigationIcons setSidebarOpen={setIsSidebarOpen} />,
+        {
+          preloadedState
+        }
+      )
     })
   })
 

--- a/tests/unit/containers/offer-page/faq-block/FaqBlock.spec.jsx
+++ b/tests/unit/containers/offer-page/faq-block/FaqBlock.spec.jsx
@@ -4,54 +4,71 @@ import FaqBlock from '~/containers/offer-page/faq-block/FaqBlock'
 import { renderWithProviders } from '~tests/test-utils'
 
 const handleNonInputValueChange = vi.fn()
+
 const mockDate = 1487076708000
 Date.now = vi.fn(() => mockDate)
-const mockedFaqData = { question: '', answer: '', id: `${mockDate}` }
 
-const data = {
-  FAQ: [mockedFaqData]
+const emptyQuestion = { question: '', answer: '', id: `${mockDate}` }
+const newQuestion = { question: 'New Question', answer: 'New Answer' }
+
+const generateQuestions = (length = 1) => {
+  return Array.from({ length }, (_, index) => ({
+    ...emptyQuestion,
+    id: String(mockDate + index)
+  }))
 }
 
-const props = {
-  data,
-  handleNonInputValueChange
+const renderAndMock = (questions = generateQuestions()) => {
+  const data = { FAQ: questions }
+  return renderWithProviders(
+    <FaqBlock
+      handleNonInputValueChange={handleNonInputValueChange}
+      data={data}
+    />
+  )
 }
 
 describe('FaqBlock component', () => {
-  beforeEach(() => {
-    renderWithProviders(<FaqBlock {...props} />)
-  })
   it('should update FAQ item when input changes', () => {
+    renderAndMock()
+
     const questionInput = screen.getByLabelText('offerPage.labels.question')
     const answerInput = screen.getByLabelText('offerPage.labels.answer')
 
     fireEvent.change(questionInput, {
-      target: { value: 'New question' }
+      target: { value: newQuestion.question }
     })
 
     expect(handleNonInputValueChange).toHaveBeenCalledWith('FAQ', [
-      { ...mockedFaqData, question: 'New question', answer: '' }
+      { ...emptyQuestion, question: newQuestion.question }
     ])
 
     fireEvent.change(answerInput, {
-      target: { value: 'New answer' }
+      target: { value: newQuestion.answer }
     })
 
     expect(handleNonInputValueChange).toHaveBeenCalledWith('FAQ', [
-      { ...mockedFaqData, question: '', answer: 'New answer' }
+      { ...emptyQuestion, answer: newQuestion.answer }
     ])
   })
 
-  it('should add question or show error', () => {
+  it('should add question', () => {
+    renderAndMock()
+
     const addButton = screen.getByText('button.addQuestion')
     fireEvent.click(addButton)
 
     expect(handleNonInputValueChange).toHaveBeenCalledWith('FAQ', [
-      ...data.FAQ,
-      mockedFaqData
+      emptyQuestion,
+      emptyQuestion
     ])
+  })
 
-    data.FAQ.push(...Array(4).fill(mockedFaqData))
+  it('should show error when questions limit is reached', () => {
+    const initialQuestions = generateQuestions(5)
+    renderAndMock(initialQuestions)
+
+    const addButton = screen.getByText('button.addQuestion')
     fireEvent.click(addButton)
 
     const errorMessage = screen.getByText('offerPage.errorMessages.faq')
@@ -59,12 +76,15 @@ describe('FaqBlock component', () => {
   })
 
   it('should remove question', () => {
+    const initialQuestions = generateQuestions(2)
+    renderAndMock(initialQuestions)
+
     const closeButton = screen.getAllByTestId('CloseRoundedIcon')[0]
     fireEvent.click(closeButton)
 
     expect(handleNonInputValueChange).toHaveBeenCalledWith(
       'FAQ',
-      data.FAQ.slice(1)
+      [initialQuestions[1]]
     )
   })
 })

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { renderWithProviders, TestSnackbar } from '~tests/test-utils'
 
 import { useMatch } from 'react-router-dom'
@@ -97,9 +97,9 @@ describe('ProfileInfo component tests', () => {
       renderWithBreakpoints(laptopData, 'student')
     })
 
-    it('should copy link to profile', () => {
+    it('should copy link to profile', async () => {
       const iconBtn = screen.getByTestId('icon-btn')
-      fireEvent.click(iconBtn)
+      await act(() => fireEvent.click(iconBtn))
 
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled()
     })

--- a/tests/unit/pages/chat/Chat.spec.jsx
+++ b/tests/unit/pages/chat/Chat.spec.jsx
@@ -1,5 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { fireEvent, screen, waitFor, act } from '@testing-library/react'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import Chat from '~/pages/chat/Chat'
@@ -91,27 +90,21 @@ describe('Chat for desktop', () => {
   })
 
   it('should send new message and clear input', async () => {
-    const user = userEvent.setup()
-
     const chatItem = screen.getByText('Scott Short')
 
-    waitFor(() => {
-      fireEvent.click(chatItem)
-    })
+    fireEvent.click(chatItem)
 
     const messageInput = await screen.findByLabelText(
       'chatPage.chat.inputLabel'
     )
 
-    await user.type(messageInput, 'new message')
+    fireEvent.change(messageInput, { target: { value: 'new message' } })
 
     expect(messageInput.value).toBe('new message')
 
     const sendBtn = screen.getByTestId('send-btn')
 
-    waitFor(() => {
-      fireEvent.click(sendBtn)
-    })
+    await act(() => fireEvent.click(sendBtn))
 
     expect(messageInput.value).toBe('')
   })
@@ -123,11 +116,12 @@ describe('Chat for mobile', () => {
     isMobile: true,
     isTablet: false
   }
-  beforeEach(() => {
+  beforeEach(async () => {
     useBreakpoints.mockImplementation(() => mobileData)
 
-    renderWithProviders(<Chat />)
+    await waitFor(() => renderWithProviders(<Chat />))
   })
+
   it('should render just right pane in a chat', async () => {
     const chip = await screen.findByText('chatPage.chat.chipLabel')
 

--- a/tests/unit/pages/chat/messages-list/MessagesList.spec.jsx
+++ b/tests/unit/pages/chat/messages-list/MessagesList.spec.jsx
@@ -6,6 +6,8 @@ vi.mock('~/components/message/Message', () => ({
   default: vi.fn(() => <div data-testid='mock-message'>Mock Message</div>)
 }))
 
+vi.spyOn(window, "getComputedStyle").mockReturnValue(new CSSStyleDeclaration)
+
 global.IntersectionObserver = vi.fn().mockImplementation((callback) => ({
   observe: vi.fn(),
   unobserve: vi.fn(),

--- a/tests/unit/pages/create-course/CreateCourse.spec.jsx
+++ b/tests/unit/pages/create-course/CreateCourse.spec.jsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { configureStore } from '@reduxjs/toolkit'
 
 import reducer from '~/redux/reducer'
@@ -98,7 +98,7 @@ const updateFormData = (data) => {
 }
 const mockUseForm = vi.hoisted(() => {
   return vi.fn(({ onSubmit } = {}) => {
-    mockOnSubmit = onSubmit
+    mockOnSubmit = () => act(() => onSubmit())
     return {
       handleSubmit: mockHandleSubmit,
       handleInputChange: mockHandleInputChange,

--- a/tests/unit/pages/my-courses/MyCourses.spec.jsx
+++ b/tests/unit/pages/my-courses/MyCourses.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, act } from '@testing-library/react'
 import { renderWithProviders, mockAxiosClient } from '~tests/test-utils'
 import { URLs } from '~/constants/request'
 
@@ -19,10 +19,10 @@ const mockCoursesData = {
 }
 
 describe('tests for MyCourses page', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockAxiosClient.onGet(URLs.courses.get).reply(200, mockCoursesData)
     mockAxiosClient.onPost(URLs.courses.create).reply(200, null)
-    renderWithProviders(<MyCourses />)
+    await waitFor(() => renderWithProviders(<MyCourses />))
   })
 
   it('should render page title', async () => {
@@ -32,17 +32,13 @@ describe('tests for MyCourses page', () => {
   })
 
   it('should click delete button', async () => {
-    waitFor(() => {
-      const menu = screen.getAllByTestId('MoreVertIcon')[0].parentElement
+    const menu = screen.getAllByTestId('MoreVertIcon')[0].parentElement
 
-      fireEvent.click(menu)
-    })
+    fireEvent.click(menu)
 
     const deleteBtn = await screen.findByText('common.delete')
 
-    waitFor(() => {
-      fireEvent.click(deleteBtn)
-    })
+    fireEvent.click(deleteBtn)
 
     const title = screen.getByText(
       'myCoursesPage.modalMessages.confirmDeletionMessage'
@@ -52,17 +48,13 @@ describe('tests for MyCourses page', () => {
   })
 
   it('should click duplicate button', async () => {
-    waitFor(() => {
-      const menu = screen.getAllByTestId('MoreVertIcon')[1].parentElement
+    const menu = screen.getAllByTestId('MoreVertIcon')[1].parentElement
 
-      fireEvent.click(menu)
-    })
+    await act(() => fireEvent.click(menu))
 
-    const duplicateBtn = await screen.findByText('common.duplicate')
+    const duplicateBtn = screen.getByText('common.duplicate')
 
-    waitFor(() => {
-      fireEvent.click(duplicateBtn)
-    })
+    await act(() => fireEvent.click(duplicateBtn))
 
     const title = screen.getByText(
       '1Advanced Lineal Math: Theoretical Concepts'

--- a/tests/unit/pages/subjects/Subjects.spec.jsx
+++ b/tests/unit/pages/subjects/Subjects.spec.jsx
@@ -52,8 +52,8 @@ describe('Subjects page', () => {
     vi.clearAllMocks()
   })
 
-  beforeEach(() => {
-    renderWithProviders(<Subjects />)
+  beforeEach(async () => {
+    await waitFor(() => renderWithProviders(<Subjects />))
   })
 
   it('should render title with description', () => {
@@ -97,8 +97,8 @@ describe('Subjects page with empty data', () => {
     vi.clearAllMocks()
   })
 
-  beforeEach(() => {
-    renderWithProviders(<Subjects />)
+  beforeEach(async () => {
+    await waitFor(() => renderWithProviders(<Subjects />))
   })
 
   it('should render not found results when no subjects are found', () => {

--- a/tests/unit/pages/tutor-profile/TutorProfile.spec.jsx
+++ b/tests/unit/pages/tutor-profile/TutorProfile.spec.jsx
@@ -13,7 +13,7 @@ const tutorAppMain = {
 
 const studentAppMain = {
   userRole: 'student',
-  _id: '648850c4fdc2d1a130c24aea'
+  _id: '648850c4fdc2d1a130c24aeb'
 }
 
 const videoMockDataStudent = {


### PR DESCRIPTION
I've fixed all warnings during tests run. Now, test results take only `300` lines instead of `4 600` before (without coverage). 

Some of the common fixes I done include adding `act` for events firing, `waitFor` for render, adding different ids for mock data, or, in some cases, replacing `_id` by `id`. In FaqBlock, I slightly changed tests to remove warning. And in one case I mocked `useAxios` because request was trying to be made from testing environment, so it threw a warning.