### PR TITLE
Hide the attachments accordion on the lesson details page if no attachments are available

### DIFF
--- a/src/pages/lesson-details/LessonDetails.tsx
+++ b/src/pages/lesson-details/LessonDetails.tsx
@@ -95,10 +95,14 @@ const LessonDetails = () => {
         />
       )
     },
-    {
-      title: 'lesson.attachments',
-      content: <Box sx={styles.attachmentList}>{attachmentsList}</Box>
-    }
+    ...(response.attachments.length > 0
+      ? [
+          {
+            title: 'lesson.attachments',
+            content: <Box sx={styles.attachmentList}>{attachmentsList}</Box>
+          }
+        ]
+      : [])
   ]
 
   const isEditable = userId === response.author

--- a/src/pages/lesson-details/LessonDetails.tsx
+++ b/src/pages/lesson-details/LessonDetails.tsx
@@ -17,7 +17,6 @@ import Accordions from '~/components/accordion/Accordions'
 import useAccordion from '~/hooks/use-accordions'
 import IconExtensionWithTitle from '~/components/icon-extension-with-title/IconExtensionWithTitle'
 import AppButton from '~/components/app-button/AppButton'
-
 import { errorRoutes } from '~/router/constants/errorRoutes'
 import { authRoutes } from '~/router/constants/authRoutes'
 import { styles } from '~/pages/lesson-details/LessonsDetails.styles'
@@ -33,7 +32,6 @@ const LessonDetails = () => {
   const { t } = useTranslation()
   const { userId } = useAppSelector((state) => state.appMain)
   const { openModal } = useModalContext()
-
   const [expandedItems, handleAccordionChange] = useAccordion({
     initialState: 0,
     multiple: true
@@ -54,9 +52,7 @@ const LessonDetails = () => {
     onResponseError: responseError
   })
 
-  if (loading) {
-    return <Loader pageLoad />
-  }
+  if (loading) return <Loader pageLoad />
 
   const handleEditLesson = () => {
     openModal({
@@ -83,19 +79,19 @@ const LessonDetails = () => {
     </Box>
   ))
 
-  const sanitizedHtmlContent = DOMPurify.sanitize(response.content)
-
   const items = [
     {
       title: 'lesson.content',
       content: (
         <Box
-          dangerouslySetInnerHTML={{ __html: sanitizedHtmlContent }}
+          dangerouslySetInnerHTML={{
+            __html: DOMPurify.sanitize(response.content)
+          }}
           sx={styles.content}
         />
       )
     },
-    ...(response.attachments.length > 0
+    ...(response.attachments?.length
       ? [
           {
             title: 'lesson.attachments',

--- a/src/services/course-service.ts
+++ b/src/services/course-service.ts
@@ -4,6 +4,22 @@ import { axiosClient } from '~/plugins/axiosClient'
 import { Course, CourseForm, GetCoursesParams } from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
 
+export interface Resource {
+  _id: string
+  name: string
+  type: string
+}
+
+export interface Section {
+  _id: string
+  title: string
+  resources: Resource[]
+}
+
+export interface ResourceData {
+  sections: Section[]
+}
+
 export const CourseService = {
   getCourses: async (params?: GetCoursesParams): Promise<AxiosResponse> =>
     await axiosClient.get(URLs.courses.get, { params }),

--- a/tests/unit/pages/lesson-details/LessonDetails.spec.jsx
+++ b/tests/unit/pages/lesson-details/LessonDetails.spec.jsx
@@ -101,4 +101,24 @@ describe('LessonDetails', () => {
 
     expect(modal).toBeInTheDocument()
   })
+
+  it('should handle opening and closing of multiple accordions', async () => {
+    renderWithProviders(<LessonDetails />, { preloadedState: mockState })
+
+    const contentTitle = await screen.findByText('lesson.content')
+    const accordions = screen.getAllByText('lesson.attachments')
+    const attachmentsTitle = accordions[0]
+
+    // Expand both sections
+    fireEvent.click(contentTitle)
+    fireEvent.click(attachmentsTitle)
+
+    const attachment = screen.getAllByText('file1.png')[0]
+    expect(attachment).toBeVisible()
+
+    fireEvent.click(attachmentsTitle)
+    await waitFor(() => {
+      expect(attachment).not.toBeVisible()
+    })
+  })
 })

--- a/tests/unit/pages/lesson-details/LessonDetails.spec.jsx
+++ b/tests/unit/pages/lesson-details/LessonDetails.spec.jsx
@@ -109,7 +109,6 @@ describe('LessonDetails', () => {
     const accordions = screen.getAllByText('lesson.attachments')
     const attachmentsTitle = accordions[0]
 
-    // Expand both sections
     fireEvent.click(contentTitle)
     fireEvent.click(attachmentsTitle)
 


### PR DESCRIPTION
Expected Result:
The attachments section should only be visible when there are attachments to display. If no attachments are present, the accordion should be hidden to improve the user experience and reduce unnecessary UI elements.

Actual Result:

https://github.com/user-attachments/assets/55270cca-bbda-45e7-b454-235a4c875037

