### PR TITLE
Added sizing utility classes

### DIFF
--- a/src/scss/utilities/_index.scss
+++ b/src/scss/utilities/_index.scss
@@ -2,4 +2,5 @@
 
 @forward 'background';
 @forward 'flexbox';
+@forward 'sizing';
 @forward 'spacing';

--- a/src/scss/utilities/sizing.scss
+++ b/src/scss/utilities/sizing.scss
@@ -1,0 +1,113 @@
+@use '../variables' as *;
+@use '../functions' as *;
+@use '../mixins' as *;
+@use 'sass:map';
+
+$-space-var-map: map-to-var-map($spaces, 'space');
+
+$sizing-utilities: (
+  // width utilities
+  'width':
+    (
+      class: 'w',
+      properties: width,
+      values:
+        map.merge(
+          $-space-var-map,
+          (
+            'auto': auto,
+            'min': min-content,
+            'max': max-content,
+            'fit': fit-content,
+            'screen': 100vw,
+            '25': 25%,
+            '50': 50%,
+            '75': 75%,
+            '100': 100%
+          )
+        )
+    ),
+  'min-width': (
+    class: 'min-w',
+    properties: min-width,
+    values:
+      map.merge(
+        $-space-var-map,
+        (
+          'min': min-content,
+          'max': max-content,
+          'fit': fit-content,
+          '100': 100%
+        )
+      )
+  ),
+  'max-width': (
+    class: 'max-w',
+    properties: max-width,
+    values:
+      map.merge(
+        $-space-var-map,
+        (
+          'min': min-content,
+          'max': max-content,
+          'fit': fit-content,
+          '100': 100%
+        )
+      )
+  ),
+  // height utilities
+  'height':
+    (
+      class: 'h',
+      properties: height,
+      values:
+        map.merge(
+          $-space-var-map,
+          (
+            'auto': auto,
+            'min': min-content,
+            'max': max-content,
+            'fit': fit-content,
+            'screen': 100vh,
+            '25': 25%,
+            '50': 50%,
+            '75': 75%,
+            '100': 100%
+          )
+        )
+    ),
+  'min-height': (
+    class: 'min-h',
+    properties: min-height,
+    values:
+      map.merge(
+        $-space-var-map,
+        (
+          'screen': 100vh,
+          '100': 100%,
+          'min': min-content,
+          'max': max-content,
+          'fit': fit-content
+        )
+      )
+  ),
+  'max-height': (
+    class: 'max-h',
+    properties: max-height,
+    values:
+      map.merge(
+        $-space-var-map,
+        (
+          'screen': 100vh,
+          '100': 100%,
+          'min': min-content,
+          'max': max-content,
+          'fit': fit-content
+        )
+      )
+  )
+);
+
+@each $key, $utility in $sizing-utilities {
+  @include generate-utilities($utility);
+}


### PR DESCRIPTION
### Added sizing utility classes

- Implemented utility classes for the following sizing properties:
  - **width** (`w-1`, `w-2`, `w-min`, `w-max` etc.).
  - **min-width** (`min-w-1`, `min-w-2` etc.).
  -  **max-width** (`max-w-1`, `max-w-2` etc.).
  - **height** (`h-1`, `h-2`, `h-min`, `h-max` etc.).
  - **min-height** (`min-h-1`, `min-h-2` etc.).
  -  **max-height** (`max-h-1`, `max-h-2` etc.).

    #### Example of usage:
```typescript
className="w-100 h-screen"
```
