### PR TITLE
Fix render empty state for faqItems

### DIFF
--- a/src/pages/offer-details/OfferDetails.tsx
+++ b/src/pages/offer-details/OfferDetails.tsx
@@ -261,7 +261,7 @@ const OfferDetails = () => {
       <AppCard sx={styles.wrapper}>
         <OfferGeneralInfo offer={offerData} />
       </AppCard>
-      {faqItems?.length && (
+      {faqItems && faqItems.length > 0 && (
         <AppCard sx={styles.wrapper}>
           <MultiAccordionWithTitle
             items={faqItems}


### PR DESCRIPTION
- [x] prevent rendering 0 when faqItems is empty

Before:
![image](https://github.com/user-attachments/assets/2a3df450-88b1-4335-a951-c2d6499a85d0)
After:
![image](https://github.com/user-attachments/assets/50a602e5-d1b5-4e3e-8646-830fb01b5771)
