### PR TITLE
The user can not save the information on 'Edit Profile' page after clicking on the 'Home page'

### DIFF
--- a/src/constants/translations/en/edit-profile.json
+++ b/src/constants/translations/en/edit-profile.json
@@ -22,6 +22,14 @@
       "videoPresentationDesc": "Add the link to your presentational video. Your video needs to be public and uploaded to YouTube.",
       "errorTooltip": "There is a problem with your changes"
     },
+    "profileTab": {
+      "saveUnsavedChangesModal": {
+        "title": "You have unsaved changes",
+        "description": "Are you sure you want to leave this page without updating? All your recent changes will be discarded.",
+        "cancelBtn": "Leave",
+        "submitBtn": "Update"
+      }
+    },
     "professionalTab": {
       "tabTitle": "Professional info",
       "mainTitle": "Professional information",

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -111,9 +111,9 @@ const EditProfile = () => {
     [changedFields]
   )
 
-  const getProfileTabChangedFields = useMemo<Partial<EditProfileState>>(() => {
+  const getProfileTabChangedFields = useMemo<boolean>(() => {
     if (!initialEditProfileState || !profileState) {
-      return {}
+      return false
     }
 
     const initialProfileTab = {
@@ -138,13 +138,13 @@ const EditProfile = () => {
       videoLink: profileState.videoLink
     }
 
-    return getChangedFields(initialProfileTab, changedProfileTab)
-  }, [initialEditProfileState, profileState])
+    const hasFieldsChanged = getChangedFields(
+      initialProfileTab,
+      changedProfileTab
+    )
 
-  const isProfileTabChanged = useMemo<boolean>(
-    () => Object.keys(getProfileTabChangedFields).length > 0,
-    [getProfileTabChangedFields]
-  )
+    return Object.keys(hasFieldsChanged).length > 0
+  }, [initialEditProfileState, profileState])
 
   const handleClick = async (tab: UserProfileTabsEnum) => {
     if (activeTab === tab) return
@@ -225,7 +225,7 @@ const EditProfile = () => {
     }
   }, [profileState, changedFields, dispatch, userId, hash, userRole, navigate])
 
-  const blocker = useBlocker(isProfileTabChanged)
+  const blocker = useBlocker(getProfileTabChangedFields)
   const { openDialog } = useConfirm()
 
   const openAffirmativeModal = useCallback(

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Link,
+  useBlocker,
   useLocation,
   useNavigate,
   useSearchParams
@@ -95,6 +96,63 @@ const EditProfile = () => {
     }
   }, [loading, profileState, initialEditProfileState])
 
