### PR TITLE
Fixed useMemo dependencies in AboutUserBlock

### DIFF
--- a/src/containers/user-profile/about-user-block/AboutUserBlock.tsx
+++ b/src/containers/user-profile/about-user-block/AboutUserBlock.tsx
@@ -41,7 +41,7 @@ const AboutUserBlock: FC<AboutUserBlockProps> = ({
           title: `userProfilePage.${userRole}About.${key}`,
           description: data[key]
         })),
-    [data]
+    [data, itemKeys, userRole]
   )
 
   if (accordionItems.length === 0) {


### PR DESCRIPTION
Missing dependencies (`itemKeys, userRole`) were added

Before:
![image](https://github.com/user-attachments/assets/561a0e3b-24a5-4d23-a564-dc1248650394)

After:
<img width="484" alt="Screenshot 2024-11-21 at 15 32 02" src="https://github.com/user-attachments/assets/492fff47-42f4-4232-adfe-ae37bc87cab7">
