### PR TITLE
Display active tab in URL on "My cooperations" and "My offers" pages

### DIFF
--- a/src/components/tab-filter-list/TabFilterList.tsx
+++ b/src/components/tab-filter-list/TabFilterList.tsx
@@ -1,0 +1,37 @@
+import { Box, SxProps } from '@mui/material'
+import Tab from '~/components/tab/Tab'
+
+import { useTranslation } from 'react-i18next'
+
+import { TabType } from '~/types'
+
+type TabFilterListProps = {
+  tabsData: Record<string, TabType<string>>
+  activeTab: string
+  onClick: (tabName: string, tabValue: string) => void
+  sx?: SxProps
+}
+
+const TabFilterList = ({
+  tabsData,
+  activeTab,
+  onClick,
+  sx
+}: TabFilterListProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <Box sx={sx}>
+      {Object.entries(tabsData).map(([tabName, tab]) => (
+        <Tab
+          activeTab={activeTab === tabName}
+          key={tab.label}
+          onClick={() => onClick(tabName, tab.value)}
+        >
+          {t(tab.label)}
+        </Tab>
+      ))}
+    </Box>
+  )
+}
+export default TabFilterList

--- a/src/pages/my-offers/MyOffers.tsx
+++ b/src/pages/my-offers/MyOffers.tsx
@@ -65,7 +65,9 @@ const MyOffers = () => {
   const handleOpenDrawer = () => openDrawer()
 
   useEffect(() => {
-    if (!activeTab) setSearchParams({ tab: Object.keys(tabsInfo)[0] })
+    if (!activeTab) {
+      setSearchParams({ tab: Object.keys(tabsInfo)[0] })
+    }
   }, [activeTab, setSearchParams])
 
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)

--- a/src/pages/my-offers/MyOffers.tsx
+++ b/src/pages/my-offers/MyOffers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -9,10 +9,11 @@ import AppDrawer from '~/components/app-drawer/AppDrawer'
 import AppPagination from '~/components/app-pagination/AppPagination'
 import Loader from '~/components/loader/Loader'
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
-import Tab from '~/components/tab/Tab'
+import TabFilterList from '~/components/tab-filter-list/TabFilterList'
 import CooperationOfferToolbar from '~/containers/my-cooperations/cooperation-offer-toolbar/CooperationOfferToolbar'
 import MyOffersContainer from '~/containers/my-offers/my-offers-container/MyOffersContainer'
 import CreateOffer from '~/containers/offer-page/create-offer/CreateOffer'
+import { useSearchParams } from 'react-router-dom'
 import useFilter from '~/hooks/table/use-filter'
 import usePagination from '~/hooks/table/use-pagination'
 import useSort from '~/hooks/table/use-sort'
@@ -32,8 +33,10 @@ import {
   sortTranslationKeys,
   tabsInfo
 } from '~/pages/my-offers/MyOffers.constants'
-import { CardsViewEnum, TabType } from '~/types'
+import { CardsViewEnum } from '~/types'
 import { setPageLoad } from '~/redux/reducer'
+
+type TabName = keyof typeof tabsInfo
 
 const MyOffers = () => {
   const [itemsView, setItemsView] = useState<CardsViewEnum>(
@@ -42,8 +45,13 @@ const MyOffers = () => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const breakpoints = useBreakpoints()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const activeTab = searchParams.get('tab')
   const filterOptions = useFilter({
-    initialFilters
+    initialFilters: {
+      ...initialFilters,
+      status: activeTab ? tabsInfo[activeTab as TabName].value : ''
+    }
   })
   const sortOptions = useSort({
     initialSort
@@ -55,6 +63,10 @@ const MyOffers = () => {
   const { filters, clearFilters, setFilterByKey } = filterOptions
 
   const handleOpenDrawer = () => openDrawer()
+
+  useEffect(() => {
+    if (!activeTab) setSearchParams({ tab: Object.keys(tabsInfo)[0] })
+  }, [activeTab, setSearchParams])
 
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
   const showTable = !breakpoints.isMobile && itemsView === CardsViewEnum.Inline
@@ -79,21 +91,12 @@ const MyOffers = () => {
     defaultResponse
   })
 
-  const handleTabClick = (tab: TabType<string>) => {
+  const handleTabClick = (tabName: string, tabValue: string) => {
+    setSearchParams({ tab: tabName })
     clearFilters()
     resetSort()
-    setFilterByKey('status')(tab.value)
+    setFilterByKey('status')(tabValue)
   }
-
-  const tabs = Object.values(tabsInfo).map((tab) => (
-    <Tab
-      activeTab={filters.status === tab.value}
-      key={tab.label}
-      onClick={() => handleTabClick(tab)}
-    >
-      {t(tab.label)}
-    </Tab>
-  ))
 
   const sortFields = sortTranslationKeys.map(({ title, value }) => ({
     title: t(title),
@@ -117,7 +120,12 @@ const MyOffers = () => {
           <CreateOffer closeDrawer={closeDrawer} />
         </AppDrawer>
       </Box>
-      <Box sx={styles.tabs}>{tabs}</Box>
+      <TabFilterList
+        activeTab={activeTab ?? ''}
+        onClick={handleTabClick}
+        sx={styles.tabs}
+        tabsData={tabsInfo}
+      />
       <CooperationOfferToolbar
         filterOptions={filterOptions}
         onChangeView={setItemsView}

--- a/tests/unit/components/tab-filter-list/TabFilterList.spec.jsx
+++ b/tests/unit/components/tab-filter-list/TabFilterList.spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import TabFilterList from '~/components/tab-filter-list/TabFilterList'
+
+const mockData = {
+  tab1: {
+    label: 'Tab 1',
+    value: 'tab1'
+  },
+  tab2: {
+    label: 'Tab 2',
+    value: 'tab2'
+  }
+}
+
+const handleClickMock = vi.fn()
+
+describe('TabFilterList', () => {
+  beforeEach(() => {
+    render(
+      <TabFilterList
+        activeTab='tab1'
+        onClick={handleClickMock}
+        tabsData={mockData}
+      />
+    )
+  })
+
+  it('renders TabFilterList correctly', () => {
+    expect(screen.getByText('Tab 1')).toBeInTheDocument()
+    expect(screen.getByText('Tab 2')).toBeInTheDocument()
+  })
+
+  it('calls handleClick when a tab is clicked', () => {
+    fireEvent.click(screen.getByText('Tab 2'))
+    expect(handleClickMock).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Description
This PR adds functionality to display the active tab in the URL on the **"My Cooperations"** and **"My Offers"** pages. Now, when users navigate between tabs, the URL updates reflect the selected tab, allowing for improved navigation and sharing specific tab views.

## Changes Made
- Updated routing logic to capture and display the active tab as a URL query parameter.
- Moved tabs into new component TabFilterList to reuse it across different pages
- Modified tab component behavior to sync with the URL, ensuring the correct tab is shown when visiting a URL with an active tab parameter.
- Handling for default tab selection was added when no tab parameter was present.

## Testing
- Verified that switching tabs updates the URL correctly.
- Confirmed that reloading the page with an active tab in the URL correctly displays the corresponding tab.

