### PR TITLE
Changed file size for photos

### DIFF
--- a/src/containers/tutor-home-page/add-photo-step/constants.js
+++ b/src/containers/tutor-home-page/add-photo-step/constants.js
@@ -1,4 +1,4 @@
-export const MB = 1_000_000
+export const MB = 1_048_576
 
 export const validationData = {
   maxFileSize: 5 * MB,


### PR DESCRIPTION
Was Result:
The error confirmation message appeared on the 'Edit profile' page with the text : 'Size for one file cannot be more than 5 MB' if downloaded file with size around 4,78MB, for example. 

Actual Result: 
We can download even file size equal 5 MB.