### PR TITLE
Fix the order of 'About tutor' block

### DIFF
--- a/src/containers/user-profile/about-tutor-block/AboutTutorBlock.constants.ts
+++ b/src/containers/user-profile/about-tutor-block/AboutTutorBlock.constants.ts
@@ -1,0 +1,8 @@
+import { ProfessionalBlock } from '~/types'
+
+export const aboutTutorBlockKeys: Array<keyof ProfessionalBlock> = [
+  'education',
+  'workExperience',
+  'scientificActivities',
+  'awards'
+]

--- a/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
+++ b/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -9,6 +9,7 @@ import useBreakpoints from '~/hooks/use-breakpoints'
 import Accordions from '~/components/accordion/Accordions'
 import useAccordions from '~/hooks/use-accordions'
 import { ProfessionalBlock, TypographyVariantEnum } from '~/types'
+import { aboutTutorBlockKeys } from './AboutTutorBlock.constants'
 
 import { styles } from '~/containers/user-profile/about-tutor-block/AboutTutorBlock.styles'
 
@@ -22,16 +23,16 @@ const AboutTutorBlock: FC<AboutTutorBlockProps> = ({ data }) => {
 
   const [expandedItem, handleAccordionChange] = useAccordions()
 
-  const professionalBlockKeys = Object.keys(data) as Array<
-    keyof ProfessionalBlock
-  >
-  const accordionItems = professionalBlockKeys
-    .filter((key) => data[key])
-    .reverse()
-    .map((key) => ({
-      title: `userProfilePage.aboutTutor.${key}`,
-      description: data[key]
-    }))
+  const accordionItems = useMemo(
+    () =>
+      aboutTutorBlockKeys
+        .filter((key) => data[key])
+        .map((key) => ({
+          title: `userProfilePage.aboutTutor.${key}`,
+          description: data[key]
+        })),
+    [data]
+  )
 
   if (accordionItems.length === 0) {
     return null

--- a/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
+++ b/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
@@ -27,6 +27,7 @@ const AboutTutorBlock: FC<AboutTutorBlockProps> = ({ data }) => {
   >
   const accordionItems = professionalBlockKeys
     .filter((key) => data[key])
+    .reverse()
     .map((key) => ({
       title: `userProfilePage.aboutTutor.${key}`,
       description: data[key]

--- a/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
+++ b/src/containers/user-profile/about-tutor-block/AboutTutorBlock.tsx
@@ -9,7 +9,7 @@ import useBreakpoints from '~/hooks/use-breakpoints'
 import Accordions from '~/components/accordion/Accordions'
 import useAccordions from '~/hooks/use-accordions'
 import { ProfessionalBlock, TypographyVariantEnum } from '~/types'
-import { aboutTutorBlockKeys } from './AboutTutorBlock.constants'
+import { aboutTutorBlockKeys } from '~/containers/user-profile/about-tutor-block/AboutTutorBlock.constants'
 
 import { styles } from '~/containers/user-profile/about-tutor-block/AboutTutorBlock.styles'
 


### PR DESCRIPTION
**Updated**: Created `aboutTutorBlockKeys` with the right order on Frontend.

**How it looks now:**

![image](https://github.com/user-attachments/assets/9139e7e9-ffb9-4fad-a280-e528f32d8aa5)
