### PR TITLE
Fixed duplicate chat creation bug

### DIFF
--- a/src/containers/offer-page/chat-dialog-window/ChatDialogWindow.tsx
+++ b/src/containers/offer-page/chat-dialog-window/ChatDialogWindow.tsx
@@ -157,7 +157,7 @@ const ChatDialogWindow: FC<ChatDialogWindow> = ({ chatInfo }) => {
   }
 
   const handleRedirectToChat = async () => {
-    if (!chatInfo.chatId) {
+    if (!chatInfo.chatId && !chatInfo.author._id) {
       setIsRedirected(true)
       await createNewChat()
     } else {


### PR DESCRIPTION
Fixed duplicate chat creation on second "chat button" click in mini-chat:
![image](https://github.com/user-attachments/assets/d84e2ce0-fb03-4353-b616-dab5b65c9ae9)


1) Go to my-coopeartions/{id}
2) Go to Details tab
3) Click on chat button
![image](https://github.com/user-attachments/assets/0ba1f8a1-d5a8-4065-99e6-7eadb761ee8a)
4) Mini-chat must be opened. Click "chat button" for the first time 
![image](https://github.com/user-attachments/assets/d84e2ce0-fb03-4353-b616-dab5b65c9ae9)
5) Click that button one more time
6) Before you would get the error on this step, but now the bug is fixed
