### PR TITLE
Fix long names spilling outside container on profile page

### DIFF
--- a/src/containers/user-profile/profile-info/ProfileInfo.styles.js
+++ b/src/containers/user-profile/profile-info/ProfileInfo.styles.js
@@ -67,7 +67,10 @@ export const styles = {
     },
     title: {
       typography: { xs: 'button', sm: 'h5', md: 'h4' },
-      mb: 1
+      mb: 1,
+      whiteSpace: 'normal',
+      wordBreak: 'break-all',
+      maxWidth: '95%'
     },
     description: {
       typography: { xs: 'body2', md: 'button' }


### PR DESCRIPTION
Fix long first and last names being covered by 'Edit profile' button and extend outside the container on the profile page

Demo with the longest possible name and surname (30 characters each):

Desktop:
![image](https://github.com/user-attachments/assets/198c1336-c946-4684-bcd7-c04df8c100a9)

Mobile:
![image-1](https://github.com/user-attachments/assets/87085a35-f0da-48a8-95b8-d94ecbe58156)
