### PR TITLE
Added flexbox utility classes

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -60,7 +60,13 @@
   $properties: map.get($utility, 'properties');
 
   @each $key, $value in $values {
-    .#{$class}-#{$key} {
+    $class-name: $key;
+
+    @if $class != null and $class != '' {
+      $class-name: #{$class}-#{$key};
+    }
+
+    .#{$class-name} {
       @each $property in $properties {
         #{$property}: #{$value};
       }

--- a/src/scss/utilities/_index.scss
+++ b/src/scss/utilities/_index.scss
@@ -1,4 +1,5 @@
 @charset 'UTF-8';
 
 @forward 'background';
+@forward 'flexbox';
 @forward 'spacing';

--- a/src/scss/utilities/flexbox.scss
+++ b/src/scss/utilities/flexbox.scss
@@ -87,7 +87,7 @@ $flexbox-utilities: (
     )
   ),
   'align-items': (
-    class: 'align',
+    class: 'items',
     properties: align-items,
     values: (
       'start': flex-start,

--- a/src/scss/utilities/flexbox.scss
+++ b/src/scss/utilities/flexbox.scss
@@ -1,0 +1,152 @@
+@use '../variables' as *;
+@use '../functions' as *;
+@use '../mixins' as *;
+
+$-space-var-map: map-to-var-map($spaces, 'space');
+
+$flexbox-utilities: (
+  'display-flex': (
+    properties: display,
+    values: (
+      'flex': flex,
+      'inline-flex': inline-flex
+    )
+  ),
+  'flex': (
+    class: 'flex',
+    properties: flex,
+    values: (
+      '1': 1 1 0%,
+      'auto': 1 1 auto,
+      'initial': 0 1 auto,
+      'none': none
+    )
+  ),
+  'flex-direction': (
+    class: 'flex',
+    properties: flex-direction,
+    values: (
+      'row': row,
+      'row-reverse': row-reverse,
+      'col': column,
+      'col-reverse': column-reverse
+    )
+  ),
+  'flex-grow': (
+    class: 'flex',
+    properties: flex-grow,
+    values: (
+      '0': 0,
+      '1': 1
+    )
+  ),
+  'flex-shrink': (
+    class: 'flex',
+    properties: flex-shrink,
+    values: (
+      '0': 0,
+      '1': 1
+    )
+  ),
+  'flex-wrap': (
+    class: 'flex',
+    properties: flex-wrap,
+    values: (
+      'nowrap': nowrap,
+      'wrap': wrap,
+      'wrap-reverse': wrap-reverse
+    )
+  ),
+  'justify-content': (
+    class: 'justify',
+    properties: justify-content,
+    values: (
+      'normal': normal,
+      'start': flex-start,
+      'end': flex-end,
+      'center': center,
+      'between': space-between,
+      'around': space-around,
+      'evenly': space-evenly,
+      'stretch': stretch
+    )
+  ),
+  'align-content': (
+    class: 'content',
+    properties: align-content,
+    values: (
+      'normal': normal,
+      'start': flex-start,
+      'end': flex-end,
+      'center': center,
+      'between': space-between,
+      'around': space-around,
+      'evenly': space-evenly,
+      'baseline': baseline,
+      'stretch': stretch
+    )
+  ),
+  'align-items': (
+    class: 'align',
+    properties: align-items,
+    values: (
+      'start': flex-start,
+      'end': flex-end,
+      'center': center,
+      'baseline': baseline,
+      'stretch': stretch
+    )
+  ),
+  'align-self': (
+    class: 'self',
+    properties: align-self,
+    values: (
+      'auto': auto,
+      'start': flex-start,
+      'end': flex-end,
+      'center': center,
+      'baseline': baseline,
+      'stretch': stretch
+    )
+  ),
+  'order': (
+    class: 'order',
+    properties: order,
+    values: (
+      '1': 1,
+      '2': 2,
+      '3': 3,
+      '4': 4,
+      '5': 5,
+      '6': 6,
+      '7': 7,
+      '8': 8,
+      '9': 9,
+      '10': 10,
+      '11': 11,
+      '12': 12,
+      'first': -9999,
+      'last': 9999,
+      'none': 0
+    )
+  ),
+  'gap': (
+    class: 'gap',
+    properties: gap,
+    values: $-space-var-map
+  ),
+  'gap-x': (
+    class: 'gap-x',
+    properties: column-gap,
+    values: $-space-var-map
+  ),
+  'gap-y': (
+    class: 'gap-y',
+    properties: row-gap,
+    values: $-space-var-map
+  )
+);
+
+@each $key, $utility in $flexbox-utilities {
+  @include generate-utilities($utility);
+}

--- a/src/scss/utilities/spacing.scss
+++ b/src/scss/utilities/spacing.scss
@@ -3,7 +3,7 @@
 @use '../mixins' as *;
 @use 'sass:map';
 
-$space-var-map: map-to-var-map($spaces, 'space');
+$-space-var-map: map-to-var-map($spaces, 'space');
 
 $spacing-utilities: (
   // Margin utilities
@@ -13,7 +13,7 @@ $spacing-utilities: (
       properties: margin,
       values:
         map.merge(
-          $space-var-map,
+          $-space-var-map,
           (
             'auto': 'auto'
           )
@@ -24,7 +24,7 @@ $spacing-utilities: (
     properties: margin-right margin-left,
     values:
       map.merge(
-        $space-var-map,
+        $-space-var-map,
         (
           'auto': 'auto'
         )
@@ -35,7 +35,7 @@ $spacing-utilities: (
     properties: margin-top margin-bottom,
     values:
       map.merge(
-        $space-var-map,
+        $-space-var-map,
         (
           'auto': 'auto'
         )
@@ -46,7 +46,7 @@ $spacing-utilities: (
     properties: margin-top,
     values:
       map.merge(
-        $space-var-map,
+        $-space-var-map,
         (
           'auto': 'auto'
         )
@@ -57,7 +57,7 @@ $spacing-utilities: (
     properties: margin-right,
     values:
       map.merge(
-        $space-var-map,
+        $-space-var-map,
         (
           'auto': 'auto'
         )
@@ -68,7 +68,7 @@ $spacing-utilities: (
     properties: margin-bottom,
     values:
       map.merge(
-        $space-var-map,
+        $-space-var-map,
         (
           'auto': 'auto'
         )
@@ -79,7 +79,7 @@ $spacing-utilities: (
     properties: margin-left,
     values:
       map.merge(
-        $space-var-map,
+        $-space-var-map,
         (
           'auto': 'auto'
         )
@@ -90,37 +90,37 @@ $spacing-utilities: (
     (
       class: 'p',
       properties: padding,
-      values: $space-var-map
+      values: $-space-var-map
     ),
   'padding-x': (
     class: 'px',
     properties: padding-right padding-left,
-    values: $space-var-map
+    values: $-space-var-map
   ),
   'padding-y': (
     class: 'py',
     properties: padding-top padding-bottom,
-    values: $space-var-map
+    values: $-space-var-map
   ),
   'padding-top': (
     class: 'pt',
     properties: padding-top,
-    values: $space-var-map
+    values: $-space-var-map
   ),
   'padding-right': (
     class: 'pr',
     properties: padding-right,
-    values: $space-var-map
+    values: $-space-var-map
   ),
   'padding-bottom': (
     class: 'pb',
     properties: padding-bottom,
-    values: $space-var-map
+    values: $-space-var-map
   ),
   'padding-left': (
     class: 'pl',
     properties: padding-left,
-    values: $space-var-map
+    values: $-space-var-map
   )
 );
 


### PR DESCRIPTION
### Added flexbox utility classes

- Implemented utility classes for the following flexbox properties:
  - **flex-direction** (`flex-row`, `flex-col`, `flex-row-reverse`, `flex-col-reverse`).
  - **flex-grow** (`grow-0`, `grow-1`).
  - **flex-shrink** (`shrink-0`, `shrink-1`).
  - **flex-wrap** (`flex-wrap`, `flex-nowrap`, `flex-wrap-reverse`).
  - **justify-content** (`justify-normal`, `justify-start`, `justify-center`, `justify-end`, `justify-between`, `justify-around`, `justify-evenly`, `justify-stretch`).
  - **align-items** (`items-start`, `items-center`, `items-end`, `items-stretch`, `items-baseline`).
  - **align-content** (`content-normal`, `content-start`, `content-center`, `content-end`, `content-between`, `content-around`, `content-evenly`, `content-stretch`, `content-baseline`).
  - **align-self** (`self-auto`, `self-start`, `self-center`, `self-end`, `self-stretch`, `self-baseline`).
  - **order** (`order-1`, `order-2`, `order-3`, etc.).
  - **gap** (`gap-1`, `gap-2`, `gap-3`, etc.).
  - **gap-x** (`gap-x-1`, `gap-x-2`, `gap-x-3`, etc.).
  -  **gap-y** (`gap-y-1`, `gap-y-2`, `gap-y-3`, etc.).

    #### Example of usage:
```typescript
className="flex justify-center items-center"
className="flex flex-col gap-2"
```

### Additional
- made scss var `$space-var-map` private to avoid conflicts 
