### PR TITLE
create badge component 

### DIFF
--- a/src/design-system/components/badge/Badge.scss
+++ b/src/design-system/components/badge/Badge.scss
@@ -1,0 +1,20 @@
+@use '~scss/utilities' as *;
+
+@mixin badge-style($bg-color, $color) {
+  & > .MuiBadge-dot {
+    background-color: $bg-color;
+  }
+
+  & > .MuiBadge-standard {
+    background-color: $bg-color;
+    color: $color;
+  }
+}
+
+.#{$prefix}badge-error {
+  @include badge-style(var(--#{$prefix}red-500), var(--#{$prefix}neutral-50));
+}
+
+.#{$prefix}badge-success {
+  @include badge-style(var(--#{$prefix}green-600), var(--#{$prefix}neutral-50));
+}

--- a/src/design-system/components/badge/Badge.tsx
+++ b/src/design-system/components/badge/Badge.tsx
@@ -1,0 +1,39 @@
+import { Badge as MuiBadge, BadgeProps as MuiBadgeProps } from '@mui/material'
+import { FC } from 'react'
+
+type BadgeColor = 'primary' | 'success' | 'error'
+
+type SmallBadgeProps = {
+  variant: 'sm'
+  color?: BadgeColor
+  isVisible?: boolean
+}
+
+type LargeBadgeProps = {
+  variant: 'lg'
+  badgeContent: number
+  maxContent?: number
+  color?: BadgeColor
+  isVisible?: boolean
+}
+
+type BadgeProps = (LargeBadgeProps | SmallBadgeProps) &
+  Omit<MuiBadgeProps, 'variant'>
+
+const Badge: FC<BadgeProps> = ({ children, ...props }) => {
+  const displayBadge = (props.isVisible ?? true) ? props.badgeContent : 0
+  const badgeVariant = props.variant === 'sm' ? 'dot' : 'standard'
+  return (
+    <MuiBadge
+      badgeContent={displayBadge}
+      color={props.color}
+      max={props.variant === 'lg' ? (props.maxContent ?? 10) : undefined}
+      overlap='circular'
+      variant={badgeVariant}
+    >
+      {children}
+    </MuiBadge>
+  )
+}
+
+export default Badge

--- a/src/design-system/components/badge/Badge.tsx
+++ b/src/design-system/components/badge/Badge.tsx
@@ -26,20 +26,20 @@ const Badge: React.FC<BadgeProps> = ({
   color = 'primary',
   ...props
 }) => {
-  const displayBadge = isVisible ? props.badgeContent : 0
+  const badgeContent = isVisible ? props.badgeContent : 0
   const badgeVariant = props.variant === 'sm' ? 'dot' : 'standard'
-  const maxContentShown =
+  const maxContent =
     props.variant === 'lg' ? (props.maxContent ?? 10) : undefined
-  const maxShown =
+  const isZeroShown =
     props.variant === 'lg' ? (props.isZeroShown ?? false) : undefined
 
   return (
     <MuiBadge
-      badgeContent={displayBadge}
+      badgeContent={badgeContent}
       color={color}
-      max={maxContentShown}
+      max={maxContent}
       overlap='circular'
-      showZero={maxShown}
+      showZero={isZeroShown}
       variant={badgeVariant}
     >
       {children}

--- a/src/design-system/components/badge/Badge.tsx
+++ b/src/design-system/components/badge/Badge.tsx
@@ -1,4 +1,5 @@
 import { Badge as MuiBadge, BadgeProps as MuiBadgeProps } from '@mui/material'
+import './Badge.scss'
 
 type BadgeColor = 'primary' | 'success' | 'error'
 
@@ -36,6 +37,7 @@ const Badge: React.FC<BadgeProps> = ({
   return (
     <MuiBadge
       badgeContent={badgeContent}
+      className={`s2s-badge-${color}`}
       color={color}
       max={maxContent}
       overlap='circular'

--- a/src/design-system/components/badge/Badge.tsx
+++ b/src/design-system/components/badge/Badge.tsx
@@ -1,5 +1,4 @@
 import { Badge as MuiBadge, BadgeProps as MuiBadgeProps } from '@mui/material'
-import { FC } from 'react'
 
 type BadgeColor = 'primary' | 'success' | 'error'
 
@@ -15,23 +14,32 @@ type LargeBadgeProps = {
   maxContent?: number
   color?: BadgeColor
   isVisible?: boolean
-  showZero?: boolean
+  isZeroShown?: boolean
 }
 
 type BadgeProps = (LargeBadgeProps | SmallBadgeProps) &
   Omit<MuiBadgeProps, 'variant'>
 
-const Badge: FC<BadgeProps> = ({ children, ...props }) => {
-  const displayBadge = (props.isVisible ?? true) ? props.badgeContent : 0
+const Badge: React.FC<BadgeProps> = ({
+  children,
+  isVisible = true,
+  color = 'primary',
+  ...props
+}) => {
+  const displayBadge = isVisible ? props.badgeContent : 0
   const badgeVariant = props.variant === 'sm' ? 'dot' : 'standard'
+  const maxContentShown =
+    props.variant === 'lg' ? (props.maxContent ?? 10) : undefined
+  const maxShown =
+    props.variant === 'lg' ? (props.isZeroShown ?? false) : undefined
+
   return (
     <MuiBadge
       badgeContent={displayBadge}
-      color={props.color ?? 'primary'}
-      data-testid='badge'
-      max={props.variant === 'lg' ? (props.maxContent ?? 10) : undefined}
+      color={color}
+      max={maxContentShown}
       overlap='circular'
-      showZero={props.showZero}
+      showZero={maxShown}
       variant={badgeVariant}
     >
       {children}

--- a/src/design-system/components/badge/Badge.tsx
+++ b/src/design-system/components/badge/Badge.tsx
@@ -27,7 +27,7 @@ const Badge: React.FC<BadgeProps> = ({
   ...props
 }) => {
   const badgeContent = isVisible ? props.badgeContent : 0
-  const badgeVariant = props.variant === 'sm' ? 'dot' : 'standard'
+  const variant = props.variant === 'sm' ? 'dot' : 'standard'
   const maxContent =
     props.variant === 'lg' ? (props.maxContent ?? 10) : undefined
   const isZeroShown =
@@ -40,7 +40,7 @@ const Badge: React.FC<BadgeProps> = ({
       max={maxContent}
       overlap='circular'
       showZero={isZeroShown}
-      variant={badgeVariant}
+      variant={variant}
     >
       {children}
     </MuiBadge>

--- a/src/design-system/components/badge/Badge.tsx
+++ b/src/design-system/components/badge/Badge.tsx
@@ -15,6 +15,7 @@ type LargeBadgeProps = {
   maxContent?: number
   color?: BadgeColor
   isVisible?: boolean
+  showZero?: boolean
 }
 
 type BadgeProps = (LargeBadgeProps | SmallBadgeProps) &
@@ -26,9 +27,11 @@ const Badge: FC<BadgeProps> = ({ children, ...props }) => {
   return (
     <MuiBadge
       badgeContent={displayBadge}
-      color={props.color}
+      color={props.color ?? 'primary'}
+      data-testid='badge'
       max={props.variant === 'lg' ? (props.maxContent ?? 10) : undefined}
       overlap='circular'
+      showZero={props.showZero}
       variant={badgeVariant}
     >
       {children}

--- a/src/design-system/stories/Badge.stories.tsx
+++ b/src/design-system/stories/Badge.stories.tsx
@@ -39,12 +39,14 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
       description:
         'Defines the color of the badge, affecting its visual style. Can be used to align the badge with your application`s theme.',
       control: { type: 'radio' },
-      options: ['primary', 'success', 'error']
+      options: ['primary', 'success', 'error'],
+      defaultValue: 'primary'
     },
     badgeContent: {
       description:
         'The content to be displayed inside the badge. Typically used for numeric values or short text. If the variant is set to "sm," this prop is ignored.',
-      control: { type: 'number' }
+      control: { type: 'number' },
+      defaultValue: 4
     },
     maxContent: {
       description:
@@ -52,52 +54,37 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
       control: { type: 'number' },
       defaultValue: 10
     },
+    showZero: {
+      description:
+        'determines whether the badge displays a `0` when the `variant` is set to `lg` and `badgeContent` is `0`',
+      control: { type: 'boolean' },
+      defaultValue: false
+    },
+    isVisible: {
+      description:
+        'Determines whether the badge is visible. Set this to `false` to hide the badge, regardless of its content.',
+      control: { type: 'boolean' },
+      defaultValue: true
+    },
     children: {
       description:
         'The element to be wrapped by the badge. This is typically an icon, button, or other visual element.',
       control: { type: 'text' }
     }
+  },
+  args: {
+    variant: 'lg',
+    color: 'primary',
+    badgeContent: 7,
+    maxContent: 10,
+    showZero: false,
+    isVisible: true
   }
 }
 
 export default meta
 
 type Story = StoryObj<typeof Badge>
-
-export const Default: Story = {
-  args: {
-    variant: 'sm',
-    color: 'primary',
-    isVisible: true,
-    children: (
-      <IconButton>
-        <NotificationsRoundedIcon color='info' />
-      </IconButton>
-    )
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The default configuration of the badge with a primary color, `sm` size displaying as small dot, and visibility enabled'
-      }
-    }
-  }
-}
-
-export const SmallSuccessBadge: Story = {
-  args: {
-    ...Default.args,
-    color: 'success'
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: 'A small badge with success color'
-      }
-    }
-  }
-}
 
 export const FullBadge: Story = {
   args: {
@@ -117,6 +104,55 @@ export const FullBadge: Story = {
       description: {
         story:
           'A large badge (`lg` variant) with numeric content and a maximum display value of 10.'
+      }
+    }
+  }
+}
+
+export const SmallBadge: Story = {
+  args: {
+    variant: 'sm',
+    color: 'primary',
+    isVisible: true,
+    children: (
+      <IconButton>
+        <NotificationsRoundedIcon color='info' />
+      </IconButton>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Simple configuration of the badge with a primary color, `sm` size displaying as small dot, and visibility enabled'
+      }
+    }
+  }
+}
+
+export const SmallSuccessBadge: Story = {
+  args: {
+    ...SmallBadge.args,
+    color: 'success'
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A small badge with success color'
+      }
+    }
+  }
+}
+
+export const SmallErrorBadge: Story = {
+  args: {
+    ...SmallBadge.args,
+    color: 'error'
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A small badge with error color'
       }
     }
   }

--- a/src/design-system/stories/Badge.stories.tsx
+++ b/src/design-system/stories/Badge.stories.tsx
@@ -17,7 +17,7 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
 
 - **Variants:** 
   - \`sm\`: Displays the badge as a small dot (ideal for simple status indicators).
-  - \`lg\`: Displays the badge with a numeric or textual value.
+  - \`lg\`: Displays the badge with a numeric value.
 - **Visibility Control:** Use the \`isVisible\` prop to toggle the visibility of the badge dynamically. When set to \`false\`, the badge content is hidden.
 - **Content Customization:** 
   - \`badgeContent\`: Render a numeric value or any textual content.

--- a/src/design-system/stories/Badge.stories.tsx
+++ b/src/design-system/stories/Badge.stories.tsx
@@ -54,7 +54,7 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
       control: { type: 'number' },
       defaultValue: 10
     },
-    showZero: {
+    isZeroShown: {
       description:
         'determines whether the badge displays a `0` when the `variant` is set to `lg` and `badgeContent` is `0`',
       control: { type: 'boolean' },
@@ -77,7 +77,7 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
     color: 'primary',
     badgeContent: 7,
     maxContent: 10,
-    showZero: false,
+    isZeroShown: false,
     isVisible: true
   }
 }

--- a/src/design-system/stories/Badge.stories.tsx
+++ b/src/design-system/stories/Badge.stories.tsx
@@ -31,7 +31,7 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
   argTypes: {
     variant: {
       description:
-        'Specifies the style of the badge. `sm` displays the badge as a small dot for status indicators, while `lg` displays a numeric or textual value.',
+        'Specifies the style of the badge. `sm` displays the badge as a small dot for status indicators, while `lg` displays a numeric value.',
       control: { type: 'radio' },
       options: ['sm', 'lg']
     },
@@ -44,7 +44,7 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
     },
     badgeContent: {
       description:
-        'The content to be displayed inside the badge. Typically used for numeric values or short text. If the variant is set to "sm," this prop is ignored.',
+        'The content to be displayed inside the badge. If the variant is set to "sm," this prop is ignored.',
       control: { type: 'number' },
       defaultValue: 4
     },

--- a/src/design-system/stories/Badge.stories.tsx
+++ b/src/design-system/stories/Badge.stories.tsx
@@ -1,0 +1,157 @@
+import { IconButton } from '@mui/material'
+import type { Meta, StoryObj } from '@storybook/react'
+import Badge from '~scss-components/badge/Badge'
+import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded'
+
+const meta: Meta<typeof Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The \`Badge\` component is a versatile and reusable component designed to enhance your application's UI by displaying notifications, counts, or statuses. Built on top of Material-UI's Badge, this custom implementation ensures consistency with your design system while adding additional customization options.
+
+#### Key Features:
+
+- **Variants:** 
+  - \`sm\`: Displays the badge as a small dot (ideal for simple status indicators).
+  - \`lg\`: Displays the badge with a numeric or textual value.
+- **Visibility Control:** Use the \`isVisible\` prop to toggle the visibility of the badge dynamically. When set to \`false\`, the badge content is hidden.
+- **Content Customization:** 
+  - \`badgeContent\`: Render a numeric value or any textual content.
+  - \`maxContent\`: Specify the maximum value to display. If badgeContent exceeds this value, it displays \`maxContent+\`.
+- **Color Options:** Supports predefined color options: \`primary\`, \`success\`, and \`error\`, aligning with the design system.
+- **Children Support:** Seamlessly wrap any element (e.g., icons, text, buttons) with the badge, making it highly adaptable to your application's requirements.
+`
+      }
+    }
+  },
+  argTypes: {
+    variant: {
+      description:
+        'Specifies the style of the badge. `sm` displays the badge as a small dot for status indicators, while `lg` displays a numeric or textual value.',
+      control: { type: 'radio' },
+      options: ['sm', 'lg']
+    },
+    color: {
+      description:
+        'Defines the color of the badge, affecting its visual style. Can be used to align the badge with your application`s theme.',
+      control: { type: 'radio' },
+      options: ['primary', 'success', 'error']
+    },
+    badgeContent: {
+      description:
+        'The content to be displayed inside the badge. Typically used for numeric values or short text. If the variant is set to "sm," this prop is ignored.',
+      control: { type: 'number' }
+    },
+    maxContent: {
+      description:
+        'Controls the visibility of the badge. When set to `false`, the badge content is hidden.',
+      control: { type: 'number' },
+      defaultValue: 10
+    },
+    children: {
+      description:
+        'The element to be wrapped by the badge. This is typically an icon, button, or other visual element.',
+      control: { type: 'text' }
+    }
+  }
+}
+
+export default meta
+
+type Story = StoryObj<typeof Badge>
+
+export const Default: Story = {
+  args: {
+    variant: 'sm',
+    color: 'primary',
+    isVisible: true,
+    children: (
+      <IconButton>
+        <NotificationsRoundedIcon color='info' />
+      </IconButton>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default configuration of the badge with a primary color, `sm` size displaying as small dot, and visibility enabled'
+      }
+    }
+  }
+}
+
+export const SmallSuccessBadge: Story = {
+  args: {
+    ...Default.args,
+    color: 'success'
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A small badge with success color'
+      }
+    }
+  }
+}
+
+export const FullBadge: Story = {
+  args: {
+    variant: 'lg',
+    color: 'primary',
+    isVisible: true,
+    badgeContent: 7,
+    maxContent: 10,
+    children: (
+      <IconButton>
+        <NotificationsRoundedIcon color='info' />
+      </IconButton>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A large badge (`lg` variant) with numeric content and a maximum display value of 10.'
+      }
+    }
+  }
+}
+
+export const SuccessFullBadge: Story = {
+  args: {
+    ...FullBadge.args,
+    color: 'success',
+    maxContent: 99,
+    badgeContent: 102
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A large badge (`lg` variant) with numeric content, success color, and a maximum display value of 99.'
+      }
+    }
+  }
+}
+
+export const ErrorFullBadge: Story = {
+  args: {
+    ...FullBadge.args,
+    color: 'error',
+    maxContent: 10,
+    badgeContent: 7
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A large badge (`lg` variant) with numeric content, error color, and a content of 7.'
+      }
+    }
+  }
+}

