### PR TITLE
2510/feature/mini chat window and default open chat

### DIFF
--- a/src/containers/offer-page/chat-dialog-window/ChatDialogWindow.tsx
+++ b/src/containers/offer-page/chat-dialog-window/ChatDialogWindow.tsx
@@ -101,6 +101,7 @@ const ChatDialogWindow: FC<ChatDialogWindow> = ({ chatInfo }) => {
         member: chatInfo.author._id,
         memberRole: chatInfo.authorRole
       }),
+
     [chatInfo.author._id, chatInfo.authorRole]
   )
 

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -69,10 +69,10 @@ const Chat = () => {
   const lastOpenedChat = chatInfo?.chatId
 
   useEffect(() => {
-    setChatInfo(null)
     if (lastOpenedChat) {
       localStorage.setItem('currentChatId', lastOpenedChat as string)
     }
+    setChatInfo(null)
   }, [setChatInfo, lastOpenedChat])
 
   const openChatsHandler = (e: MouseEvent<HTMLButtonElement>) => {

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -9,7 +9,9 @@ import { messageService } from '~/services/message-service'
 import { useDrawer } from '~/hooks/use-drawer'
 import useAxios from '~/hooks/use-axios'
 import useBreakpoints from '~/hooks/use-breakpoints'
+
 import { useAppSelector } from '~/hooks/use-redux'
+import { useChatContext } from '~/context/chat-context'
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
 import AppDrawer from '~/components/app-drawer/AppDrawer'
 import AppChip from '~/components/app-chip/AppChip'
@@ -47,6 +49,7 @@ const Chat = () => {
   const [prevScrollHeight, setPrevScrollHeight] = useState(0)
   const [prevScrollTop, setPrevScrollTop] = useState(0)
   const { userId: myId } = useAppSelector((state) => state.appMain)
+  const { setChatInfo, chatInfo } = useChatContext()
 
   const limit = 15
 
@@ -62,6 +65,15 @@ const Chat = () => {
 
   const allotmentSizes = isSidebarOpen && isDesktop ? [25, 50, 25] : [25, 75]
   const { Persistent, Temporary } = DrawerVariantEnum
+
+  const lastOpenedChat = chatInfo?.chatId
+
+  useEffect(() => {
+    setChatInfo(null)
+    if (lastOpenedChat) {
+      localStorage.setItem('currentChatId', lastOpenedChat as string)
+    }
+  }, [setChatInfo, lastOpenedChat])
 
   const openChatsHandler = (e: MouseEvent<HTMLButtonElement>) => {
     openDrawer()
@@ -146,7 +158,7 @@ const Chat = () => {
   useEffect(() => {
     const currentChatId = localStorage.getItem('currentChatId')
 
-    if (currentChatId) {
+    if (currentChatId && !selectedChat) {
       const foundChat = listOfChats.find(
         (chat: ChatResponse) => chat._id === currentChatId
       )
@@ -157,7 +169,7 @@ const Chat = () => {
         localStorage.removeItem('currentChatId')
       }
     }
-  }, [listOfChats])
+  }, [listOfChats, lastOpenedChat, selectedChat])
 
   if (loading || (isMessagesLoading && !skip)) {
     return <Loader size={100} />

--- a/tests/unit/pages/chat/Chat.spec.jsx
+++ b/tests/unit/pages/chat/Chat.spec.jsx
@@ -9,7 +9,7 @@ import { URLs } from '~/constants/request'
 import {
   chatsMock,
   messagesMock
-} from '~tests/unit/containers/chat/list-of-users-with-search/MockChat.spec.constants'
+} from '~tests/unit/pages/chat/ChatsMock.constants'
 import { afterEach } from 'vitest'
 
 vi.mock('~/pages/chat/MessagesList', () => ({

--- a/tests/unit/pages/chat/Chat.spec.jsx
+++ b/tests/unit/pages/chat/Chat.spec.jsx
@@ -9,7 +9,8 @@ import { URLs } from '~/constants/request'
 import {
   chatsMock,
   messagesMock
-} from '~tests/unit/pages/chat/ChatsMock.constants'
+} from '~tests/unit/containers/chat/list-of-users-with-search/MockChat.spec.constants'
+import { afterEach } from 'vitest'
 
 vi.mock('~/pages/chat/MessagesList', () => ({
   default: vi.fn(() => (
@@ -20,6 +21,7 @@ vi.mock('~/pages/chat/MessagesList', () => ({
 }))
 
 vi.mock('~/hooks/use-breakpoints')
+
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
   observe: vi.fn(),
   unobserve: vi.fn(),
@@ -36,6 +38,8 @@ const mockChatContext = {
 vi.mock('~/context/chat-context', () => ({
   useChatContext: () => mockChatContext
 }))
+
+const mockSetChatInfo = vi.fn()
 
 const mockRef = { current: { scrollTo: vi.fn(), scrollHeight: 100 } }
 
@@ -62,12 +66,17 @@ describe('Chat for desktop', () => {
     isMobile: false,
     isTablet: false
   }
+
   beforeEach(async () => {
     useBreakpoints.mockImplementation(() => desktopData)
 
     await waitFor(() => {
       renderWithProviders(<Chat />)
     })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('should render user in a chat', async () => {
@@ -119,12 +128,50 @@ describe('Chat for mobile', () => {
   beforeEach(async () => {
     useBreakpoints.mockImplementation(() => mobileData)
 
-    await waitFor(() => renderWithProviders(<Chat />))
+    await waitFor(() => {
+      renderWithProviders(<Chat />)
+    })
   })
 
-  it('should render just right pane in a chat', async () => {
+  it('should not render left panel in a chat', async () => {
     const chip = await screen.findByText('chatPage.chat.chipLabel')
 
-    expect(chip).toBeInTheDocument()
+    expect(chip).not.toBeInTheDocument()
+  })
+})
+
+describe('Chat - open last chat and close mini chat window', () => {
+  beforeEach(async () => {
+    vi.mock('~/context/chat-context', () => ({
+      useChatContext: () => ({
+        chatInfo: { chatId: chatsMock[0]._id },
+        setChatInfo: mockSetChatInfo
+      })
+    }))
+    Storage.prototype.getItem = vi.fn((key) => {
+      if (key === 'currentChatId') return chatsMock[0]._id
+      return null
+    })
+    Storage.prototype.setItem = vi.fn()
+
+    await waitFor(() => {
+      renderWithProviders(<Chat />)
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should open the last chat and close the mini chat window', async () => {
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-messages-list')).toBeInTheDocument()
+    })
+    expect(localStorage.getItem).toHaveBeenCalledWith('currentChatId')
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'currentChatId',
+      chatsMock[0]._id
+    )
+    expect(mockSetChatInfo).toHaveBeenCalledWith(null)
   })
 })


### PR DESCRIPTION
For now, when user is just open Chat from after opening mini-chat we have two cases:
- if mini-chat was opening without sending any messages and user did not send messages to this user before, when he click on main Chat then the mini-chat will be closed but in main Chat window will be no chat selected
- if mini-chat was opening with sending a message and or user sent messages to this user before, when he click on main Chat then the mini-chat will be closed and in main Chat window will be selected conwersation with this user

test for Chat.jsx should be refactored after connecting sockets


https://github.com/user-attachments/assets/3afc2a32-684a-4c2c-8fd9-ef802931abed



