### PR TITLE
Prevent profile updates without changes

### DIFF
--- a/src/containers/edit-profile/profile-tab/ProfileTab.tsx
+++ b/src/containers/edit-profile/profile-tab/ProfileTab.tsx
@@ -14,7 +14,7 @@ import {
   updateProfileData,
   updateValidityStatus
 } from '~/redux/features/editProfileSlice'
-import { EditProfileForm, MainUserRole } from '~/types'
+import { EditProfileForm, MainUserRole, UserRoleEnum } from '~/types'
 import { styles } from '~/containers/edit-profile/profile-tab/ProfileTab.styles'
 import { scrollToAndHighlight } from '~/utils/scroll-and-highlight'
 import { fieldsWithIncreasedHeight } from '~/components/profile-item/complete-profile.constants'
@@ -42,10 +42,7 @@ const ProfileTab: FC = () => {
     nativeLanguage,
     photo: photo ?? '',
     professionalSummary: professionalSummary || '',
-    videoLink:
-      typeof videoLink === 'string'
-        ? videoLink
-        : (videoLink?.[userRole as MainUserRole] ?? '')
+    videoLink: videoLink?.[userRole as MainUserRole] || ''
   }
 
   const {
@@ -62,7 +59,15 @@ const ProfileTab: FC = () => {
   })
 
   const debouncedUpdateProfileData = useDebounce(() => {
-    void dispatch(updateProfileData(data))
+    const payload = {
+      ...data,
+      videoLink: {
+        student: userRole === UserRoleEnum.Student ? data.videoLink : null,
+        tutor: userRole === UserRoleEnum.Tutor ? data.videoLink : null
+      }
+    }
+
+    void dispatch(updateProfileData(payload))
   }, 300)
 
   const { hash, pathname } = useLocation()

--- a/src/containers/edit-profile/profile-tab/ProfileTab.tsx
+++ b/src/containers/edit-profile/profile-tab/ProfileTab.tsx
@@ -67,7 +67,7 @@ const ProfileTab: FC = () => {
       }
     }
 
-    void dispatch(updateProfileData(payload))
+    dispatch(updateProfileData(payload))
   }, 300)
 
   const { hash, pathname } = useLocation()

--- a/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.tsx
+++ b/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.tsx
@@ -99,8 +99,7 @@ const ProfileTabForm: FC<ProfileTabFormProps> = ({
     void resizeImage(files[0])
   }
   const handleRemovePhoto = () => {
-    const updatedPhoto =
-      typeof photo === 'string' ? null : { src: '', name: '' }
+    const updatedPhoto = ''
     handleNonInputValueChange('photo', updatedPhoto)
   }
 

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -44,7 +44,14 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
       return statePhoto.src
     }
 
-    if (photo || photo === '') {
+    if (typeof statePhoto === 'string' && statePhoto !== '') {
+      return createUrlPath(
+        import.meta.env.VITE_APP_IMG_USER_URL || '',
+        statePhoto
+      )
+    }
+
+    if (photo) {
       return createUrlPath(import.meta.env.VITE_APP_IMG_USER_URL || '', photo)
     }
   }, [photo, statePhoto])

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -44,7 +44,7 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
       return statePhoto.src
     }
 
