### PR TITLE
Fixed two identical items displaying

### DIFF
--- a/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
+++ b/src/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList.tsx
@@ -15,13 +15,18 @@ const ProfessionalCategoryList: FC<ProfessionalCategoryListProps> = ({
   openProfessionalCategoryModal,
   handleDeleteCategory
 }) => {
-  const professionalCategoryItems = items.map((item) => {
+  const uniqueItems = items.filter(
+    (item, index, array) =>
+      array.findIndex((i) => i.category._id === item.category._id) === index
+  )
+
+  const professionalCategoryItems = uniqueItems.map((item) => {
     const handleDelete = () => handleDeleteCategory(item._id, item.category._id)
     return (
       <ProfessionalCategory
         handleDelete={handleDelete}
         item={item}
-        key={item._id}
+        key={item.category._id}
         openProfessionalCategoryModal={openProfessionalCategoryModal}
       />
     )


### PR DESCRIPTION
How it was: Two identical categories displayed in the professional information block.
![image](https://github.com/user-attachments/assets/28722871-1de2-4c9a-8050-567471d6a9c7)

How it became: One category with its subjects must be displayed in a single instance in the professional information block.
![image](https://github.com/user-attachments/assets/8c33b98f-886c-4d65-9cf4-d49688cc4a55)
![image](https://github.com/user-attachments/assets/b22b5f7c-1f50-477b-9e01-4dff02c21309)

