### PR TITLE
Bound confirmation modal on resources edit

### DIFF
--- a/src/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.tsx
+++ b/src/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { useTranslation } from 'react-i18next'
@@ -17,7 +18,6 @@ import { useModalContext } from '~/context/modal-context'
 import Loader from '~/components/loader/Loader'
 import useAxios from '~/hooks/use-axios'
 import { CourseService } from '~/services/course-service'
-import { useMemo } from 'react'
 
 interface ChangeResourceConfirmModalProps {
   resourceId?: string
@@ -61,10 +61,16 @@ const ChangeResourceConfirmModal = ({
   )
   ////////////////////////////////////!
 
-  const handleConfirm = () => {
-    onConfirm?.()
+  const handleConfirm = useCallback(() => {
     closeModal()
-  }
+    onConfirm?.()
+  }, [closeModal, onConfirm])
+
+  useEffect(() => {
+    if (!loading && !courseList?.length) {
+      handleConfirm()
+    }
+  }, [courseList, handleConfirm, loading])
 
   if (loading) {
     return (
@@ -75,7 +81,6 @@ const ChangeResourceConfirmModal = ({
   }
 
   if (!loading && !courseList?.length) {
-    handleConfirm()
     return null
   }
 

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -54,6 +54,7 @@ import { useModalContext } from '~/context/modal-context'
 
 import useAxios from '~/hooks/use-axios'
 import useMenu from '~/hooks/use-menu'
+import ChangeResourceConfirmModal from '../change-resource-confirm-modal/ChangeResourceConfirmModal'
 
 interface SectionProps extends CourseSectionHandlers {
   sectionData: CourseSection
@@ -173,12 +174,22 @@ const CourseSectionContainer: FC<SectionProps> = ({
     if (!resourceType) return
 
     if (resourceType === ResourceType.Attachment) {
+      const handleConfirm = () =>
+        openModal({
+          component: (
+            <EditAttachmentModal
+              attachment={resource as Attachment}
+              closeModal={closeModal}
+              updateAttachment={updateData}
+            />
+          )
+        })
       openModal({
         component: (
-          <EditAttachmentModal
-            attachment={resource as Attachment}
-            closeModal={closeModal}
-            updateAttachment={updateData}
+          <ChangeResourceConfirmModal
+            onConfirm={handleConfirm}
+            resourceId={resource.isDuplicate ? '' : resource._id}
+            title={(resource as Attachment).fileName}
           />
         )
       })

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -12,6 +12,7 @@ import useBreakpoints from '~/hooks/use-breakpoints'
 import useAxios from '~/hooks/use-axios'
 import usePagination from '~/hooks/table/use-pagination'
 import { authRoutes } from '~/router/constants/authRoutes'
+import { useModalContext } from '~/context/modal-context'
 
 import { defaultResponses, snackbarVariants } from '~/constants'
 import {
@@ -35,6 +36,7 @@ import {
 } from '~/utils/helper-functions'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
+import ChangeResourceConfirmModal from '../change-resource-confirm-modal/ChangeResourceConfirmModal'
 
 const QuizzesContainer = () => {
   const dispatch = useAppDispatch()
@@ -44,6 +46,7 @@ const QuizzesContainer = () => {
   const searchTitle = useRef<string>('')
   const breakpoints = useBreakpoints()
   const [selectedItems, setSelectedItems] = useState<string[]>([])
+  const { openModal } = useModalContext()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -82,10 +85,6 @@ const QuizzesContainer = () => {
     []
   )
 
-  const onEdit = (id: string) => {
-    navigate(createUrlPath(authRoutes.myResources.editQuiz.path, id))
-  }
-
   const { response, loading, fetchData } = useAxios<
     ItemsWithCount<Quiz>,
     GetResourcesParams
@@ -94,6 +93,21 @@ const QuizzesContainer = () => {
     defaultResponse: defaultResponses.itemsWithCount,
     onResponseError
   })
+
+  const onEdit = (id: string) => {
+    const resource = response.items.find((item) => item._id === id)
+    openModal({
+      component: (
+        <ChangeResourceConfirmModal
+          onConfirm={() =>
+            navigate(createUrlPath(authRoutes.myResources.editQuiz.path, id))
+          }
+          resourceId={id}
+          title={resource?.title}
+        />
+      )
+    })
+  }
 
   const props = {
     columns: columnsToShow,

--- a/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
+++ b/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
@@ -1,10 +1,4 @@
-import {
-  ChangeEvent,
-  MouseEventHandler,
-  useCallback,
-  useEffect,
-  useState
-} from 'react'
+import { ChangeEvent, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import { AxiosResponse } from 'axios'
@@ -56,7 +50,6 @@ import { createUrlPath } from '~/utils/helper-functions'
 import { styles } from '~/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.styles'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
-import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 
 const CreateOrEditQuizContainer = ({
   title,
@@ -222,21 +215,6 @@ const CreateOrEditQuizContainer = ({
           resourceType: ResourceType.Quiz
         })
 
-  const openChangeResourceConfirmModal: MouseEventHandler<HTMLButtonElement> = (
-    e
-  ) => {
-    e.preventDefault()
-    openModal({
-      component: (
-        <ChangeResourceConfirmModal
-          onConfirm={() => onSaveQuiz()}
-          resourceId={id}
-          title={title}
-        />
-      )
-    })
-  }
-
   if (getQuizLoading) {
     return <Loader pageLoad />
   }
@@ -322,7 +300,7 @@ const CreateOrEditQuizContainer = ({
             {t('common.cancel')}
           </AppButton>
           <AppButton
-            onClick={openChangeResourceConfirmModal}
+            onClick={onSaveQuiz}
             size={SizeEnum.ExtraLarge}
             type={ButtonTypeEnum.Submit}
           >

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -36,6 +36,7 @@ import { styles } from '~/containers/my-resources/attachments-container/Attachme
 import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
+import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 
 const AttachmentsContainer = () => {
   const { t } = useTranslation()
@@ -137,12 +138,23 @@ const AttachmentsContainer = () => {
   const onEdit = (id: string) => {
     const attachment = response.items.find((item) => item._id === id)
 
+    const handleConfirm = () =>
+      openModal({
+        component: (
+          <EditAttachmentModal
+            attachment={attachment as Attachment}
+            closeModal={closeModal}
+            updateAttachment={updateData}
+          />
+        )
+      })
+
     openModal({
       component: (
-        <EditAttachmentModal
-          attachment={attachment as Attachment}
-          closeModal={closeModal}
-          updateAttachment={updateData}
+        <ChangeResourceConfirmModal
+          onConfirm={handleConfirm}
+          resourceId={id}
+          title={attachment?.fileName}
         />
       )
     })

--- a/src/containers/my-resources/lessons-container/LessonsContainer.tsx
+++ b/src/containers/my-resources/lessons-container/LessonsContainer.tsx
@@ -34,10 +34,13 @@ import {
 import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
+import { useModalContext } from '~/context/modal-context'
+import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 
 const LessonsContainer = () => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
+  const { openModal } = useModalContext()
   const { page, handleChangePage } = usePagination()
   const sortOptions = useSort({ initialSort })
   const searchTitle = useRef<string>('')
@@ -81,10 +84,6 @@ const LessonsContainer = () => {
     []
   )
 
-  const onEdit = (id: string) => {
-    navigate(createUrlPath(authRoutes.myResources.editLesson.path, id))
-  }
-
   const { response, loading, fetchData } = useAxios<
     ItemsWithCount<Lesson>,
     GetResourcesParams
@@ -93,6 +92,21 @@ const LessonsContainer = () => {
     defaultResponse: defaultResponses.itemsWithCount,
     onResponseError
   })
+
+  const onEdit = (id: string) => {
+    const resource = response.items.find((item) => item._id === id)
+    openModal({
+      component: (
+        <ChangeResourceConfirmModal
+          onConfirm={() =>
+            navigate(createUrlPath(authRoutes.myResources.editLesson.path, id))
+          }
+          resourceId={id}
+          title={resource?.title}
+        />
+      )
+    })
+  }
 
   const props = {
     columns: columnsToShow,

--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, SyntheticEvent, useEffect } from 'react'
+import { SyntheticEvent, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import { AxiosResponse } from 'axios'
@@ -51,7 +51,6 @@ import {
 } from '~/types'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
-import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 
 const CreateOrEditLesson = () => {
   const { t } = useTranslation()
@@ -192,21 +191,6 @@ const CreateOrEditLesson = () => {
     onResponseError: handleResponseError
   })
 
-  const openChangeResourceConfirmModal: MouseEventHandler<HTMLButtonElement> = (
-    e
-  ) => {
-    e.preventDefault()
-    openModal({
-      component: (
-        <ChangeResourceConfirmModal
-          onConfirm={() => handleSubmit()}
-          resourceId={id}
-          title={data.title}
-        />
-      )
-    })
-  }
-
   useEffect(() => {
     if (id) {
       void fetchDataLesson(id)
@@ -282,11 +266,7 @@ const CreateOrEditLesson = () => {
           >
             {t('common.cancel')}
           </AppButton>
-          <AppButton
-            onClick={openChangeResourceConfirmModal}
-            size={SizeEnum.XXL}
-            type={ButtonTypeEnum.Submit}
-          >
+          <AppButton size={SizeEnum.XXL} type={ButtonTypeEnum.Submit}>
             {t('common.save')}
           </AppButton>
         </Box>

--- a/src/pages/lesson-details/LessonDetails.tsx
+++ b/src/pages/lesson-details/LessonDetails.tsx
@@ -24,12 +24,15 @@ import { styles } from '~/pages/lesson-details/LessonsDetails.styles'
 import { Lesson, TypographyVariantEnum } from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
 import { useAppSelector } from '~/hooks/use-redux'
+import { useModalContext } from '~/context/modal-context'
+import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 
 const LessonDetails = () => {
   const { lessonId } = useParams()
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { userId } = useAppSelector((state) => state.appMain)
+  const { openModal } = useModalContext()
 
   const [expandedItems, handleAccordionChange] = useAccordion({
     initialState: 0,
@@ -56,7 +59,19 @@ const LessonDetails = () => {
   }
 
   const handleEditLesson = () => {
-    navigate(createUrlPath(authRoutes.myResources.editLesson.path, lessonId))
+    openModal({
+      component: (
+        <ChangeResourceConfirmModal
+          onConfirm={() =>
+            navigate(
+              createUrlPath(authRoutes.myResources.editLesson.path, lessonId)
+            )
+          }
+          resourceId={lessonId}
+          title={response.title}
+        />
+      )
+    })
   }
 
   const attachmentsList = response.attachments.map((attachment) => (

--- a/tests/unit/containers/my-quizzes/QuizzesContainer.spec.jsx
+++ b/tests/unit/containers/my-quizzes/QuizzesContainer.spec.jsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import QuizzesContainer from '~/containers/my-quizzes/QuizzesContainer'
 import {
   mockAxiosClient,
@@ -6,6 +6,26 @@ import {
   TestSnackbar
 } from '~tests/test-utils'
 import { URLs } from '~/constants/request'
+
+vi.mock(
+  '~/containers/my-resources/my-resources-table/MyResourcesTable',
+  () => ({
+    default: ({ actions }) => (
+      <div data-testid='testTable'>
+        <button data-testid='editButton' onClick={() => actions.onEdit()}>
+          Edit
+        </button>
+      </div>
+    )
+  })
+)
+
+vi.mock(
+  '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal',
+  () => ({
+    default: () => <div data-testid='confirmModal' />
+  })
+)
 
 const quizzesMock = {
   _id: '64ca5914b57f2442403394a5',
@@ -52,10 +72,26 @@ describe('QuizzesContainer component with data', () => {
     mockAxiosClient.reset()
   })
 
-  it('should render table', async () => {
-    const title = await screen.findByText(responseQuizzesMock.items[0].title)
+  it('should render "New quiz" button', () => {
+    const addBtn = screen.getByText('myResourcesPage.quizzes.addBtn')
 
-    expect(title).toBeInTheDocument()
+    expect(addBtn).toBeInTheDocument()
+  })
+
+  it('should render table with questions', async () => {
+    const table = await screen.findByTestId('testTable')
+
+    expect(table).toBeInTheDocument()
+  })
+
+  it('should run onEdit action', async () => {
+    const editButton = await screen.findByTestId('editButton')
+
+    fireEvent.click(editButton)
+
+    const modal = await screen.findByTestId('confirmModal')
+
+    expect(modal).toBeInTheDocument()
   })
 })
 

--- a/tests/unit/containers/my-resources/LessonsContainer.spec.jsx
+++ b/tests/unit/containers/my-resources/LessonsContainer.spec.jsx
@@ -1,9 +1,29 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 
 import LessonsContainer from '~/containers/my-resources/lessons-container/LessonsContainer'
 
 import { mockAxiosClient, renderWithProviders } from '~tests/test-utils'
 import { URLs } from '~/constants/request'
+
+vi.mock(
+  '~/containers/my-resources/my-resources-table/MyResourcesTable',
+  () => ({
+    default: ({ actions }) => (
+      <div data-testid='testTable'>
+        <button data-testid='editButton' onClick={() => actions.onEdit()}>
+          Edit
+        </button>
+      </div>
+    )
+  })
+)
+
+vi.mock(
+  '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal',
+  () => ({
+    default: () => <div data-testid='confirmModal' />
+  })
+)
 
 const lessonMock = {
   _id: '64e49ce305b3353b2ae6309e',
@@ -28,20 +48,6 @@ const lessonResponseMock = {
   items: responseItemsMock
 }
 
-const responseItemsMockCategory = Array(10)
-  .fill()
-  .map((_, index) => ({
-    ...lessonMock,
-    category: { id: '64fb2c33eba89699411d22bb', name: 'New Category' },
-    _id: `${index}`,
-    title: index + lessonMock.title
-  }))
-
-const lessonResponseMockCategory = {
-  count: 10,
-  items: responseItemsMockCategory
-}
-
 describe('LessonContainer test', () => {
   beforeEach(async () => {
     await waitFor(() => {
@@ -62,35 +68,20 @@ describe('LessonContainer test', () => {
 
     expect(addBtn).toBeInTheDocument()
   })
-  it('should render table with lessons', async () => {
-    const columnLabel = await screen.findByText('myResourcesPage.lessons.title')
-    const lessonTitle = await screen.findByText(responseItemsMock[5].title)
 
-    expect(columnLabel).toBeInTheDocument()
-    expect(lessonTitle).toBeInTheDocument()
-  })
-})
+  it('should render table with questions', async () => {
+    const table = await screen.findByTestId('testTable')
 
-describe('Lessons category test', () => {
-  beforeEach(async () => {
-    await waitFor(() => {
-      mockAxiosClient
-        .onGet(URLs.resources.lessons.get)
-        .reply(200, lessonResponseMockCategory)
-      renderWithProviders(<LessonsContainer />)
-    })
+    expect(table).toBeInTheDocument()
   })
 
-  afterEach(() => {
-    vi.clearAllMocks()
-    mockAxiosClient.reset()
-  })
+  it('should run onEdit action', async () => {
+    const editButton = await screen.findByTestId('editButton')
 
-  it('should render correct category', async () => {
-    const category = await screen.findByText(
-      'myResourcesPage.categories.category'
-    )
+    fireEvent.click(editButton)
 
-    expect(category).toBeInTheDocument()
+    const modal = await screen.findByTestId('confirmModal')
+
+    expect(modal).toBeInTheDocument()
   })
 })

--- a/tests/unit/pages/create-or-edit-lesson/CreateOrEditLessonWithId.spec.jsx
+++ b/tests/unit/pages/create-or-edit-lesson/CreateOrEditLessonWithId.spec.jsx
@@ -40,7 +40,7 @@ describe('CreateOrEditLesson component with id', () => {
     expect(titleInput).toBeInTheDocument()
   })
 
-  it.skip('should edit a lesson', async () => {
+  it('should edit a lesson', async () => {
     mockAxiosClient.onPatch(URLs.resources.lessons.patch).reply(200)
     const editLessonSpy = vi.spyOn(ResourceService, 'editLesson')
     const titleInput = await screen.findByDisplayValue(mockLesson.title)

--- a/tests/unit/pages/lesson-details/LessonDetails.spec.jsx
+++ b/tests/unit/pages/lesson-details/LessonDetails.spec.jsx
@@ -19,6 +19,13 @@ vi.mock('react-router-dom', async () => {
   }
 })
 
+vi.mock(
+  '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal',
+  () => ({
+    default: () => <div data-testid='testModal' />
+  })
+)
+
 const userId = '6477007a6fa4d05e1a800ce5'
 const mockState = {
   appMain: { userId: userId, userRole: 'tutor' }
@@ -90,7 +97,8 @@ describe('LessonDetails', () => {
     const editButton = screen.getByText('common.edit')
 
     fireEvent.click(editButton)
+    const modal = await screen.findByTestId('testModal')
 
-    expect(mockNavigate).toHaveBeenCalled()
+    expect(modal).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
### Summary
This PR adds a confirmation modal that appears when users attempt to edit resources, ensuring any `courses` or `cooperations` are not updated unintentionally. This modal prompts users to confirm or cancel their action, improving the overall user experience and preventing accidental edits.

### Changes
- **Binding Logic**: Bound the modal to trigger only on edit actions, responding dynamically based on the user's actions.

### Testing
1. Open a resource and attempt to edit it.
2. Verify that the confirmation modal appears, prompting a decision to confirm or cancel.
3. Ensure that confirming proceeds with the edit, while canceling dismisses the modal without saving changes.