### PR TITLE
Fix profile page accordion description text overflow

### DIFF
--- a/src/components/accordion/Accordion.styles.ts
+++ b/src/components/accordion/Accordion.styles.ts
@@ -35,7 +35,8 @@ export const styles: AccordionSx = {
     description: {
       fontSize: { md: '14px', sm: '8px' },
       lineHeight: { md: '24px', sm: '12px' },
-      color: 'basic.white'
+      color: 'basic.white',
+      wordWrap: 'break-word'
     },
     active: {
       backgroundColor: 'primary.800',
@@ -66,7 +67,8 @@ export const styles: AccordionSx = {
       pb: '24px',
       color: 'primary.900',
       typography: 'body2',
-      fontWeight: 400
+      fontWeight: 400,
+      wordWrap: 'break-word'
     },
     active: {
       boxShadow: commonShadow,

--- a/src/containers/user-profile/about-user-block/AboutUserBlock.styles.tsx
+++ b/src/containers/user-profile/about-user-block/AboutUserBlock.styles.tsx
@@ -37,7 +37,8 @@ export const styles = {
       }
     },
     '& .MuiAccordionDetails-root': {
-      p: { md: '0 24px 24px', xs: '0 12px 12px' }
+      p: { md: '0 24px 24px', xs: '0 12px 12px' },
+      wordWrap: 'break-word'
     },
     '& .MuiAccordion-root': {
       transition: 'background-color 0.2s ease-in-out'

--- a/src/containers/user-profile/about-user-block/AboutUserBlock.tsx
+++ b/src/containers/user-profile/about-user-block/AboutUserBlock.tsx
@@ -41,7 +41,7 @@ const AboutUserBlock: FC<AboutUserBlockProps> = ({
           title: `userProfilePage.${userRole}About.${key}`,
           description: data[key]
         })),
-    [data]
+    [data, itemKeys, userRole]
   )
 
   if (accordionItems.length === 0) {


### PR DESCRIPTION
**Before**
The big text without spaces in the "Education", “Work experience”, “Scientific activities”, “Awards” field will overflow and extend outside the container on the profile page:
![image](https://github.com/user-attachments/assets/f8320bc9-0b23-4e77-9663-f1ce248535c6)

**Now**
Text without spaces breaks to fit into container:
![image](https://github.com/user-attachments/assets/25c81c95-1e1e-492e-b4fd-cc06133e2a6b)

Text with spaces behaves as usual:
![image](https://github.com/user-attachments/assets/22341157-2a24-42ce-bfa7-883bffd5276f)

_Additionaly: fixed useMemo missing dependencies in AboutUserBlock accordionItems._

