### PR TITLE
fixed ConfirmDialog styles

### DIFF
--- a/src/components/confirm-dialog/ConfirmDialog.styles.ts
+++ b/src/components/confirm-dialog/ConfirmDialog.styles.ts
@@ -2,19 +2,24 @@ import { TypographyVariantEnum } from '~/types'
 
 export const styles = {
   root: {
-    minWidth: { xs: '280px', sm: '400px' }
+    minWidth: { xs: '280px', sm: '400px' },
+    maxWidth: '600px'
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    px: '16px'
   },
   icon: {
-    position: 'absolute',
     color: 'primary.600',
-    right: '32px',
-    top: '32px',
-    p: 0
+    p: 0,
+    mt: '20px',
+    alignSelf: 'start'
   },
   title: {
     color: 'primary.700',
     typography: TypographyVariantEnum.H5,
-    p: '26px 0px 20px 30px'
+    p: '20px 15px 15px 14px'
   },
   content: {
     color: 'primary.600',

--- a/src/components/confirm-dialog/ConfirmDialog.tsx
+++ b/src/components/confirm-dialog/ConfirmDialog.tsx
@@ -11,6 +11,7 @@ import AppButton from '~/components/app-button/AppButton'
 import { styles } from '~/components/confirm-dialog/ConfirmDialog.styles'
 
 import { ButtonVariantEnum } from '~/types'
+import { Box } from '@mui/material'
 
 interface ConfirmDialogProps {
   message: string
@@ -42,10 +43,12 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
       onClose={onDismiss}
       open={open}
     >
-      <Typography sx={styles.title}>{t(title)}</Typography>
-      <IconButton onClick={onDismiss} sx={styles.icon}>
-        <CloseIcon />
-      </IconButton>
+      <Box sx={styles.header}>
+        <Typography sx={styles.title}>{t(title)}</Typography>
+        <IconButton onClick={onDismiss} sx={styles.icon}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
       <DialogContent sx={styles.content}>
         <Typography>{t(message)}</Typography>
       </DialogContent>


### PR DESCRIPTION
before: 
<img width="473" alt="before" src="https://github.com/user-attachments/assets/340c6584-bdd7-4720-9855-c58c7e922968">

after:
<img width="531" alt="after" src="https://github.com/user-attachments/assets/417be15e-65c0-4fdf-842e-e4099c2a6815">


- [x] fixed ConfirmDialog styles