### PR TITLE
Added refreshing for an access token

### DIFF
--- a/src/services/setup-interceptors.ts
+++ b/src/services/setup-interceptors.ts
@@ -1,12 +1,11 @@
-import {
-  AxiosError,
-  InternalAxiosRequestConfig,
-  AxiosHeaders,
-  AxiosResponse
-} from 'axios'
+import { InternalAxiosRequestConfig, AxiosHeaders, AxiosResponse } from 'axios'
 import { axiosClient } from '~/plugins/axiosClient'
 import i18n from '~/plugins/i18n'
-import { authService } from '~/services/auth-service'
+import { checkAuth } from '~/redux/reducer'
+import { store } from '~/redux/store'
+import { router } from '~/router/router'
+import { AxiosResponseError } from '~/types'
+import { authRoutes } from '~/router/constants/authRoutes'
 
 export const setupInterceptors = (): void => {
   axiosClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
@@ -21,16 +20,24 @@ export const setupInterceptors = (): void => {
     (response: AxiosResponse) => {
       return response
     },
-    async (error: AxiosError) => {
-      const originalRequest = error.config as InternalAxiosRequestConfig
-      if (error.code === 'UNAUTHORIZED' && error.config) {
-        try {
-          return await axiosClient.request(originalRequest)
-        } catch (e) {
-          return authService.endpoints.logout.initiate()
-        }
+    async (error: AxiosResponseError) => {
+      if (error.response?.data.code !== 'UNAUTHORIZED') {
+        return Promise.reject(error)
       }
-      return Promise.reject(error)
+
+      const originalRequest = error.config as InternalAxiosRequestConfig
+      if (
+        error.response?.data.code === 'UNAUTHORIZED' &&
+        error.config &&
+        !error.config._isRetry
+      ) {
+        error.config._isRetry = true
+        await store.dispatch(checkAuth())
+        return axiosClient.request(originalRequest)
+      } else {
+        void router.navigate(authRoutes.accountMenu.logout.path)
+        return Promise.reject(error)
+      }
     }
   )
 }

--- a/src/services/setup-interceptors.ts
+++ b/src/services/setup-interceptors.ts
@@ -22,7 +22,7 @@ export const setupInterceptors = (): void => {
     },
     async (error: AxiosResponseError) => {
       if (error.response?.data.code !== 'UNAUTHORIZED') {
-        return Promise.reject(error)
+        return Promise.resolve(error)
       }
 
       const originalRequest = error.config as InternalAxiosRequestConfig
@@ -35,8 +35,9 @@ export const setupInterceptors = (): void => {
         await store.dispatch(checkAuth())
         return axiosClient.request(originalRequest)
       } else {
-        void router.navigate(authRoutes.accountMenu.logout.path)
-        return Promise.reject(error)
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        router.navigate(authRoutes.accountMenu.logout.path)
+        return Promise.resolve(error)
       }
     }
   )

--- a/src/types/services/types/services.types.ts
+++ b/src/types/services/types/services.types.ts
@@ -1,5 +1,5 @@
+import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { Sort } from '~/types'
-import { AxiosResponse } from 'axios'
 
 export interface RequestParams {
   limit?: number
@@ -17,3 +17,7 @@ export interface ErrorResponse {
 export type ServiceFunction<Response, Params = undefined> = (
   params: Params extends undefined ? undefined : Params
 ) => Promise<AxiosResponse<Response>>
+
+export interface AxiosResponseError extends AxiosError<ErrorResponse> {
+  config: InternalAxiosRequestConfig & { _isRetry: boolean }
+}

--- a/tests/unit/services/setup-interceptors.spec.js
+++ b/tests/unit/services/setup-interceptors.spec.js
@@ -1,0 +1,87 @@
+import { vi } from 'vitest'
+
+import { setupInterceptors } from '~/services/setup-interceptors'
+import { mockAxiosClient } from '~tests/test-utils'
+import { axiosClient } from '~/plugins/axiosClient'
+import { authRoutes } from '~/router/constants/authRoutes'
+
+const navigateMock = vi.fn()
+const dispatchMock = vi.fn()
+
+vi.mock('~/plugins/i18n', () => {
+  return {
+    default: { language: 'en' }
+  }
+})
+
+vi.mock('~/redux/store', () => {
+  return {
+    store: { dispatch: (params) => dispatchMock(params) }
+  }
+})
+
+vi.mock('~/router/router', () => {
+  return {
+    router: { navigate: (params) => navigateMock(params) }
+  }
+})
+
+const testUrl = '/test'
+
+const unauthorizedError = {
+  code: 'UNAUTHORIZED',
+  message: 'Unauthorized message',
+  status: 401
+}
+
+const okResponse = {
+  code: 'OK',
+  status: 200
+}
+
+describe('setupInterceptors tests', () => {
+  beforeAll(() => {
+    setupInterceptors()
+  })
+
+  it('should return error if the code in response data is not UNAUTHORIZED', async () => {
+    const badRequestError = {
+      code: 'BAD_REQUEST',
+      message: 'bad request message',
+      status: 400
+    }
+    mockAxiosClient.onGet(testUrl).reply(400, badRequestError)
+
+    try {
+      await axiosClient.get(testUrl)
+    } catch (error) {
+      expect(error.response.data).toEqual(badRequestError)
+    }
+  })
+
+  it('should should navigate to the logout path if tokens were not refreshed', async () => {
+    mockAxiosClient.onGet(testUrl).reply(401, unauthorizedError)
+
+    try {
+      await axiosClient.get(testUrl)
+    } catch (error) {
+      expect(navigateMock).toHaveBeenCalledWith(
+        authRoutes.accountMenu.logout.path
+      )
+      expect(error.response.data).toEqual(unauthorizedError)
+    }
+  })
+
+  it('should return response if tokens were refreshed', async () => {
+    mockAxiosClient
+      .onGet(testUrl)
+      .replyOnce(401, unauthorizedError)
+      .onGet(testUrl)
+      .reply(200, okResponse)
+
+    const response = await axiosClient.get(testUrl)
+
+    expect(dispatchMock).toHaveBeenCalled()
+    expect(response.data).toEqual(okResponse)
+  })
+})


### PR DESCRIPTION
- [x] addedd refresh logic for an access token

If you want to test it by reducing the lifetime of an access token, please don't set it to less than 2 seconds because it will cause conflicts in refresh logic if multiple requests are sent on a page at the same time