### PR TITLE
Remove unnecessary "Add to drafts" button

### DIFF
--- a/src/containers/offer-page/create-or-edit-offer/CreateOrEditOffer.constants.ts
+++ b/src/containers/offer-page/create-or-edit-offer/CreateOrEditOffer.constants.ts
@@ -10,7 +10,8 @@ export const getInitialValues = (offer: Offer | null) => ({
   description: offer?.description ?? '',
   price: offer?.price.toString() ?? '',
   status: offer?.status ?? StatusEnum.Active,
-  FAQ: offer?.FAQ ?? [{ question: '', answer: '', id: `${Date.now()}` }]
+  FAQ: offer?.FAQ ?? [{ question: '', answer: '', id: `${Date.now()}` }],
+  enrolledUsers: offer?.enrolledUsers ?? []
 })
 
 export const validations = {

--- a/src/containers/offer-page/create-or-edit-offer/CreateOrEditOffer.tsx
+++ b/src/containers/offer-page/create-or-edit-offer/CreateOrEditOffer.tsx
@@ -123,7 +123,9 @@ const CreateOrEditOffer: FC<CreateOrUpdateOfferProps> = ({
   const changeStatus = () =>
     handleNonInputValueChange('status', StatusEnum.Draft)
 
-  const isClosed = existingOffer?.status !== StatusEnum.Closed
+  const isMovableToDrafts =
+    existingOffer?.status !== StatusEnum.Closed &&
+    existingOffer?.status !== StatusEnum.Draft
 
   return (
     <Box
@@ -164,7 +166,7 @@ const CreateOrEditOffer: FC<CreateOrUpdateOfferProps> = ({
         >
           {t(`offerPage.${offerAction}.buttonTitles.${userRole}`)}
         </AppButton>
-        {isClosed && (
+        {isMovableToDrafts && (
           <AppButton
             onClick={changeStatus}
             size={SizeEnum.ExtraLarge}

--- a/tests/unit/containers/offer-page/edit-offer/EditOffer.spec.jsx
+++ b/tests/unit/containers/offer-page/edit-offer/EditOffer.spec.jsx
@@ -18,7 +18,8 @@ export const offerMock = {
   languages: ['Ukrainian'],
   subject: { _id: '6422dbc0823be47b41eeb8d9' },
   category: { _id: '6421ed8ed991d46a84721dfa' },
-  FAQ: []
+  FAQ: [],
+  status: 'draft'
 }
 
 const requiredSymbol = ' *'
@@ -134,5 +135,11 @@ describe('CreateOffer component', () => {
 
     expect(checkboxProfessional).toBeChecked()
     expect(checkboxBeginner).toBeChecked()
+  })
+
+  it('should not render "add to draft" button for draft offer', () => {
+    const draftButton = screen.queryByText('button.addToDrafts')
+
+    expect(draftButton).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
- Changed render condition for `AddToDrafts` button (made it rendered only on non-draft offers)
- Updated `getInitialValues` return value (it fixed ts error in `CreateOrEditOffer.tsx` file
- Added unit test for checking if `AddToDrafts` button is not displayed with draft offer

Before:

https://github.com/user-attachments/assets/50998a72-b4a3-457b-97ea-854aae23c2b5

After:

https://github.com/user-attachments/assets/7fb7dd18-39ca-4438-9270-54afc7e4cc4d



