### PR TITLE
Fix students accessing unavailable cooperation resources

### DIFF
--- a/src/containers/course-section/resource-item/ResourceItem.tsx
+++ b/src/containers/course-section/resource-item/ResourceItem.tsx
@@ -173,7 +173,11 @@ const ResourceItem: FC<ResourceItemProps> = ({
   )
 
   const onResourceItemClick = () => {
-    if (!isView) return
+    if (
+      !isView ||
+      resourceAvailabilityStatus !== ResourceAvailabilityStatusEnum.Open
+    )
+      return
     const type = resourceType ?? resource.resourceType
 
     if (type === ResourceType.Attachment) {


### PR DESCRIPTION
Now, when the user clicks on an unavailable resource, they are no longer redirected:


https://github.com/user-attachments/assets/6c8d3f8e-0691-4732-a470-1460731fcbbb

