### PR TITLE
fixed the email input erroring

### DIFF
--- a/src/containers/guest-home-page/login-form/LoginForm.tsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.tsx
@@ -57,7 +57,6 @@ const LoginForm: React.FC<LoginFormProps> = ({
   return (
     <Box component='form' onSubmit={handleSubmit} sx={styles.form}>
       <AppTextField
-        autoFocus
         data-testid={'email'}
         errorMsg={t(errors.email ?? '')}
         fullWidth


### PR DESCRIPTION
Removed autoFocus from one of the input fields in order to avoid triggering validation on button click, as the button click would lead to a blur event, thereby causing the validation to activate.

How it looks now:
![image](https://github.com/user-attachments/assets/5b6ba06d-c0a7-4bd4-8ffb-fafe8ce0bf61)
