### PR TITLE
Contacts should be listed in ascending order 

### DIFF
--- a/src/containers/chat/list-of-users-with-search/ListOfUsersWithSearch.constants.ts
+++ b/src/containers/chat/list-of-users-with-search/ListOfUsersWithSearch.constants.ts
@@ -1,5 +1,13 @@
 import { ChatResponse } from '~/types'
 
+const sortChatsByDate = (listOfChats: ChatResponse[]): ChatResponse[] => {
+  return listOfChats.sort((a, b) => {
+    const dateA = new Date(a.latestMessage.createdAt).getTime()
+    const dateB = new Date(b.latestMessage.createdAt).getTime()
+    return dateB - dateA
+  })
+}
+
 export const filterChats = (
   listOfChats: ChatResponse[],
   userId: string,
@@ -7,7 +15,9 @@ export const filterChats = (
 ): ChatResponse[] => {
   const lowerCaseSearch = search.toLocaleLowerCase()
 
-  return listOfChats.filter((item) => {
+  const sortedChats = sortChatsByDate(listOfChats)
+
+  return sortedChats.filter((item) => {
     const otherMember = item.members.find(
       (member) => member.user._id !== userId
     )

--- a/src/containers/chat/list-of-users-with-search/ListOfUsersWithSearch.constants.ts
+++ b/src/containers/chat/list-of-users-with-search/ListOfUsersWithSearch.constants.ts
@@ -2,8 +2,8 @@ import { ChatResponse } from '~/types'
 
 const sortChatsByDate = (listOfChats: ChatResponse[]): ChatResponse[] => {
   return listOfChats.sort((a, b) => {
-    const dateA = new Date(a.latestMessage.createdAt).getTime()
-    const dateB = new Date(b.latestMessage.createdAt).getTime()
+    const dateA = new Date(a.updatedAt).getTime()
+    const dateB = new Date(b.updatedAt).getTime()
     return dateB - dateA
   })
 }


### PR DESCRIPTION
A User should see contacts (chats) listed in ascending order based on the date and time of interaction. In other words the most recent interactions should be on the top of the list.

Expected and actual result:
![image](https://github.com/user-attachments/assets/a3370728-37b0-4fa3-b6f1-d3956fc4a424)
