### PR TITLE
Fixed the bookmark icon position on the offer details page

### DIFF
--- a/src/pages/offer-details/OfferDetails.styles.ts
+++ b/src/pages/offer-details/OfferDetails.styles.ts
@@ -61,8 +61,11 @@ export const styles = {
   },
   offerCard: {
     ...border,
-    p: { sm: '20px 20px', md: '20px 30px' }
+    p: { sm: '30px 20px', md: '30px' }
   },
-  offerCardSquare: border,
+  offerCardSquare: {
+    ...border,
+    p: '30px 20px'
+  },
   faqAccordion
 }


### PR DESCRIPTION
- [x] increased vertical padding of the offer card container to prevent the bookmark icon from overflowing

<img width="1440" alt="Screenshot 2024-09-16 at 17 51 30" src="https://github.com/user-attachments/assets/7ce34b75-2d60-4593-96db-ec557118fa62">

<img width="1439" alt="Screenshot 2024-09-16 at 17 53 04" src="https://github.com/user-attachments/assets/5baed31a-82b6-4f7d-9d9e-4a8a90fc26b2">
