### PR TITLE
Fixed margin in the SubjectLevelChips component

### DIFF
--- a/src/components/subject-level-chips/SubjectLevelChips.styles.ts
+++ b/src/components/subject-level-chips/SubjectLevelChips.styles.ts
@@ -5,8 +5,7 @@ export const styles = {
     display: 'flex',
     flexWrap: 'wrap',
     alignItems: 'start',
-    gap: '4px',
-    ml: '8px'
+    gap: '4px'
   },
   subjectChipLabel: {
     typography: 'overline',

--- a/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.styles.ts
+++ b/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.styles.ts
@@ -43,10 +43,13 @@ export const style = {
     ...ellipsisTextStyle(2)
   },
   subjectContainer: {
+    display: 'flex'
+  },
+  categoryContainer: {
     display: 'flex',
-    '& > *': {
-      mr: '8px'
-    }
+    alignItems: 'center',
+    gap: '8px',
+    mr: '16px'
   },
   buttons: {
     mr: '15px',

--- a/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.tsx
+++ b/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.tsx
@@ -165,8 +165,10 @@ const MyCooperationsDetails = () => {
           {t('cooperationDetailsPage.tutoringSubject')}
         </Typography>
         <Box sx={style.subjectContainer}>
-          <CategoryIcon sx={style.iconColor(categoryColor)} />
-          <Typography>{offer.category.name}</Typography>
+          <Box sx={style.categoryContainer}>
+            <CategoryIcon sx={style.iconColor(categoryColor)} />
+            <Typography>{offer.category.name}</Typography>
+          </Box>
           <SubjectLevelChips
             color={offer.category.appearance.color}
             proficiencyLevel={offer.proficiencyLevel}


### PR DESCRIPTION
- [x] removed margin-left from the SubjectLevelChips component because we shouldn't add margin to a component
- [x] fixed styles for the MyCooperationsDetails component to match the [figma mockup](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=17472-90717&t=XlwBKnn7TimWASom-4)

<img width="1440" alt="Screenshot 2024-09-16 at 17 06 52" src="https://github.com/user-attachments/assets/8c5b671e-8888-4efd-9ec4-0be5f40abd9b">

<img width="1440" alt="Screenshot 2024-09-16 at 17 06 25" src="https://github.com/user-attachments/assets/ccd56035-58cf-43e5-b280-c753683b4813">
