### PR TITLE
Fixed search inputs on the find offer page

### DIFF
--- a/src/components/search-filter-input/SearchFilterInput.styles.tsx
+++ b/src/components/search-filter-input/SearchFilterInput.styles.tsx
@@ -19,6 +19,7 @@ export const styles = {
     left: '15px'
   },
   searchBtn: {
-    ml: '25px'
+    width: '105px',
+    ml: '10px'
   }
 }

--- a/src/constants/translations/en/find-offer-page.json
+++ b/src/constants/translations/en/find-offer-page.json
@@ -38,7 +38,7 @@
     "level": "Level",
     "language": "Language",
     "price": "Price",
-    "search": "Search by name",
+    "search": "Search by tutor name",
     "nativeSpeaker": "Native speaker"
   },
   "sortTitles": {

--- a/src/constants/translations/uk/find-offer-page.json
+++ b/src/constants/translations/uk/find-offer-page.json
@@ -38,7 +38,7 @@
     "level": "Рівень",
     "language": "Мова",
     "price": "Ціна",
-    "search": "Пошук за іменем",
+    "search": "Пошук за іменем викладача",
     "nativeSpeaker": "Носій рідної мови"
   },
   "sortTitles": {

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -7,8 +7,9 @@ import AppRange from '~/components/app-range/AppRange'
 import CheckboxList from '~/components/checkbox-list/CheckboxList'
 import FilterInput from '~/components/filter-input/FilterInput'
 import RadioButtonInputs from '~/components/radio-button-inputs/RadioButtonInputs'
-import { useAppSelector } from '~/hooks/use-redux'
 
+import { useAppSelector } from '~/hooks/use-redux'
+import useBreakpoints from '~/hooks/use-breakpoints'
 import {
   languageValues,
   radioButtonsTranslationKeys
@@ -38,6 +39,7 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
   filters,
   price
 }) => {
+  const { isLaptopAndAbove } = useBreakpoints()
   const { t } = useTranslation()
   const { userRole } = useAppSelector((state) => state.appMain)
   const levelOptions = Object.values(ProficiencyLevelEnum)
@@ -116,11 +118,15 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
         onChange={handleFilterChange('rating')}
         value={Number(filters.rating)}
       />
-      {filterTitle(t('findOffers.filterTitles.search'))}
-      <FilterInput
-        onChange={updateFilterByKey('search')}
-        value={filters.search || ''}
-      />
+      {!isLaptopAndAbove && (
+        <>
+          {filterTitle(t('findOffers.filterTitles.search'))}
+          <FilterInput
+            onChange={updateFilterByKey('search')}
+            value={filters.search || ''}
+          />
+        </>
+      )}
     </>
   )
 }

--- a/src/containers/find-offer/offer-search-toolbar/OfferSearchToolbar.styles.ts
+++ b/src/containers/find-offer/offer-search-toolbar/OfferSearchToolbar.styles.ts
@@ -7,8 +7,8 @@ export const styles = {
   },
   autocomplete: {
     width: '100%',
-    maxWidth: { md: '220px' },
-    mr: '30px',
+    maxWidth: { md: '180px', lg: '220px' },
+    mr: { sm: '20px', lg: '30px' },
     '& .MuiOutlinedInput-root': {
       padding: '5px 9px'
     },


### PR DESCRIPTION
- [x] fixed search button width to match the figma mockup
- [x] fixed the label for a search input so users know that they are searching by a tutor name and not by an offer name
- [x] removed the duplicate input from wide screens
- [x] fixed adaptability of the search input in the OfferSearchToolbar container