### PR TITLE
Verified ability to save a 'Last name' containing allowed special characters

### DIFF
--- a/tests/unit/containers/edit-profile/ProfileTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/ProfileTab.spec.jsx
@@ -27,6 +27,13 @@ vi.mock(
           required
           value={data.firstName}
         />
+        <input
+          onBlur={handleBlur('lastName')}
+          onChange={handleInputChange('lastName')}
+          placeholder={'lastName'}
+          required
+          value={data.lastName}
+        />
       </div>
     )
   })
@@ -155,4 +162,18 @@ describe('ProfileTab', () => {
     expect(firstNameInput).toBeInTheDocument()
     expect(firstNameInput).toHaveFocus()
   })
+
+  it('should place cursor in the "Last name" field when clicked', async () => {
+    renderWithMockData();
+  
+    const lastNameInput = screen.getByPlaceholderText('lastName');
+    expect(lastNameInput).toBeInTheDocument();
+    expect(document.activeElement).not.toBe(lastNameInput);
+  
+    await userEvent.click(lastNameInput);
+  
+    expect(document.activeElement).toBe(lastNameInput);
+    expect(lastNameInput).toHaveFocus()
+  });
+  
 })

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -73,10 +73,12 @@ const userMock = {
 
 const mockData = {
   firstName: '',
+  lastName: '',
   photo: null,
   videoLink: '',
   errors: {
     firstName: '',
+    lastName: '',
     videoLink: '',
   },
 };
@@ -468,6 +470,41 @@ describe('EditProfile', () => {
 
     for (const data of testData) {
       fireEvent.change(firstNameInput, { target: { value: data } });
+
+      const updateButton = screen.getByText('editProfilePage.updateBtn')
+      expect(updateButton).not.toBeDisabled();
+    }
+  });
+
+  it('should replace the existing text in the "Last name" field with test data and Update button becomes anable and active', () => {
+    const testData = ["Mc'Neil", "O'Neill-Johnson", "Van Gogh"];
+
+    const mockT = vi.fn((key) => {
+      const translations = {
+        'common.labels.lastName': 'Last Name',
+        'editProfilePage.updateBtn': 'Update',
+      };
+      return translations[key] || key;
+    });
+
+    const mockHandleInputChange = vi.fn();
+
+    render(
+      <ProfileTabForm
+        t={mockT}
+        data={mockData}
+        errors={mockData.errors}
+        handleInputChange={mockHandleInputChange}
+        handleBlur={() => {}}
+        openAlert={() => {}}
+      />
+    );
+
+    const lastNameInput = screen.getByLabelText(/common.labels.lastName/i)
+    expect(lastNameInput).toBeInTheDocument();
+
+    for (const data of testData) {
+      fireEvent.change(lastNameInput, { target: { value: data } });
 
       const updateButton = screen.getByText('editProfilePage.updateBtn')
       expect(updateButton).not.toBeDisabled();

--- a/tests/unit/utils/common.spec.jsx
+++ b/tests/unit/utils/common.spec.jsx
@@ -20,10 +20,13 @@ const mockedValues = {
   longText: 'wwwwwwwwwwwwwwwwwwwwwwwwwwwwwww',
   emptyField: '',
   spaceField: '    ',
-  nameWithApostropheEn: "O'braian",
-  nameWithApostropheUa: "Мар'яна",
-  nameWithHyphen: "Анна-Марія",
-  nameWithSpace: "Анна Марія",
+  firstNameWithApostropheEn: "O'braian",
+  firstNameWithApostropheUa: "Мар'яна",
+  firstNameWithHyphen: "Анна-Марія",
+  firstNameWithSpace: "Анна Марія",
+  lastNameWithApostrophe: "Mc'Neil",
+  lastNameWithApostropheAndHyphen: "O'Neill-Johnson",
+  lastNameWithSpace: "Van Gogh",
 }
 
 const errorMessages = {
@@ -51,23 +54,38 @@ export const passwordField = (value) => {
 }
 
 describe('commonValidation', () => {
-  it('Should accept name in English with apostrophe', () => {
-    const result = nameField(mockedValues.nameWithApostropheEn)
+  it('Should accept firstName in English with apostrophe', () => {
+    const result = nameField(mockedValues.firstNameWithApostropheEn)
     expect(result).not.toBe(errorMessages.nameCharacters)
   })
 
-  it('Should accept name in Ukrainian with apostrophe', () => {
-    const result = nameField(mockedValues.nameWithApostropheUa)
+  it('Should accept firstName in Ukrainian with apostrophe', () => {
+    const result = nameField(mockedValues.firstNameWithApostropheUa)
     expect(result).not.toBe(errorMessages.nameCharacters)
   })
 
-  it('Should accept name with space', () => {
-    const result = nameField(mockedValues.nameWithSpace)
+  it('Should accept firstName with space', () => {
+    const result = nameField(mockedValues.firstNameWithSpace)
     expect(result).not.toBe(errorMessages.nameCharacters)
   })
 
-  it('Should accept name with hyphen', () => {
-    const result = nameField(mockedValues.nameWithHyphen)
+  it('Should accept firstName with hyphen', () => {
+    const result = nameField(mockedValues.firstNameWithHyphen)
+    expect(result).not.toBe(errorMessages.nameCharacters)
+  })
+
+  it('Should accept lastName with apostrophe', () => {
+    const result = nameField(mockedValues.lastNameWithApostrophe)
+    expect(result).not.toBe(errorMessages.nameCharacters)
+  })
+
+  it('Should accept lastName with apostrophe and hyphen', () => {
+    const result = nameField(mockedValues.lastNameWithApostropheAndHyphen)
+    expect(result).not.toBe(errorMessages.nameCharacters)
+  })
+
+  it('Should accept lastName with space', () => {
+    const result = nameField(mockedValues.lastNameWithSpace)
     expect(result).not.toBe(errorMessages.nameCharacters)
   })
 


### PR DESCRIPTION
Issue #2875 

1. Checked when student/tutor clicked, the cursor is placed in the "Last Name" field. (ProfileTab.spec.jsx)

2. Checking that the name from the specified testData list is replaced and after that the Update button becomes anable and active.
(EditProfile.spec.jsx & common.spec.jsx)

3. Check after a successful update, a green notification appears with the text: 'Success! Your data has been updated.' already exists (EditProfile.spec.jsx)

4. Validation of names with an apostrophe, hyphen, or space. (common.spec.jsx)