--- a/src/design-system/stories/Badge.stories.tsx
+++ b/src/design-system/stories/Badge.stories.tsx
@@ -20,7 +20,7 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
   - \`lg\`: Displays the badge with a numeric value.
 - **Visibility Control:** Use the \`isVisible\` prop to toggle the visibility of the badge dynamically. When set to \`false\`, the badge content is hidden.
 - **Content Customization:** 
-  - \`badgeContent\`: Render a numeric value or any textual content.
+  - \`badgeContent\`: Render a numeric content.
   - \`maxContent\`: Specify the maximum value to display. If badgeContent exceeds this value, it displays \`maxContent+\`.
 - **Color Options:** Supports predefined color options: \`primary\`, \`success\`, and \`error\`, aligning with the design system.
 - **Children Support:** Seamlessly wrap any element (e.g., icons, text, buttons) with the badge, making it highly adaptable to your application's requirements.

--- a/tests/unit/design-system/components/Badge/Badge.spec.jsx
+++ b/tests/unit/design-system/components/Badge/Badge.spec.jsx
@@ -4,7 +4,7 @@ import { screen, render } from '@testing-library/react'
 import Badge from '~scss-components/badge/Badge'
 
 describe('Badge Component', () => {
-  test('renders with "dot" variant when "sm" is passed', () => {
+  it('it should be rendered with "dot" variant when "sm" is passed', () => {
     render(
       <Badge variant='sm'>
         <IconButton>
@@ -20,7 +20,7 @@ describe('Badge Component', () => {
     expect(dotBadge).toBeInTheDocument()
   })
 
-  it('renders with correct badge content when "lg" is passed', () => {
+  it('it should be rendered with correct badge content when "lg" is passed', () => {
     render(
       <Badge variant='lg' badgeContent={5}>
         <IconButton>
@@ -33,7 +33,7 @@ describe('Badge Component', () => {
     expect(badgeContent).toBeInTheDocument
   })
 
-  it('hides badge content when "isVisible" is false', () => {
+  it('badge content should be hidden when "isVisible" is false', () => {
     render(
       <Badge variant='lg' badgeContent={5} isVisible={false}>
         <IconButton>

--- a/tests/unit/design-system/components/Badge/Badge.spec.jsx
+++ b/tests/unit/design-system/components/Badge/Badge.spec.jsx
@@ -1,0 +1,48 @@
+import { NotificationsActiveRounded } from '@mui/icons-material'
+import { IconButton } from '@mui/material'
+import { screen, render } from '@testing-library/react'
+import Badge from '~scss-components/badge/Badge'
+
+describe('Badge Component', () => {
+  test('renders with "dot" variant when "sm" is passed', () => {
+    render(
+      <Badge variant='sm'>
+        <IconButton>
+          <NotificationsActiveRounded />
+        </IconButton>
+      </Badge>
+    )
+
+    const dotBadge = screen.getByText('', {
+      selector: '.MuiBadge-dot'
+    })
+
+    expect(dotBadge).toBeInTheDocument()
+  })
+
+  it('renders with correct badge content when "lg" is passed', () => {
+    render(
+      <Badge variant='lg' badgeContent={5}>
+        <IconButton>
+          <NotificationsActiveRounded />
+        </IconButton>
+      </Badge>
+    )
+
+    const badgeContent = screen.getByText('5')
+    expect(badgeContent).toBeInTheDocument
+  })
+
+  it('hides badge content when "isVisible" is false', () => {
+    render(
+      <Badge variant='lg' badgeContent={5} isVisible={false}>
+        <IconButton>
+          <NotificationsActiveRounded />
+        </IconButton>
+      </Badge>
+    )
+
+    const badgeContent = screen.queryByText('5')
+    expect(badgeContent).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Created Badge component #2861

**Props:**

- `variant`: Determines the badge style (`sm` or `lg`).
- `color`: Supports `primary`, `success`, and `error` colors (default: `primary`).
- `isVisible`: Controls visibility of the badge (default: `true`).
- `badgeContent`: Numeric or textual content (applies to `lg `variant).
- `maxContent`: Specifies the maximum number to display, e.g., 99+ (default: `10`).
- `isZeroShown`: Toggles visibility of 0 content for the `lg` variant (default:`false`).

**Examples:**
- variant ='`lg`'
- badgeContent='`7`'
- rest props by default
<img width="59" alt="Screenshot 2024-12-01 at 23 05 40" src="https://github.com/user-attachments/assets/ba845327-c7d9-47c7-83f7-359b8d62aa49">

--------------------

- variant = '`sm`'
<img width="48" alt="Screenshot 2024-12-01 at 23 05 48" src="https://github.com/user-attachments/assets/30246eab-36fa-4673-aadb-2603f49f9baf">

--------------------

- color = '`success`'
<img width="51" alt="Screenshot 2024-12-01 at 23 05 52" src="https://github.com/user-attachments/assets/a71ae579-97ef-4490-ba6e-cf0699f3a4e8">

--------------------

- color='`error`'
<img width="49" alt="Screenshot 2024-12-01 at 23 06 04" src="https://github.com/user-attachments/assets/6d21210c-3881-4ff8-bce6-1f7af9b7041e">

--------------------

- variant ='`lg`'
- color ='`success`'
- maxContent ='`99`'
<img width="74" alt="Screenshot 2024-12-01 at 23 06 20" src="https://github.com/user-attachments/assets/044a24c7-3b88-40a7-9d75-747b6f3579c4">

--------------------

- variant ='`lg`'
- badgeContent='`7`'
- color = '`error`'
<img width="53" alt="Screenshot 2024-12-01 at 23 06 24" src="https://github.com/user-attachments/assets/86c69d86-6528-45b4-959a-a21912cb8f39">

--------------------

- variant ='`lg`'
- badgeContent='`0`'
- isZeroShown
<img width="66" alt="Screenshot 2024-12-01 at 23 06 39" src="https://github.com/user-attachments/assets/d808ee1f-8315-4f95-a9b5-6f1e2f3a13d5">

--------------------


- [x] Implemented Badge component.
- [x] Added prop types and default values.
- [x] Integrated component into Storybook with examples.
- [x] Verified rendering and behavior through unit tests.