### PR TITLE
Fixed logIn form validation

### DIFF
--- a/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
+++ b/src/containers/guest-home-page/login-dialog/LoginDialog.jsx
@@ -8,7 +8,7 @@ import useForm from '~/hooks/use-form'
 import { useLoginMutation } from '~/services/auth-service'
 import { useModalContext } from '~/context/modal-context'
 import { useAppDispatch } from '~/hooks/use-redux'
-import { email } from '~/utils/validations/login'
+import { email, logInPassword } from '~/utils/validations/login'
 import loginImg from '~/assets/img/login-dialog/login.svg'
 import { login, snackbarVariants } from '~/constants'
 
@@ -47,7 +47,7 @@ const LoginDialog = () => {
         }
       },
       initialValues: { email: '', password: '', rememberMe: false },
-      validations: { email }
+      validations: { email, password: logInPassword }
     }
   )
 

--- a/src/containers/guest-home-page/login-form/LoginForm.tsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.tsx
@@ -108,7 +108,11 @@ const LoginForm: React.FC<LoginFormProps> = ({
       </Box>
 
       <AppButton
-        disabled={!data.email || !data.password}
+        disabled={
+          !data.email ||
+          !data.password ||
+          !Object.values(errors).every((elem) => elem === '')
+        }
         loading={authLoading}
         sx={styles.loginButton}
         type='submit'

--- a/src/containers/guest-home-page/login-form/LoginForm.tsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.tsx
@@ -54,6 +54,11 @@ const LoginForm: React.FC<LoginFormProps> = ({
     openModal({ component: <ForgotPassword /> })
   }
 
+  const isDisabled =
+    !data.email ||
+    !data.password ||
+    !Object.values(errors).every((elem) => elem === '')
+
   return (
     <Box component='form' onSubmit={handleSubmit} sx={styles.form}>
       <AppTextField
@@ -108,11 +113,7 @@ const LoginForm: React.FC<LoginFormProps> = ({
       </Box>
 
       <AppButton
-        disabled={
-          !data.email ||
-          !data.password ||
-          !Object.values(errors).every((elem) => elem === '')
-        }
+        disabled={isDisabled}
         loading={authLoading}
         sx={styles.loginButton}
         type='submit'

--- a/src/utils/validations/login.js
+++ b/src/utils/validations/login.js
@@ -26,3 +26,14 @@ export const confirmPassword = (password, data) => {
         : ''
   })
 }
+
+export const logInPassword = (password) => {
+  return emptyField({
+    value: password,
+    emptyMessage: 'common.errorMessages.emptyField',
+    helperText:
+      password.length < 8 || password.length > 25
+        ? 'common.errorMessages.passwordLength'
+        : ''
+  })
+}

--- a/tests/unit/containers/guest-home-page/login-form/LoginForm.spec.jsx
+++ b/tests/unit/containers/guest-home-page/login-form/LoginForm.spec.jsx
@@ -9,7 +9,7 @@ vi.mock('~/hooks/use-confirm', () => {
   }
 })
 
-const errors = { email: false, password: false, rememberMe: false }
+const errors = { email: '', password: '', rememberMe: '' }
 const data = {
   email: 'email@mail.com',
   password: 'passTest1',


### PR DESCRIPTION
1. Now the helper text “Password cannot be shorter than 8 and longer than 25 characters” is displayed + Empty field error.
2. The “Login” button is disabled when error messages related to inputs appear.

![image](https://github.com/user-attachments/assets/bef28fe4-9a41-41bd-bd13-3d1ceecc50a3)

![image](https://github.com/user-attachments/assets/d24c2aae-e876-482f-a86f-3ba5e302825e)