+  const changedProfileFields = useMemo<Partial<EditProfileState>>(() => {
+    if (!initialEditProfileState || !profileState) return {}
+
+    const changedInitial = {
+      firstName: initialEditProfileState.firstName,
+      lastName: initialEditProfileState.lastName,
+      photo: initialEditProfileState.photo,
+      city: initialEditProfileState.city,
+      country: initialEditProfileState.country,
+      nativeLanguage: initialEditProfileState.nativeLanguage,
+      professionalSummary: initialEditProfileState.professionalSummary,
+      videoLink: initialEditProfileState.videoLink
+    }
+
+    const changedCurrent = {
+      firstName: profileState.firstName,
+      lastName: profileState.lastName,
+      photo: profileState.photo,
+      city: profileState.city,
+      country: profileState.country,
+      nativeLanguage: profileState.nativeLanguage,
+      professionalSummary: profileState.professionalSummary,
+      videoLink: profileState.videoLink
+    }
+
+    const hasPhotoChanged = hasPhotoChanges(
+      changedInitial.photo,
+      changedCurrent.photo
+    )
+
+    const hasChanged =
+      hasChanges(changedInitial, changedCurrent) || hasPhotoChanged
+
+    if (hasChanged) {
+      const changes: Partial<EditProfileState> = {
+        ...changedCurrent
+      }
+
+      if (!hasChanges(changedInitial.videoLink, changedCurrent.videoLink)) {
+        delete changes.videoLink
+      }
+
+      if (hasPhotoChanged) {
+        changes.photo = changedCurrent.photo
+      }
+
+      return changes
+    } else {
+      return {}
+    }
+  }, [profileState, initialEditProfileState])
+
+  const isProfileChanged = useMemo<boolean>(
+    () => Object.keys(changedProfileFields).length > 0,
+    [changedProfileFields]
+  )
+
   const changedFields = useMemo<Partial<EditProfileState>>(() => {
     if (!profileState || !initialEditProfileState) {
       return {}
@@ -121,10 +179,10 @@ const EditProfile = () => {
     }
   }
 
-  const { hash } = useLocation()
+  const { hash, search, pathname } = useLocation()
   const navigate = useNavigate()
 
-  const handleUpdateUser = async (): Promise<void> => {
+  const handleUpdateUser = useCallback(async (): Promise<void> => {
     const { country, city } = profileState
     const {
       videoLink,
@@ -184,7 +242,41 @@ const EditProfile = () => {
     if (hash) {
       navigate(`${authRoutes.myProfile.path}#complete`)
     }
-  }
+  }, [profileState, changedFields])
+
+  const blocker = useBlocker(isProfileChanged)
+  const { openDialog } = useConfirm()
+
+  useEffect(() => {
+    if (blocker && blocker.location) {
+      const hasPathnameChanged = pathname !== blocker.location.pathname
+      const hasSearchChanged = search !== blocker.location.search
+
+      if (hasSearchChanged && !hasPathnameChanged) {
+        blocker.proceed?.()
+      }
+
+      if (hasPathnameChanged) {
+        openDialog({
+          title: t(
+            'editProfilePage.profile.profileTab.saveUnsavedChangesModal.title'
+          ),
+          message: t(
+            'editProfilePage.profile.profileTab.saveUnsavedChangesModal.description'
+          ),
+          cancelButton: t(
+            'editProfilePage.profile.profileTab.saveUnsavedChangesModal.cancelBtn'
+          ),
+          confirmButton: t(
+            'editProfilePage.profile.profileTab.saveUnsavedChangesModal.submitBtn'
+          ),
+          sendConfirm: (isConfirmed) => {
+            isConfirmed ? void handleUpdateUser() : blocker.proceed?.()
+          }
+        })
+      }
+    }
+  }, [blocker, pathname, openDialog, search, t, handleUpdateUser])
 
   const cooperationContent = activeTab && tabsData[activeTab]?.content
 

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -112,7 +112,9 @@ const EditProfile = () => {
   )
 
   const getProfileTabChangedFields = useMemo<Partial<EditProfileState>>(() => {
-    if (!initialEditProfileState || !profileState) return {}
+    if (!initialEditProfileState || !profileState) {
+      return {}
+    }
 
     const initialProfileTab = {
       firstName: initialEditProfileState.firstName,
@@ -229,7 +231,7 @@ const EditProfile = () => {
   const openAffirmativeModal = useCallback(
     (hasPathnameChanged: boolean) => {
       if (hasPathnameChanged) {
-        return openDialog({
+        openDialog({
           title: t(
             'editProfilePage.profile.profileTab.saveUnsavedChangesModal.title'
           ),

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -96,10 +96,10 @@ const EditProfile = () => {
     }
   }, [loading, profileState, initialEditProfileState])
 
-  const changedProfileFields = useMemo<Partial<EditProfileState>>(() => {
-    if (!initialEditProfileState || !profileState) return {}
+  const changedProfileFields = useMemo<Partial<EditProfileState | null>>(() => {
+    if (!initialEditProfileState || !profileState) return null
 
-    const changedInitial = {
+    const initialProfileInformation = {
       firstName: initialEditProfileState.firstName,
       lastName: initialEditProfileState.lastName,
       photo: initialEditProfileState.photo,
@@ -110,7 +110,7 @@ const EditProfile = () => {
       videoLink: initialEditProfileState.videoLink
     }
 
-    const changedCurrent = {
+    const changedProfileInformation = {
       firstName: profileState.firstName,
       lastName: profileState.lastName,
       photo: profileState.photo,
@@ -121,42 +121,77 @@ const EditProfile = () => {
       videoLink: profileState.videoLink
     }
 
-    const hasPhotoChanged = hasPhotoChanges(
-      changedInitial.photo,
-      changedCurrent.photo
+    const isPhotoChanged = hasPhotoChanges(
+      initialProfileInformation.photo,
+      changedProfileInformation.photo
     )
 
-    const hasChanged =
-      hasChanges(changedInitial, changedCurrent) || hasPhotoChanged
+    const isProfileInformationChanged =
+      hasChanges(initialProfileInformation, changedProfileInformation) ||
+      isPhotoChanged
 
-    if (hasChanged) {
-      const changes: Partial<EditProfileState> = {
-        ...changedCurrent
-      }
-
-      if (!hasChanges(changedInitial.videoLink, changedCurrent.videoLink)) {
-        delete changes.videoLink
-      }
-
-      if (hasPhotoChanged) {
-        changes.photo = changedCurrent.photo
-      }
-
-      return changes
-    } else {
+    if (!isProfileInformationChanged) {
       return {}
     }
+
+    const changes: Partial<EditProfileState> = {
+      ...changedProfileInformation
+    }
+
+    if (
+      !hasChanges(
+        initialProfileInformation.videoLink,
+        changedProfileInformation.videoLink
+      )
+    ) {
+      delete changes.videoLink
+    }
+
+    if (isPhotoChanged) {
+      changes.photo = changedProfileInformation.photo
+    }
+
+    return changes
   }, [profileState, initialEditProfileState])
 
-  const isProfileChanged = useMemo<boolean>(
-    () => Object.keys(changedProfileFields).length > 0,
-    [changedProfileFields]
-  )
+  const isProfileChanged = Boolean(changedProfileFields)
 
   const changedFields = useMemo<Partial<EditProfileState>>(() => {
+<<<<<<< HEAD
     if (!profileState || !initialEditProfileState) {
       return {}
     }
+=======
+    if (!initialEditProfileState || !profileState) return {}
+    const { videoLink: initialVideoLink } = initialEditProfileState
+    const { videoLink: currentVideoLink } = profileState
+
+    const { photo: initialPhoto, ...initialData } = initialEditProfileState
+    const { photo: currentPhoto, ...currentData } = profileState
+
+    const isPhotoChanged = hasPhotoChanges(initialPhoto, currentPhoto)
+
+    const hasChanged = hasChanges(initialData, currentData) || isPhotoChanged
+
+    if (!hasChanged) {
+      return {}
+    }
+
+    const changes: Partial<EditProfileState> = {
+      ...currentData
+    }
+
+    if (!hasChanges(initialVideoLink, currentVideoLink)) {
+      delete changes.videoLink
+    }
+
+    if (isPhotoChanged) {
+      changes.photo = currentPhoto
+    }
+
+    return changes
+  }, [profileState, initialEditProfileState])
+>>>>>>> 1df70c09 (fixed comments)
 
     return getChangedFields(initialEditProfileState, profileState)
   }, [profileState, initialEditProfileState])
@@ -242,7 +277,7 @@ const EditProfile = () => {
     if (hash) {
       navigate(`${authRoutes.myProfile.path}#complete`)
     }
-  }, [profileState, changedFields])
+  }, [profileState, changedFields, dispatch, userId, hash, userRole, navigate])
 
   const blocker = useBlocker(isProfileChanged)
   const { openDialog } = useConfirm()

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -44,6 +44,8 @@ const EditProfile = () => {
     typeof profileState | null
   >(null)
 
+  const [isModalConfirmed, setIsModalConfirmed] = useState(false)
+
   const [searchParams, setSearchParams] = useSearchParams({
     tab: UserProfileTabsEnum.Profile
   })
@@ -96,10 +98,23 @@ const EditProfile = () => {
     }
   }, [loading, profileState, initialEditProfileState])
 
-  const changedProfileFields = useMemo<Partial<EditProfileState | null>>(() => {
-    if (!initialEditProfileState || !profileState) return null
+  const changedFields = useMemo<Partial<EditProfileState>>(() => {
+    if (!profileState || !initialEditProfileState) {
+      return {}
+    }
 
-    const initialProfileInformation = {
+    return getChangedFields(initialEditProfileState, profileState)
+  }, [profileState, initialEditProfileState])
+
+  const isChanged = useMemo<boolean>(
+    () => Object.keys(changedFields).length > 0,
+    [changedFields]
+  )
+
+  const getProfileTabChangedFields = useMemo<Partial<EditProfileState>>(() => {
+    if (!initialEditProfileState || !profileState) return {}
+
+    const initialProfileTab = {
       firstName: initialEditProfileState.firstName,
       lastName: initialEditProfileState.lastName,
       photo: initialEditProfileState.photo,
@@ -110,7 +125,7 @@ const EditProfile = () => {
       videoLink: initialEditProfileState.videoLink
     }
 
-    const changedProfileInformation = {
+    const changedProfileTab = {
       firstName: profileState.firstName,
       lastName: profileState.lastName,
       photo: profileState.photo,
@@ -121,83 +136,12 @@ const EditProfile = () => {
       videoLink: profileState.videoLink
     }
 
-    const isPhotoChanged = hasPhotoChanges(
-      initialProfileInformation.photo,
-      changedProfileInformation.photo
-    )
+    return getChangedFields(initialProfileTab, changedProfileTab)
+  }, [initialEditProfileState, profileState])
 
-    const isProfileInformationChanged =
-      hasChanges(initialProfileInformation, changedProfileInformation) ||
-      isPhotoChanged
-
-    if (!isProfileInformationChanged) {
-      return {}
-    }
-
-    const changes: Partial<EditProfileState> = {
-      ...changedProfileInformation
-    }
-
-    if (
-      !hasChanges(
-        initialProfileInformation.videoLink,
-        changedProfileInformation.videoLink
-      )
-    ) {
-      delete changes.videoLink
-    }
-
-    if (isPhotoChanged) {
-      changes.photo = changedProfileInformation.photo
-    }
-
-    return changes
-  }, [profileState, initialEditProfileState])
-
-  const isProfileChanged = Boolean(changedProfileFields)
-
-  const changedFields = useMemo<Partial<EditProfileState>>(() => {
-<<<<<<< HEAD
-    if (!profileState || !initialEditProfileState) {
-      return {}
-    }
-=======
-    if (!initialEditProfileState || !profileState) return {}
-    const { videoLink: initialVideoLink } = initialEditProfileState
-    const { videoLink: currentVideoLink } = profileState
-
-    const { photo: initialPhoto, ...initialData } = initialEditProfileState
-    const { photo: currentPhoto, ...currentData } = profileState
-
-    const isPhotoChanged = hasPhotoChanges(initialPhoto, currentPhoto)
-
-    const hasChanged = hasChanges(initialData, currentData) || isPhotoChanged
-
-    if (!hasChanged) {
-      return {}
-    }
-
-    const changes: Partial<EditProfileState> = {
-      ...currentData
-    }
-
-    if (!hasChanges(initialVideoLink, currentVideoLink)) {
-      delete changes.videoLink
-    }
-
-    if (isPhotoChanged) {
-      changes.photo = currentPhoto
-    }
-
-    return changes
-  }, [profileState, initialEditProfileState])
->>>>>>> 1df70c09 (fixed comments)
-
-    return getChangedFields(initialEditProfileState, profileState)
-  }, [profileState, initialEditProfileState])
-  const isChanged = useMemo<boolean>(
-    () => Object.keys(changedFields).length > 0,
-    [changedFields]
+  const isProfileTabChanged = useMemo<boolean>(
+    () => Object.keys(getProfileTabChangedFields).length > 0,
+    [getProfileTabChangedFields]
   )
 
   const handleClick = async (tab: UserProfileTabsEnum) => {
@@ -279,20 +223,13 @@ const EditProfile = () => {
     }
   }, [profileState, changedFields, dispatch, userId, hash, userRole, navigate])
 
-  const blocker = useBlocker(isProfileChanged)
+  const blocker = useBlocker(isProfileTabChanged)
   const { openDialog } = useConfirm()
 
-  useEffect(() => {
-    if (blocker && blocker.location) {
-      const hasPathnameChanged = pathname !== blocker.location.pathname
-      const hasSearchChanged = search !== blocker.location.search
-
-      if (hasSearchChanged && !hasPathnameChanged) {
-        blocker.proceed?.()
-      }
-
+  const openAffirmativeModal = useCallback(
+    (hasPathnameChanged: boolean) => {
       if (hasPathnameChanged) {
-        openDialog({
+        return openDialog({
           title: t(
             'editProfilePage.profile.profileTab.saveUnsavedChangesModal.title'
           ),
@@ -306,12 +243,40 @@ const EditProfile = () => {
             'editProfilePage.profile.profileTab.saveUnsavedChangesModal.submitBtn'
           ),
           sendConfirm: (isConfirmed) => {
-            isConfirmed ? void handleUpdateUser() : blocker.proceed?.()
+            if (isConfirmed) {
+              setIsModalConfirmed(true)
+              void handleUpdateUser()
+            } else {
+              blocker.proceed?.()
+            }
           }
         })
       }
+    },
+    [blocker, handleUpdateUser, openDialog, t]
+  )
+
+  useEffect(() => {
+    if (blocker && blocker.location && !isModalConfirmed) {
+      const hasPathnameChanged = pathname !== blocker.location.pathname
+      const hasSearchChanged = search !== blocker.location.search
+
+      if (hasSearchChanged && !hasPathnameChanged) {
+        blocker.proceed?.()
+      }
+
+      openAffirmativeModal(hasPathnameChanged)
     }
-  }, [blocker, pathname, openDialog, search, t, handleUpdateUser])
+  }, [
+    blocker,
+    pathname,
+    openDialog,
+    search,
+    t,
+    handleUpdateUser,
+    openAffirmativeModal,
+    isModalConfirmed
+  ])
 
   const cooperationContent = activeTab && tabsData[activeTab]?.content
 

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -82,17 +82,28 @@ const mockData = {
     videoLink: '',
   },
 };
+
+const mockOpenDialog = vi.fn();
+
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    useBlocker: vi.fn(),
+    useBlocker: vi.fn(() => ({
+      location: { pathname: '/another-page', search: '' },
+      proceed: vi.fn(),
+    })),
+    useNavigate: () => vi.fn()
   };
 });
 
 vi.mock('~/hooks/use-confirm', () => ({
-  default: () => ({ checkConfirmation: () => true })
-}))
+  default: () => ({
+    checkConfirmation: () => true,
+    openDialog: mockOpenDialog, 
+    setNeedConfirmation: vi.fn()
+  })
+}));
 
 vi.mock('~/redux/features/editProfileSlice', async () => {
   const actual = await vi.importActual('~/redux/features/editProfileSlice')
@@ -522,5 +533,45 @@ describe('EditProfile', () => {
       const updateButton = screen.getByText('editProfilePage.updateBtn')
       expect(updateButton).not.toBeDisabled()
     }
+  });
+
+  it('should show modal window if changes in profile tab are detected', () => {
+    const mockHandleInputChange = vi.fn();
+
+    useAppSelector.mockImplementation((selector) =>
+      selector({
+        ...mockState,
+        editProfile: {
+          ...mockState.editProfile,
+          profileState: { ...userMock },
+          loading: LoadingStatusEnum.Fulfilled
+        }
+      })
+    )
+
+    renderWithProviders(
+      <ProfileTabForm
+        data={mockData}
+        errors={mockData.errors}
+        handleBlur={() => {}}
+        handleInputChange={mockHandleInputChange}
+        openAlert={() => {}}
+      />
+    );
+
+    const firstNameInput = screen.getByLabelText(/common.labels.firstName/i)
+    expect(firstNameInput).toBeInTheDocument();
+
+    fireEvent.change(firstNameInput, { target: { value: 'Jack' } });
+
+    window.history.pushState({}, '', '/another-page')
+
+    expect(mockOpenDialog).toHaveBeenCalledWith({
+      message: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.description',
+      cancelButton: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.cancelBtn',
+      confirmButton: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.submitBtn',
+      sendConfirm: expect.any(Function),
+      title: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.title'
+    })
   })
-})
+});

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -79,31 +79,31 @@ const mockData = {
   errors: {
     firstName: '',
     lastName: '',
-    videoLink: '',
-  },
-};
+    videoLink: ''
+  }
+}
 
-const mockOpenDialog = vi.fn();
+const mockOpenDialog = vi.fn()
 
 vi.mock('react-router-dom', async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal()
   return {
     ...actual,
     useBlocker: vi.fn(() => ({
       location: { pathname: '/another-page', search: '' },
-      proceed: vi.fn(),
+      proceed: vi.fn()
     })),
     useNavigate: () => vi.fn()
-  };
-});
+  }
+})
 
 vi.mock('~/hooks/use-confirm', () => ({
   default: () => ({
     checkConfirmation: () => true,
-    openDialog: mockOpenDialog, 
+    openDialog: mockOpenDialog,
     setNeedConfirmation: vi.fn()
   })
-}));
+}))
 
 vi.mock('~/redux/features/editProfileSlice', async () => {
   const actual = await vi.importActual('~/redux/features/editProfileSlice')
@@ -533,10 +533,10 @@ describe('EditProfile', () => {
       const updateButton = screen.getByText('editProfilePage.updateBtn')
       expect(updateButton).not.toBeDisabled()
     }
-  });
+  })
 
   it('should show modal window if changes in profile tab are detected', () => {
-    const mockHandleInputChange = vi.fn();
+    const mockHandleInputChange = vi.fn()
 
     useAppSelector.mockImplementation((selector) =>
       selector({
@@ -557,21 +557,24 @@ describe('EditProfile', () => {
         handleInputChange={mockHandleInputChange}
         openAlert={() => {}}
       />
-    );
+    )
 
     const firstNameInput = screen.getByLabelText(/common.labels.firstName/i)
-    expect(firstNameInput).toBeInTheDocument();
+    expect(firstNameInput).toBeInTheDocument()
 
-    fireEvent.change(firstNameInput, { target: { value: 'Jack' } });
+    fireEvent.change(firstNameInput, { target: { value: 'Jack' } })
 
     window.history.pushState({}, '', '/another-page')
 
     expect(mockOpenDialog).toHaveBeenCalledWith({
-      message: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.description',
-      cancelButton: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.cancelBtn',
-      confirmButton: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.submitBtn',
+      message:
+        'editProfilePage.profile.profileTab.saveUnsavedChangesModal.description',
+      cancelButton:
+        'editProfilePage.profile.profileTab.saveUnsavedChangesModal.cancelBtn',
+      confirmButton:
+        'editProfilePage.profile.profileTab.saveUnsavedChangesModal.submitBtn',
       sendConfirm: expect.any(Function),
       title: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.title'
     })
   })
-});
+})

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -79,9 +79,16 @@ const mockData = {
   errors: {
     firstName: '',
     lastName: '',
-    videoLink: ''
-  }
-}
+    videoLink: '',
+  },
+};
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useBlocker: vi.fn(),
+  };
+});
 
 vi.mock('~/hooks/use-confirm', () => ({
   default: () => ({ checkConfirmation: () => true })


### PR DESCRIPTION
Was result:
If user has unsaved changes and redirected to another page, he could do this without any information about unsaved changes.

Actual result:
If user has unsaved changes and want to go to another page, modal window appears about unsaved changes with propose to update or leave without changes.

![image](https://github.com/user-attachments/assets/3aabe065-dd99-4085-bff6-87d72873dd52)

https://github.com/user-attachments/assets/9beb532b-b69d-4ccd-9619-843d3c6ba443