-    if (typeof statePhoto === 'string' && statePhoto !== '') {
+    if (typeof statePhoto === 'string') {
       return createUrlPath(
         import.meta.env.VITE_APP_IMG_USER_URL || '',
         statePhoto

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -12,8 +12,9 @@ import { defaultResponses } from '~/constants'
 
 import { styles } from '~/containers/navigation-icons/NavigationIcons.styles'
 
-import { UserResponse, UserRole } from '~/types'
+import { UpdatedPhoto, UserResponse, UserRole } from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
+import { isUpdatedPhoto } from '~/utils/is-updated-photo'
 
 interface AccountIconProps {
   openMenu: (event: MouseEvent) => void
@@ -40,8 +41,8 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
   const { photo: statePhoto } = useAppSelector((state) => state.editProfile)
 
   const avatarSrc = useMemo(() => {
-    if (typeof statePhoto === 'object' && statePhoto?.src) {
-      return statePhoto.src
+    if (isUpdatedPhoto(statePhoto)) {
+      return (statePhoto as UpdatedPhoto).src
     }
 
     if (typeof statePhoto === 'string') {

--- a/src/containers/navigation-icons/AccountIcon.tsx
+++ b/src/containers/navigation-icons/AccountIcon.tsx
@@ -40,11 +40,11 @@ const AccountIcon: FC<AccountIconProps> = ({ openMenu }) => {
   const { photo: statePhoto } = useAppSelector((state) => state.editProfile)
 
   const avatarSrc = useMemo(() => {
-    if (statePhoto?.src) {
+    if (typeof statePhoto === 'object' && statePhoto?.src) {
       return statePhoto.src
     }
 
-    if (photo) {
+    if (photo || photo === '') {
       return createUrlPath(import.meta.env.VITE_APP_IMG_USER_URL || '', photo)
     }
   }, [photo, statePhoto])

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -240,7 +240,7 @@ const EditProfile = () => {
       dataToUpdate.mainSubjects = categories
     }
 
-    if (photo || photo === '') {
+    if (typeof photo === 'object' || photo === '') {
       dataToUpdate.photo = photo
     }
 

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -141,6 +141,10 @@ const EditProfile = () => {
       )
     }
     void fetchData()
+
+    return () => {
+      void fetchData()
+    }
   }, [dispatch, userId, userRole])
 
   useEffect(() => {

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -22,6 +22,7 @@ import {
   ButtonVariantEnum,
   SizeEnum,
   UpdatedPhoto,
+  EditProfilePhoto,
   UpdateUserParams,
   UserProfileTabsEnum,
   UserRole
@@ -90,14 +91,14 @@ const EditProfile = () => {
     return JSON.stringify(initialData) !== JSON.stringify(currentData)
   }
 
-  const isUpdatedPhoto = (photo: string | null | UpdatedPhoto): boolean => {
+  const isUpdatedPhoto = (photo: EditProfilePhoto): boolean => {
     return photo !== null && typeof photo === 'object' && 'name' in photo
   }
 
   const hasPhotoChanges = useCallback(
     (
-      initialPhoto: string | null | UpdatedPhoto,
-      currentPhoto: string | null | UpdatedPhoto
+      initialPhoto: EditProfilePhoto,
+      currentPhoto: EditProfilePhoto
     ): boolean => {
       if (initialPhoto !== '' && currentPhoto === '') {
         return true

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -12,7 +12,6 @@ import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
 
 import useConfirm from '~/hooks/use-confirm'
-
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 import Loader from '~/components/loader/Loader'
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
@@ -25,11 +24,10 @@ import {
   EditProfilePhoto,
   UpdateUserParams,
   UserProfileTabsEnum,
-  UserRole
+  UserRole,
+  DataByRole
 } from '~/types'
 import { tabsData } from '~/pages/edit-profile/EditProfile.constants'
-
-import { styles } from '~/pages/edit-profile/EditProfile.styles'
 import {
   fetchUserById,
   updateUser,
@@ -39,7 +37,10 @@ import { LoadingStatusEnum } from '~/redux/redux.constants'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { snackbarVariants } from '~/constants'
 import { authRoutes } from '~/router/constants/authRoutes'
-import { DataByRole } from '~/types'
+import { areAllValuesEmptyStrings } from '~/utils/are-all-values-empty-strings'
+import { isUpdatedPhoto } from '~/utils/is-updated-photo'
+
+import { styles } from '~/pages/edit-profile/EditProfile.styles'
 
 const EditProfile = () => {
   const [initialEditProfileState, setInitialEditProfileState] = useState<
@@ -76,23 +77,11 @@ const EditProfile = () => {
   const isPasswordSecurityTab =
     activeTab === UserProfileTabsEnum.PasswordAndSecurity
 
-  const areAllValuesEmptyStrings = (obj: {
-    [key: string]: string
-  }): boolean => {
-    return Object.values(obj).every(
-      (value) => typeof value === 'string' && value === ''
-    )
-  }
-
   const hasChanges = (
     initialData: Partial<EditProfileState> | DataByRole<string>,
     currentData: Partial<EditProfileState> | DataByRole<string>
   ): boolean => {
     return JSON.stringify(initialData) !== JSON.stringify(currentData)
-  }
-
-  const isUpdatedPhoto = (photo: EditProfilePhoto): boolean => {
-    return photo !== null && typeof photo === 'object' && 'name' in photo
   }
 
   const hasPhotoChanges = useCallback(

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -157,7 +157,11 @@ const EditProfile = () => {
     if (city && country) dataToUpdate.address = { city, country }
 
     if (videoLink) {
-      dataToUpdate.videoLink = videoLink[userRole as keyof DataByRole<string>]
+      const updatedVideolink = videoLink[userRole as keyof DataByRole<string>]
+
+      if (updatedVideolink) {
+        dataToUpdate.videoLink = updatedVideolink
+      }
     }
 
     if (notificationSettings)

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Link,
@@ -20,8 +20,6 @@ import SidebarMenu from '~/components/sidebar-menu/SidebarMenu'
 import {
   ButtonVariantEnum,
   SizeEnum,
-  UpdatedPhoto,
-  EditProfilePhoto,
   UpdateUserParams,
   UserProfileTabsEnum,
   UserRole,
@@ -37,10 +35,9 @@ import { LoadingStatusEnum } from '~/redux/redux.constants'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { snackbarVariants } from '~/constants'
 import { authRoutes } from '~/router/constants/authRoutes'
-import { areAllValuesEmptyStrings } from '~/utils/are-all-values-empty-strings'
-import { isUpdatedPhoto } from '~/utils/is-updated-photo'
 
 import { styles } from '~/pages/edit-profile/EditProfile.styles'
+import { hasPhotoChanges } from '~/utils/has-photo-changes'
 
 const EditProfile = () => {
   const [initialEditProfileState, setInitialEditProfileState] = useState<
@@ -83,45 +80,6 @@ const EditProfile = () => {
   ): boolean => {
     return JSON.stringify(initialData) !== JSON.stringify(currentData)
   }
-
-  const hasPhotoChanges = useCallback(
-    (
-      initialPhoto: EditProfilePhoto,
-      currentPhoto: EditProfilePhoto
-    ): boolean => {
-      if (initialPhoto !== '' && currentPhoto === '') {
-        return true
-      }
-
-      if (
-        typeof initialPhoto === 'string' &&
-        isUpdatedPhoto(currentPhoto) &&
-        (currentPhoto as UpdatedPhoto).name !== initialPhoto
-      ) {
-        return true
-      }
-
-      if (
-        initialPhoto === null &&
-        isUpdatedPhoto(currentPhoto) &&
-        areAllValuesEmptyStrings(currentPhoto as UpdatedPhoto)
-      ) {
-        return true
-      }
-
-      if (
-        isUpdatedPhoto(initialPhoto) &&
-        isUpdatedPhoto(currentPhoto) &&
-        (initialPhoto as UpdatedPhoto).name !==
-          (currentPhoto as UpdatedPhoto).name
-      ) {
-        return true
-      }
-
-      return false
-    },
-    []
-  )
 
   useEffect(() => {
     const fetchData = async () => {
@@ -174,7 +132,7 @@ const EditProfile = () => {
     } else {
       return {}
     }
-  }, [profileState, initialEditProfileState, hasPhotoChanges])
+  }, [profileState, initialEditProfileState])
 
   const isChanged = useMemo<boolean>(
     () => Object.keys(changedFields).length > 0,

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -81,6 +81,10 @@ const EditProfile = () => {
     return JSON.stringify(initialData) !== JSON.stringify(currentData)
   }
 
+  const areAllValuesEmptyStrings = (obj: DataByRole<string>): boolean => {
+    return Object.values(obj).every((value) => value === '')
+  }
+
   useEffect(() => {
     const fetchData = async () => {
       await dispatch(
@@ -101,6 +105,8 @@ const EditProfile = () => {
 
   const changedFields = useMemo<Partial<EditProfileState>>(() => {
     if (!initialEditProfileState || !profileState) return {}
+    const { videoLink: initialVideoLink } = initialEditProfileState
+    const { videoLink: currentVideoLink } = profileState
 
     const { photo: initialPhoto, ...initialData } = initialEditProfileState
     const { photo: currentPhoto, ...currentData } = profileState
@@ -110,6 +116,13 @@ const EditProfile = () => {
 
     if (hasChanged) {
       const changes: Partial<EditProfileState> = { ...currentData }
+
+      if (
+        areAllValuesEmptyStrings(initialVideoLink) &&
+        areAllValuesEmptyStrings(currentVideoLink)
+      ) {
+        delete changes.videoLink
+      }
 
       if (initialPhoto === currentPhoto) {
         delete changes.photo
@@ -159,9 +172,7 @@ const EditProfile = () => {
     if (videoLink) {
       const updatedVideolink = videoLink[userRole as keyof DataByRole<string>]
 
-      if (updatedVideolink) {
-        dataToUpdate.videoLink = updatedVideolink
-      }
+      dataToUpdate.videoLink = updatedVideolink
     }
 
     if (notificationSettings)

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -37,6 +37,7 @@ import { LoadingStatusEnum } from '~/redux/redux.constants'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { snackbarVariants } from '~/constants'
 import { authRoutes } from '~/router/constants/authRoutes'
+import { DataByRole } from '~/types'
 
 const EditProfile = () => {
   const [initialEditProfileState, setInitialEditProfileState] = useState<
@@ -155,11 +156,8 @@ const EditProfile = () => {
 
     if (city && country) dataToUpdate.address = { city, country }
 
-    if (typeof videoLink === 'string' || typeof videoLink === 'undefined') {
-      dataToUpdate.videoLink = videoLink ?? ''
-    } else if (typeof videoLink === 'object') {
-      dataToUpdate.videoLink =
-        videoLink[userRole as keyof typeof videoLink] || ''
+    if (videoLink) {
+      dataToUpdate.videoLink = videoLink[userRole as keyof DataByRole<string>]
     }
 
     if (notificationSettings)

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Link,
@@ -21,6 +21,7 @@ import SidebarMenu from '~/components/sidebar-menu/SidebarMenu'
 import {
   ButtonVariantEnum,
   SizeEnum,
+  UpdatedPhoto,
   UpdateUserParams,
   UserProfileTabsEnum,
   UserRole
@@ -74,6 +75,14 @@ const EditProfile = () => {
   const isPasswordSecurityTab =
     activeTab === UserProfileTabsEnum.PasswordAndSecurity
 
+  const areAllValuesEmptyStrings = (
+    obj: DataByRole<string> | { [key: string]: string }
+  ): boolean => {
+    return Object.values(obj).every(
+      (value) => typeof value === 'string' && value === ''
+    )
+  }
+
   const hasChanges = (
     initialData: Partial<EditProfileState>,
     currentData: Partial<EditProfileState>
@@ -81,9 +90,44 @@ const EditProfile = () => {
     return JSON.stringify(initialData) !== JSON.stringify(currentData)
   }
 
-  const areAllValuesEmptyStrings = (obj: DataByRole<string>): boolean => {
-    return Object.values(obj).every((value) => value === '')
-  }
+  const hasPhotoChanges = useCallback(
+    (
+      initialPhoto: string | null | UpdatedPhoto,
+      currentPhoto: string | null | UpdatedPhoto
+    ): boolean => {
+      if (initialPhoto !== '' && currentPhoto === '') {
+        return true
+      }
+
+      if (
+        typeof initialPhoto === 'string' &&
+        (currentPhoto as UpdatedPhoto).name !== undefined &&
+        (currentPhoto as UpdatedPhoto).name !== initialPhoto
+      ) {
+        return true
+      }
+
+      if (
+        initialPhoto === null &&
+        (currentPhoto as UpdatedPhoto).name !== undefined &&
+        areAllValuesEmptyStrings(currentPhoto as UpdatedPhoto)
+      ) {
+        return true
+      }
+
+      if (
+        (initialPhoto as UpdatedPhoto).name !== undefined &&
+        (currentPhoto as UpdatedPhoto).name !== undefined &&
+        (initialPhoto as UpdatedPhoto).name !==
+          (currentPhoto as UpdatedPhoto).name
+      ) {
+        return true
+      }
+
+      return false
+    },
+    []
+  )
 
   useEffect(() => {
     const fetchData = async () => {
@@ -111,11 +155,15 @@ const EditProfile = () => {
     const { photo: initialPhoto, ...initialData } = initialEditProfileState
     const { photo: currentPhoto, ...currentData } = profileState
 
-    const hasChanged =
-      hasChanges(initialData, currentData) || initialPhoto !== currentPhoto
+    const hasPhotoChanged = hasPhotoChanges(initialPhoto, currentPhoto)
+
+    const hasChanged = hasChanges(initialData, currentData) || hasPhotoChanged
 
     if (hasChanged) {
-      const changes: Partial<EditProfileState> = { ...currentData }
+      const changes: Partial<EditProfileState> = {
+        ...currentData,
+        photo: currentPhoto
+      }
 
       if (
         areAllValuesEmptyStrings(initialVideoLink) &&
@@ -124,14 +172,15 @@ const EditProfile = () => {
         delete changes.videoLink
       }
 
-      if (initialPhoto === currentPhoto) {
+      if (!hasPhotoChanged) {
         delete changes.photo
       }
+
       return changes
     } else {
       return {}
     }
-  }, [profileState, initialEditProfileState])
+  }, [profileState, initialEditProfileState, hasPhotoChanges])
 
   const isChanged = useMemo<boolean>(
     () => Object.keys(changedFields).length > 0,
@@ -162,6 +211,7 @@ const EditProfile = () => {
       notificationSettings,
       professionalBlock,
       categories,
+      photo,
       ...rest
     } = changedFields
 
@@ -185,8 +235,8 @@ const EditProfile = () => {
       dataToUpdate.mainSubjects = categories
     }
 
-    if (typeof profileState.photo === 'object') {
-      dataToUpdate.photo = profileState.photo
+    if (photo || photo === '') {
+      dataToUpdate.photo = photo
     }
 
     await dispatch(

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -76,17 +76,17 @@ const EditProfile = () => {
   const isPasswordSecurityTab =
     activeTab === UserProfileTabsEnum.PasswordAndSecurity
 
-  const areAllValuesEmptyStrings = (
-    obj: DataByRole<string> | { [key: string]: string }
-  ): boolean => {
+  const areAllValuesEmptyStrings = (obj: {
+    [key: string]: string
+  }): boolean => {
     return Object.values(obj).every(
       (value) => typeof value === 'string' && value === ''
     )
   }
 
   const hasChanges = (
-    initialData: Partial<EditProfileState>,
-    currentData: Partial<EditProfileState>
+    initialData: Partial<EditProfileState> | DataByRole<string>,
+    currentData: Partial<EditProfileState> | DataByRole<string>
   ): boolean => {
     return JSON.stringify(initialData) !== JSON.stringify(currentData)
   }
@@ -170,10 +170,7 @@ const EditProfile = () => {
         photo: currentPhoto
       }
 
-      if (
-        areAllValuesEmptyStrings(initialVideoLink) &&
-        areAllValuesEmptyStrings(currentVideoLink)
-      ) {
+      if (!hasChanges(initialVideoLink, currentVideoLink)) {
         delete changes.videoLink
       }
 

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -166,16 +166,15 @@ const EditProfile = () => {
 
     if (hasChanged) {
       const changes: Partial<EditProfileState> = {
-        ...currentData,
-        photo: currentPhoto
+        ...currentData
       }
 
       if (!hasChanges(initialVideoLink, currentVideoLink)) {
         delete changes.videoLink
       }
 
-      if (!hasPhotoChanged) {
-        delete changes.photo
+      if (hasPhotoChanged) {
+        changes.photo = currentPhoto
       }
 
       return changes

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -90,6 +90,10 @@ const EditProfile = () => {
     return JSON.stringify(initialData) !== JSON.stringify(currentData)
   }
 
+  const isUpdatedPhoto = (photo: string | null | UpdatedPhoto): boolean => {
+    return photo !== null && typeof photo === 'object' && 'name' in photo
+  }
+
   const hasPhotoChanges = useCallback(
     (
       initialPhoto: string | null | UpdatedPhoto,
@@ -101,7 +105,7 @@ const EditProfile = () => {
 
       if (
         typeof initialPhoto === 'string' &&
-        (currentPhoto as UpdatedPhoto).name !== undefined &&
+        isUpdatedPhoto(currentPhoto) &&
         (currentPhoto as UpdatedPhoto).name !== initialPhoto
       ) {
         return true
@@ -109,15 +113,15 @@ const EditProfile = () => {
 
       if (
         initialPhoto === null &&
-        (currentPhoto as UpdatedPhoto).name !== undefined &&
+        isUpdatedPhoto(currentPhoto) &&
         areAllValuesEmptyStrings(currentPhoto as UpdatedPhoto)
       ) {
         return true
       }
 
       if (
-        (initialPhoto as UpdatedPhoto).name !== undefined &&
-        (currentPhoto as UpdatedPhoto).name !== undefined &&
+        isUpdatedPhoto(initialPhoto) &&
+        isUpdatedPhoto(currentPhoto) &&
         (initialPhoto as UpdatedPhoto).name !==
           (currentPhoto as UpdatedPhoto).name
       ) {

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -30,7 +30,7 @@ export interface EditProfileState {
   city: string | null
   professionalSummary?: string
   nativeLanguage: string | null
-  videoLink: DataByRole<string> | string
+  videoLink: DataByRole<string>
   photo?: UpdatedPhoto | null
   categories: DataByRole<UserMainSubject[]>
   professionalBlock: ProfessionalBlock
@@ -105,7 +105,10 @@ const updateStateFromPayload = (
   state.professionalSummary = professionalSummary
   state.nativeLanguage = nativeLanguage
   state.photo = photo as UpdatedPhoto | null
-  state.videoLink = videoLink
+  state.videoLink = {
+    [UserRoleEnum.Tutor]: videoLink?.[UserRoleEnum.Tutor] ?? '',
+    [UserRoleEnum.Student]: videoLink?.[UserRoleEnum.Student] ?? ''
+  }
   state.categories = mainSubjects
   state.professionalBlock = professionalBlock || initialProfessoinalBlock
   state.notificationSettings =
@@ -189,7 +192,11 @@ const editProfileSlice = createSlice({
       state.nativeLanguage = nativeLanguage
       state.photo = photo as UpdatedPhoto
       state.professionalSummary = professionalSummary
-      state.videoLink = videoLink
+      // TODO
+      state.videoLink = {
+        [UserRoleEnum.Tutor]: videoLink?.[UserRoleEnum.Tutor] ?? '',
+        [UserRoleEnum.Student]: videoLink?.[UserRoleEnum.Student] ?? ''
+      }
     },
     addCategory: (
       state,

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -13,7 +13,7 @@ import {
   NotificationSettings,
   ProfessionalBlock,
   SubjectNameInterface,
-  UpdatedPhoto,
+  EditProfilePhoto,
   UpdateUserParams,
   UserMainSubject,
   UserMainSubjectFieldValues,
@@ -31,7 +31,7 @@ export interface EditProfileState {
   professionalSummary?: string
   nativeLanguage: string | null
   videoLink: DataByRole<string>
-  photo: UpdatedPhoto | string | null
+  photo: EditProfilePhoto
   categories: DataByRole<UserMainSubject[]>
   professionalBlock: ProfessionalBlock
   notificationSettings: NotificationSettings

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -31,7 +31,7 @@ export interface EditProfileState {
   professionalSummary?: string
   nativeLanguage: string | null
   videoLink: DataByRole<string>
-  photo?: UpdatedPhoto | string
+  photo: UpdatedPhoto | string | null
   categories: DataByRole<UserMainSubject[]>
   professionalBlock: ProfessionalBlock
   notificationSettings: NotificationSettings
@@ -66,7 +66,7 @@ const initialState: EditProfileState = {
   professionalSummary: '',
   nativeLanguage: '',
   videoLink: { [UserRoleEnum.Tutor]: '', [UserRoleEnum.Student]: '' },
-  photo: '',
+  photo: null,
   categories: { [UserRoleEnum.Tutor]: [], [UserRoleEnum.Student]: [] },
   professionalBlock: initialProfessoinalBlock,
   notificationSettings: intitialNotificationSettings,
@@ -104,7 +104,7 @@ const updateStateFromPayload = (
   state.city = address?.city ?? null
   state.professionalSummary = professionalSummary
   state.nativeLanguage = nativeLanguage
-  state.photo = photo ?? ''
+  state.photo = photo ?? null
   state.videoLink = {
     [UserRoleEnum.Tutor]: videoLink?.[UserRoleEnum.Tutor] ?? '',
     [UserRoleEnum.Student]: videoLink?.[UserRoleEnum.Student] ?? ''
@@ -193,7 +193,7 @@ const editProfileSlice = createSlice({
       state.firstName = firstName
       state.lastName = lastName
       state.nativeLanguage = nativeLanguage
-      state.photo = photo ?? ''
+      state.photo = photo ?? null
       state.professionalSummary = professionalSummary
 
       if (videoLink?.[UserRoleEnum.Tutor] !== null) {

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -7,7 +7,7 @@ import {
 } from '~/redux/redux.constants'
 import {
   DataByRole,
-  EditProfileForm,
+  EditProfileFormSubmitData,
   ErrorResponse,
   MainUserRole,
   NotificationSettings,
@@ -31,7 +31,7 @@ export interface EditProfileState {
   professionalSummary?: string
   nativeLanguage: string | null
   videoLink: DataByRole<string>
-  photo?: UpdatedPhoto | null
+  photo?: UpdatedPhoto | string
   categories: DataByRole<UserMainSubject[]>
   professionalBlock: ProfessionalBlock
   notificationSettings: NotificationSettings
@@ -66,7 +66,7 @@ const initialState: EditProfileState = {
   professionalSummary: '',
   nativeLanguage: '',
   videoLink: { [UserRoleEnum.Tutor]: '', [UserRoleEnum.Student]: '' },
-  photo: null,
+  photo: '',
   categories: { [UserRoleEnum.Tutor]: [], [UserRoleEnum.Student]: [] },
   professionalBlock: initialProfessoinalBlock,
   notificationSettings: intitialNotificationSettings,
@@ -104,7 +104,7 @@ const updateStateFromPayload = (
   state.city = address?.city ?? null
   state.professionalSummary = professionalSummary
   state.nativeLanguage = nativeLanguage
-  state.photo = photo as UpdatedPhoto | null
+  state.photo = photo ?? ''
   state.videoLink = {
     [UserRoleEnum.Tutor]: videoLink?.[UserRoleEnum.Tutor] ?? '',
     [UserRoleEnum.Student]: videoLink?.[UserRoleEnum.Student] ?? ''
@@ -173,7 +173,10 @@ const editProfileSlice = createSlice({
       const { tab, value } = action.payload
       state.tabValidityStatus[tab] = value
     },
-    updateProfileData: (state, action: PayloadAction<EditProfileForm>) => {
+    updateProfileData: (
+      state,
+      action: PayloadAction<EditProfileFormSubmitData>
+    ) => {
       const {
         city,
         country,
@@ -190,12 +193,15 @@ const editProfileSlice = createSlice({
       state.firstName = firstName
       state.lastName = lastName
       state.nativeLanguage = nativeLanguage
-      state.photo = photo as UpdatedPhoto
+      state.photo = photo ?? ''
       state.professionalSummary = professionalSummary
-      // TODO
-      state.videoLink = {
-        [UserRoleEnum.Tutor]: videoLink?.[UserRoleEnum.Tutor] ?? '',
-        [UserRoleEnum.Student]: videoLink?.[UserRoleEnum.Student] ?? ''
+
+      if (videoLink?.[UserRoleEnum.Tutor] !== null) {
+        state.videoLink[UserRoleEnum.Tutor] = videoLink[UserRoleEnum.Tutor]
+      }
+
+      if (videoLink?.[UserRoleEnum.Student] !== null) {
+        state.videoLink[UserRoleEnum.Student] = videoLink[UserRoleEnum.Student]
       }
     },
     addCategory: (

--- a/src/types/edit-profile/interfaces/editProfile.interfaces.ts
+++ b/src/types/edit-profile/interfaces/editProfile.interfaces.ts
@@ -3,7 +3,7 @@ import {
   SubjectNameInterface,
   UpdatedPhoto
 } from '~/types/common/common.index'
-import { UserResponse, DataByRole } from '~/types'
+import { UserResponse, VideoUserRole } from '~/types'
 
 export interface EditProfileForm
   extends Pick<UserResponse, 'firstName' | 'lastName'> {
@@ -11,8 +11,13 @@ export interface EditProfileForm
   city: string | null
   professionalSummary: string
   nativeLanguage: string | null
-  videoLink: DataByRole<string>
+  videoLink: string
   photo: string | UpdatedPhoto | null
+}
+
+export interface EditProfileFormSubmitData
+  extends Omit<EditProfileForm, 'videoLink'> {
+  videoLink: { [key in VideoUserRole]: string | null }
 }
 
 export interface ProfessionalCategory {

--- a/src/types/edit-profile/interfaces/editProfile.interfaces.ts
+++ b/src/types/edit-profile/interfaces/editProfile.interfaces.ts
@@ -1,9 +1,8 @@
 import {
   CategoryInterface,
-  SubjectNameInterface,
-  UpdatedPhoto
+  SubjectNameInterface
 } from '~/types/common/common.index'
-import { UserResponse, VideoUserRole } from '~/types'
+import { EditProfilePhoto, UserResponse, VideoUserRole } from '~/types'
 
 export interface EditProfileForm
   extends Pick<UserResponse, 'firstName' | 'lastName'> {
@@ -12,7 +11,7 @@ export interface EditProfileForm
   professionalSummary: string
   nativeLanguage: string | null
   videoLink: string
-  photo: UpdatedPhoto | string | null
+  photo: EditProfilePhoto
 }
 
 export interface EditProfileFormSubmitData

--- a/src/types/edit-profile/interfaces/editProfile.interfaces.ts
+++ b/src/types/edit-profile/interfaces/editProfile.interfaces.ts
@@ -12,7 +12,7 @@ export interface EditProfileForm
   professionalSummary: string
   nativeLanguage: string | null
   videoLink: string
-  photo: string | UpdatedPhoto | null
+  photo: UpdatedPhoto | string | null
 }
 
 export interface EditProfileFormSubmitData

--- a/src/types/edit-profile/interfaces/editProfile.interfaces.ts
+++ b/src/types/edit-profile/interfaces/editProfile.interfaces.ts
@@ -3,7 +3,7 @@ import {
   SubjectNameInterface,
   UpdatedPhoto
 } from '~/types/common/common.index'
-import { UserResponse } from '~/types/user/user.index'
+import { UserResponse, DataByRole } from '~/types'
 
 export interface EditProfileForm
   extends Pick<UserResponse, 'firstName' | 'lastName'> {
@@ -11,7 +11,7 @@ export interface EditProfileForm
   city: string | null
   professionalSummary: string
   nativeLanguage: string | null
-  videoLink: string
+  videoLink: DataByRole<string>
   photo: string | UpdatedPhoto | null
 }
 

--- a/src/types/edit-profile/types/editProfile.types.ts
+++ b/src/types/edit-profile/types/editProfile.types.ts
@@ -1,7 +1,8 @@
 import {
   CategoryNameInterface,
   SubjectNameInterface,
-  UserMainSubject
+  UserMainSubject,
+  UpdatedPhoto
 } from '~/types'
 
 export type OpenProfessionalCategoryModalHandler = (
@@ -13,3 +14,5 @@ export type UserMainSubjectFieldValues = string &
   boolean &
   CategoryNameInterface &
   SubjectNameInterface[]
+
+export type EditProfilePhoto = UpdatedPhoto | string | null

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -6,7 +6,7 @@ import {
   RequestParams,
   Faq,
   DataByRole,
-  UpdatedPhoto,
+  EditProfilePhoto,
   UpdateFields,
   UserStatusEnum,
   UserMainSubject,
@@ -78,7 +78,7 @@ export interface UpdateUserParams
   extends Partial<Pick<UserResponse, UpdateFields>> {
   mainSubjects?: DataByRole<UserMainSubject[]>
   videoLink?: string
-  photo?: UpdatedPhoto | string | null
+  photo?: EditProfilePhoto
 }
 
 export interface LoginParams {

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -78,7 +78,7 @@ export interface UpdateUserParams
   extends Partial<Pick<UserResponse, UpdateFields>> {
   mainSubjects?: DataByRole<UserMainSubject[]>
   videoLink?: string
-  photo?: UpdatedPhoto | null
+  photo?: UpdatedPhoto | string
 }
 
 export interface LoginParams {

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -78,7 +78,7 @@ export interface UpdateUserParams
   extends Partial<Pick<UserResponse, UpdateFields>> {
   mainSubjects?: DataByRole<UserMainSubject[]>
   videoLink?: string
-  photo?: UpdatedPhoto | string
+  photo?: UpdatedPhoto | string | null
 }
 
 export interface LoginParams {

--- a/src/utils/are-all-values-empty-strings.ts
+++ b/src/utils/are-all-values-empty-strings.ts
@@ -1,0 +1,7 @@
+export const areAllValuesEmptyStrings = (obj: {
+  [key: string]: string
+}): boolean => {
+  return Object.values(obj).every(
+    (value) => typeof value === 'string' && value === ''
+  )
+}

--- a/src/utils/has-photo-changes.ts
+++ b/src/utils/has-photo-changes.ts
@@ -1,0 +1,38 @@
+import { EditProfilePhoto, UpdatedPhoto } from '~/types'
+import { isUpdatedPhoto } from '~/utils/is-updated-photo'
+import { areAllValuesEmptyStrings } from '~/utils/are-all-values-empty-strings'
+
+export const hasPhotoChanges = (
+  initialPhoto: EditProfilePhoto,
+  currentPhoto: EditProfilePhoto
+): boolean => {
+  if (initialPhoto !== '' && currentPhoto === '') {
+    return true
+  }
+
+  if (
+    typeof initialPhoto === 'string' &&
+    isUpdatedPhoto(currentPhoto) &&
+    (currentPhoto as UpdatedPhoto).name !== initialPhoto
+  ) {
+    return true
+  }
+
+  if (
+    initialPhoto === null &&
+    isUpdatedPhoto(currentPhoto) &&
+    areAllValuesEmptyStrings(currentPhoto as UpdatedPhoto)
+  ) {
+    return true
+  }
+
+  if (
+    isUpdatedPhoto(initialPhoto) &&
+    isUpdatedPhoto(currentPhoto) &&
+    (initialPhoto as UpdatedPhoto).name !== (currentPhoto as UpdatedPhoto).name
+  ) {
+    return true
+  }
+
+  return false
+}

--- a/src/utils/is-updated-photo.ts
+++ b/src/utils/is-updated-photo.ts
@@ -1,0 +1,10 @@
+import { EditProfilePhoto } from '~/types'
+
+export const isUpdatedPhoto = (photo: EditProfilePhoto): boolean => {
+  return (
+    photo !== null &&
+    typeof photo === 'object' &&
+    'name' in photo &&
+    'src' in photo
+  )
+}

--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -56,7 +56,7 @@ describe('ProfileTabForm', () => {
     const removePhotoBtn = screen.getByRole('button', { name: 'common.remove' })
     fireEvent.click(removePhotoBtn)
 
-    expect(handleNonInputValueChange).toHaveBeenCalledWith('photo', null)
+    expect(handleNonInputValueChange).toHaveBeenCalledWith('photo', '')
   })
 
   it('should handle adding a photo', async () => {

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -227,53 +227,41 @@ describe('EditProfile', () => {
     expect(dataToUpdate).toHaveProperty('address', { city, country })
   })
 
-  it('should not include photo in dataToUpdate if profileState.photo is not an object', () => {
+  it('should not include photo in dataToUpdate if profileState.photo is a filled string', () => {
     const photo = 'stringInsteadOfObject'
     const profileState = { photo }
     const rest = {}
 
     const dataToUpdate = { ...rest }
-    if (typeof profileState.photo === 'object') {
+    if (typeof profileState.photo === 'object' || profileState.photo === '') {
       dataToUpdate.photo = profileState.photo
     }
 
     expect(dataToUpdate).not.toHaveProperty('photo')
   })
 
-  it('should not include videoLink in dataToUpdate if videoLink is null', () => {
-    const videoLink = null
+  it('should include photo in dataToUpdate if profileState.photo is empty string', () => {
+    const photo = ''
+    const profileState = { photo }
     const rest = {}
 
     const dataToUpdate = { ...rest }
-    if (videoLink) {
-      dataToUpdate.videoLink =
-        typeof videoLink === 'string' ? videoLink : videoLink[userRole]
+    if (typeof profileState.photo === 'object' || profileState.photo === '') {
+      dataToUpdate.photo = profileState.photo
     }
 
-    expect(dataToUpdate).not.toHaveProperty('videoLink')
+    expect(dataToUpdate).toHaveProperty('photo')
   })
 
-  it('should include videoLink in dataToUpdate if videoLink is a string', () => {
-    const videoLink = 'http://video1234556443.com/video'
-    const rest = {}
-
-    const dataToUpdate = { ...rest }
-    if (videoLink) {
-      dataToUpdate.videoLink =
-        typeof videoLink === 'string' ? videoLink : videoLink[userRole]
-    }
-
-    expect(dataToUpdate).toHaveProperty('videoLink', videoLink)
-  })
-
-  it('should include videoLink from userRole in dataToUpdate if videoLink is an object', () => {
+  it('should include string videoLink from userRole in dataToUpdate if videoLink do exist', () => {
     const videoLink = { tutor: 'http://video1111111.com/video' }
     const rest = {}
 
     const dataToUpdate = { ...rest }
     if (videoLink) {
-      dataToUpdate.videoLink =
-        typeof videoLink === 'string' ? videoLink : videoLink[userRole]
+      const updatedVideolink = videoLink[userRole]
+
+      dataToUpdate.videoLink = updatedVideolink
     }
 
     expect(dataToUpdate).toHaveProperty('videoLink', videoLink[userRole])

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -33,13 +33,14 @@ const mockState = {
         isSimilarOffersNotification: false,
         isEmailNotification: false
       }
-    }
+    },
+    videoLink: { tutor: '', student: '' }
   }
 }
 
 const userMock = {
   role: userRole,
-  videoLink: { [userRole]: '' },
+  videoLink: { tutor: '', student: '' },
   mainSubjects: { [userRole]: [] },
   firstName: 'John',
   lastName: 'Doe',

--- a/tests/unit/redux/editProfileSlice.spec.js
+++ b/tests/unit/redux/editProfileSlice.spec.js
@@ -87,7 +87,7 @@ const initialState = {
   professionalSummary: '',
   nativeLanguage: '',
   videoLink: { [UserRoleEnum.Tutor]: '', [UserRoleEnum.Student]: '' },
-  photo: '',
+  photo: null,
   categories: { [UserRoleEnum.Tutor]: [], [UserRoleEnum.Student]: [] },
   professionalBlock: {
     education: '',

--- a/tests/unit/redux/editProfileSlice.spec.js
+++ b/tests/unit/redux/editProfileSlice.spec.js
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
+import { vi } from 'vitest'
 import reducer, {
   setField,
   updateValidityStatus,
@@ -86,7 +87,7 @@ const initialState = {
   professionalSummary: '',
   nativeLanguage: '',
   videoLink: { [UserRoleEnum.Tutor]: '', [UserRoleEnum.Student]: '' },
-  photo: null,
+  photo: '',
   categories: { [UserRoleEnum.Tutor]: [], [UserRoleEnum.Student]: [] },
   professionalBlock: {
     education: '',
@@ -388,7 +389,10 @@ describe('editProfileSlice test', () => {
       nativeLanguage: 'nativeLanguage',
       photo: 'photo',
       professionalSummary: 'professionalSummary',
-      videoLink: 'videoLink'
+      videoLink: {
+        student: undefined,
+        tutor: 'videoLink'
+      }
     })
 
     expect(
@@ -402,7 +406,10 @@ describe('editProfileSlice test', () => {
           nativeLanguage: 'nativeLanguage',
           photo: 'photo',
           professionalSummary: 'professionalSummary',
-          videoLink: 'videoLink'
+          videoLink: {
+            student: undefined,
+            tutor: 'videoLink'
+          }
         })
       )
     ).toEqual(expectedState)

--- a/tests/unit/utils/are-all-values-empty-strings.spec.js
+++ b/tests/unit/utils/are-all-values-empty-strings.spec.js
@@ -1,0 +1,15 @@
+import { expect } from 'vitest'
+
+import { areAllValuesEmptyStrings } from '~/utils/are-all-values-empty-strings'
+
+describe('areAllValuesEmptyStrings', () => {
+  it('should return true if all values are empty strings', () => {
+    const obj = { a: '', b: '', c: '' }
+    expect(areAllValuesEmptyStrings(obj)).toBe(true)
+  })
+
+  it('should return false if any value is not an empty string', () => {
+    const obj = { a: '', b: 'hello', c: '' }
+    expect(areAllValuesEmptyStrings(obj)).toBe(false)
+  })
+})

--- a/tests/unit/utils/has-photo-changes.spec.js
+++ b/tests/unit/utils/has-photo-changes.spec.js
@@ -1,45 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { hasPhotoChanges } from '~/utils/has-photo-changes'
+import { isUpdatedPhoto } from '~/utils/is-updated-photo'
+import { areAllValuesEmptyStrings } from '~/utils/are-all-values-empty-strings'
+
+vi.mock('~/utils/is-updated-photo', () => ({
+  isUpdatedPhoto: vi.fn()
+}))
+
+vi.mock('~/utils/are-all-values-empty-strings', () => ({
+  areAllValuesEmptyStrings: vi.fn()
+}))
 
 describe('hasPhotoChanges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should return true if initialPhoto is not empty and currentPhoto is empty', () => {
     const initialPhoto = 'initialPhoto'
     const currentPhoto = ''
+    isUpdatedPhoto.mockReturnValue(false)
+    areAllValuesEmptyStrings.mockReturnValue(false)
     expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
   })
 
   it('should return true if initialPhoto is a string and currentPhoto is an UpdatedPhoto with a different name', () => {
     const initialPhoto = 'initialPhoto'
     const currentPhoto = { src: 'src', name: 'newName' }
+    isUpdatedPhoto.mockReturnValue(true)
+    areAllValuesEmptyStrings.mockReturnValue(false)
     expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
   })
 
   it('should return true if initialPhoto is null and currentPhoto is an UpdatedPhoto with all values empty strings', () => {
     const initialPhoto = null
     const currentPhoto = { src: '', name: '' }
+    isUpdatedPhoto.mockReturnValue(true)
+    areAllValuesEmptyStrings.mockReturnValue(true)
     expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
   })
 
   it('should return true if both initialPhoto and currentPhoto are UpdatedPhotos with different names', () => {
     const initialPhoto = { src: 'src1', name: 'name1' }
     const currentPhoto = { src: 'src2', name: 'name2' }
+    isUpdatedPhoto.mockReturnValue(true)
+    areAllValuesEmptyStrings.mockReturnValue(false)
     expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
   })
 
   it('should return false if there are no changes', () => {
     const initialPhoto = { src: 'src', name: 'name' }
     const currentPhoto = { src: 'src', name: 'name' }
+    isUpdatedPhoto.mockReturnValue(true)
+    areAllValuesEmptyStrings.mockReturnValue(false)
     expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(false)
   })
 
   it('should return false if both initialPhoto and currentPhoto are empty strings', () => {
     const initialPhoto = ''
     const currentPhoto = ''
+    isUpdatedPhoto.mockReturnValue(false)
+    areAllValuesEmptyStrings.mockReturnValue(false)
     expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(false)
   })
 
   it('should return false if both initialPhoto and currentPhoto are null', () => {
     const initialPhoto = null
     const currentPhoto = null
+    isUpdatedPhoto.mockReturnValue(false)
+    areAllValuesEmptyStrings.mockReturnValue(false)
     expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(false)
   })
 })

--- a/tests/unit/utils/has-photo-changes.spec.js
+++ b/tests/unit/utils/has-photo-changes.spec.js
@@ -1,0 +1,45 @@
+import { hasPhotoChanges } from '~/utils/has-photo-changes'
+
+describe('hasPhotoChanges', () => {
+  it('should return true if initialPhoto is not empty and currentPhoto is empty', () => {
+    const initialPhoto = 'initialPhoto'
+    const currentPhoto = ''
+    expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
+  })
+
+  it('should return true if initialPhoto is a string and currentPhoto is an UpdatedPhoto with a different name', () => {
+    const initialPhoto = 'initialPhoto'
+    const currentPhoto = { src: 'src', name: 'newName' }
+    expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
+  })
+
+  it('should return true if initialPhoto is null and currentPhoto is an UpdatedPhoto with all values empty strings', () => {
+    const initialPhoto = null
+    const currentPhoto = { src: '', name: '' }
+    expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
+  })
+
+  it('should return true if both initialPhoto and currentPhoto are UpdatedPhotos with different names', () => {
+    const initialPhoto = { src: 'src1', name: 'name1' }
+    const currentPhoto = { src: 'src2', name: 'name2' }
+    expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(true)
+  })
+
+  it('should return false if there are no changes', () => {
+    const initialPhoto = { src: 'src', name: 'name' }
+    const currentPhoto = { src: 'src', name: 'name' }
+    expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(false)
+  })
+
+  it('should return false if both initialPhoto and currentPhoto are empty strings', () => {
+    const initialPhoto = ''
+    const currentPhoto = ''
+    expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(false)
+  })
+
+  it('should return false if both initialPhoto and currentPhoto are null', () => {
+    const initialPhoto = null
+    const currentPhoto = null
+    expect(hasPhotoChanges(initialPhoto, currentPhoto)).toBe(false)
+  })
+})

--- a/tests/unit/utils/is-updated-photo.spec.js
+++ b/tests/unit/utils/is-updated-photo.spec.js
@@ -1,0 +1,29 @@
+import { expect } from 'vitest'
+
+import { isUpdatedPhoto } from '~/utils/is-updated-photo'
+
+describe('isUpdatedPhoto', () => {
+  it('should return true if the photo has structure of UpdatedPhoto', () => {
+    const photo = { name: 'photo-name', src: 'photo-src' }
+
+    expect(isUpdatedPhoto(photo)).toBe(true)
+  })
+
+  it('should return false if the photo is null', () => {
+    const photo = null
+
+    expect(isUpdatedPhoto(photo)).toBe(false)
+  })
+
+  it('should return false if the photo is a string', () => {
+    const photo = 'not-an-object'
+
+    expect(isUpdatedPhoto(photo)).toBe(false)
+  })
+
+  it('should return false if the photo does not have a name property', () => {
+    const photo = { src: 'photo-src' }
+
+    expect(isUpdatedPhoto(photo)).toBe(false)
+  })
+})


### PR DESCRIPTION
Fix:
The ‘Update’ button is disabled after refreshing the page:

https://github.com/user-attachments/assets/f6e4c93a-6754-4751-9f0e-bb7c3d55d2ac

The ‘Update’ button becomes active when there are new changes:
(all fields accurate work is demonstrated)

https://github.com/user-attachments/assets/116af3c0-644d-40a2-96b0-0c7b9c5259ac


Photo:
( Recordings are made before `Fixed changing a user photo in the header (#2812)` commit)
- The initial state and the current state of the photo are compared correctly.
- The ''expected by backend" data are sent to the server when the user removes the photo.

https://github.com/user-attachments/assets/612b7936-ccb8-40f3-b5ae-3a62574dcd07

https://github.com/user-attachments/assets/808ab86d-471a-453b-940b-cac2d9ad858e


VideoLink:

- The initial state and the current state of the videoLink are compared correctly.
- The videoLink type is represented accurately in the state.
- Only the videoLink associated with the current user role is sent to the server for updates.

https://github.com/user-attachments/assets/da887e97-4f89-4cef-949b-10fa40cfa201


Additional:

- Add fetching data from server before leaving the page to prevent showing not applied changes to user (For instance, avatar that was updated in redux state, but not updated on sever) [ As shown in the recording at 00:18 ](https://github.com/user-attachments/assets/3d8f4e5b-90a6-43de-9b32-385037685bcd)
- Extract separate utils, add tests for them

