### PR TITLE
Replaced Alert throughout the project

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { AlertColor } from '~/design-system/components/alert/Alert'
+import { type AlertColor } from '~/design-system/components/alert/Alert'
 
 export const s2s = 's2s'
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { AlertColor } from '@mui/material/Alert'
+import { AlertColor } from '~scss-components/alert/Alert'
 
 export const s2s = 's2s'
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-import { AlertColor } from '~scss-components/alert/Alert'
+import { AlertColor } from '~/design-system/components/alert/Alert'
 
 export const s2s = 's2s'
 

--- a/src/containers/layout/app-snackbar/AppSnackbar.styles.ts
+++ b/src/containers/layout/app-snackbar/AppSnackbar.styles.ts
@@ -1,13 +1,6 @@
 export const styles = {
-  alert: {
-    color: 'basic.white'
-  },
   action: {
     p: '4px 8px 0 30px',
     cursor: 'pointer'
-  },
-  secondMessage: {
-    fontSize: '12px',
-    fontWeight: '300'
   }
 }

--- a/src/containers/layout/app-snackbar/AppSnackbar.tsx
+++ b/src/containers/layout/app-snackbar/AppSnackbar.tsx
@@ -1,11 +1,14 @@
-import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
 import Snackbar from '@mui/material/Snackbar'
-import Alert from '@mui/material/Alert'
 import Box from '@mui/material/Box'
 
+import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 import { closeAlert, snackbarSelector } from '~/redux/features/snackbarSlice'
-import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
+
+import Alert from '~scss-components/alert/Alert'
+
 import { styles } from '~/containers/layout/app-snackbar/AppSnackbar.styles'
 
 const AppSnackbar = () => {

--- a/src/containers/layout/app-snackbar/AppSnackbar.tsx
+++ b/src/containers/layout/app-snackbar/AppSnackbar.tsx
@@ -7,7 +7,7 @@ import Box from '@mui/material/Box'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 import { closeAlert, snackbarSelector } from '~/redux/features/snackbarSlice'
 
-import Alert from '~scss-components/alert/Alert'
+import Alert from '~/design-system/components/alert/Alert'
 
 import { styles } from '~/containers/layout/app-snackbar/AppSnackbar.styles'
 
@@ -24,10 +24,6 @@ const AppSnackbar = () => {
   const translatedMessage =
     typeof message === 'string' ? t(message) : t(message.text, message.options)
 
-  const actionBody = translatedMessage
-    .split(', ')
-    .map((line) => <Box key={line}>{line}</Box>)
-
   const handleButtonClick = () => {
     navigate(route!)
     handleClose()
@@ -39,14 +35,9 @@ const AppSnackbar = () => {
     </Box>
   )
 
-  const [firstMessage, secondMessage] = translatedMessage.split(';')
-
-  const extendedBody = (
-    <>
-      <Box>{firstMessage}</Box>
-      <Box sx={styles.secondMessage}>{secondMessage}</Box>
-    </>
-  )
+  const [firstMessage, secondMessage] = isExtended
+    ? translatedMessage.split(';')
+    : translatedMessage.split(', ')
 
   return (
     <Snackbar
@@ -57,12 +48,11 @@ const AppSnackbar = () => {
     >
       <Alert
         action={isExtended && actionButton}
+        description={secondMessage}
         severity={severity}
-        sx={styles.alert}
+        title={firstMessage}
         variant='filled'
-      >
-        {isExtended ? extendedBody : actionBody}
-      </Alert>
+      />
     </Snackbar>
   )
 }

--- a/src/design-system/components/alert/Alert.scss
+++ b/src/design-system/components/alert/Alert.scss
@@ -118,4 +118,8 @@
     margin: 0 0.5rem;
     height: auto;
   }
+
+  & .s2s-alert-description {
+    margin: 0;
+  }
 }

--- a/src/design-system/components/alert/Alert.scss
+++ b/src/design-system/components/alert/Alert.scss
@@ -122,4 +122,10 @@
   & .s2s-alert-description {
     margin: 0;
   }
+
+  & .MuiAlert-action {
+    font-weight: $font-weight-medium;
+    font-size: $font-size-sm;
+    line-height: $line-height-sm;
+  }
 }

--- a/src/design-system/components/alert/Alert.tsx
+++ b/src/design-system/components/alert/Alert.tsx
@@ -74,9 +74,7 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
         {...props}
       >
         {title && <AlertTitle>{title}</AlertTitle>}
-        {description && (
-          <p className={cn('s2s-alert-description')}>{description}</p>
-        )}
+        {description && <p className='s2s-alert-description'>{description}</p>}
       </MuiAlert>
     )
   }

--- a/src/design-system/components/alert/Alert.tsx
+++ b/src/design-system/components/alert/Alert.tsx
@@ -54,10 +54,7 @@ interface AlertProps extends MuiAlertProps {
 }
 
 const Alert = forwardRef<HTMLDivElement, AlertProps>(
-  (
-    { title, label, description, children, icon, onClose, className, ...props },
-    ref
-  ) => {
+  ({ title, label, description, icon, onClose, className, ...props }, ref) => {
     const handleClose = (event: SyntheticEvent) => {
       if (onClose) {
         onClose(event)
@@ -77,8 +74,9 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
         {...props}
       >
         {title && <AlertTitle>{title}</AlertTitle>}
-        {description && <p>{description}</p>}
-        {children}
+        {description && (
+          <p className={cn('s2s-alert-description')}>{description}</p>
+        )}
       </MuiAlert>
     )
   }

--- a/src/design-system/components/alert/Alert.tsx
+++ b/src/design-system/components/alert/Alert.tsx
@@ -17,6 +17,8 @@ import { cn } from '~/utils/cn'
 
 import '~scss-components/alert/Alert.scss'
 
+export type AlertColor = 'success' | 'info' | 'warning' | 'error'
+
 export const AlertTitle = ({ children, ...props }: AlertTitleProps) => {
   return <MuiAlertTitle {...props}>{children}</MuiAlertTitle>
 }

--- a/src/design-system/stories/Alert.stories.tsx
+++ b/src/design-system/stories/Alert.stories.tsx
@@ -48,9 +48,6 @@ const meta: Meta<typeof Alert> = {
     icon: {
       description:
         'Override the icon displayed before the children. Unless provided, the icon is mapped to the value of the severity prop.'
-    },
-    children: {
-      description: 'The content of the alert.'
     }
   }
 }

--- a/src/redux/features/snackbarSlice.ts
+++ b/src/redux/features/snackbarSlice.ts
@@ -1,8 +1,9 @@
 import { createSlice, PayloadAction, Draft } from '@reduxjs/toolkit'
-import { AlertColor } from '@mui/material/Alert'
 import { sliceNames } from '~/redux/redux.constants'
 import { RootState } from '~/redux/store'
 import { TOptions } from 'i18next/typescript/options'
+
+import { AlertColor } from '~scss-components/alert/Alert'
 
 interface ExtendedSnackbarMessage {
   text: string

--- a/src/redux/features/snackbarSlice.ts
+++ b/src/redux/features/snackbarSlice.ts
@@ -3,7 +3,7 @@ import { sliceNames } from '~/redux/redux.constants'
 import { RootState } from '~/redux/store'
 import { TOptions } from 'i18next/typescript/options'
 
-import { AlertColor } from '~/design-system/components/alert/Alert'
+import { type AlertColor } from '~/design-system/components/alert/Alert'
 
 interface ExtendedSnackbarMessage {
   text: string

--- a/src/redux/features/snackbarSlice.ts
+++ b/src/redux/features/snackbarSlice.ts
@@ -3,7 +3,7 @@ import { sliceNames } from '~/redux/redux.constants'
 import { RootState } from '~/redux/store'
 import { TOptions } from 'i18next/typescript/options'
 
-import { AlertColor } from '~scss-components/alert/Alert'
+import { AlertColor } from '~/design-system/components/alert/Alert'
 
 interface ExtendedSnackbarMessage {
   text: string

--- a/tests/unit/design-system/components/Alert/Alert.spec.jsx
+++ b/tests/unit/design-system/components/Alert/Alert.spec.jsx
@@ -11,16 +11,6 @@ describe('Alert Component', () => {
     expect(screen.getByText('Test Description')).toBeInTheDocument()
   })
 
-  test('renders children content', () => {
-    render(
-      <Alert>
-        <span>Child Content</span>
-      </Alert>
-    )
-
-    expect(screen.getByText('Child Content')).toBeInTheDocument()
-  })
-
   test('renders the icon provided via the icon prop', () => {
     render(<Alert icon={<InfoOutlined data-testid='custom-icon' />} />)
 


### PR DESCRIPTION
Replaced Alert with the reusable component from a [design system]((https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=21761-14630&t=Jdf03mGz0apvrAKS-4)).
Also, I've changed the import order in related files to match our coding convention.

Before:
<img width="471" alt="Screenshot 2024-12-10 at 12 30 42" src="https://github.com/user-attachments/assets/6b8f03f6-327d-40bb-a5b8-c5eccd527f49">

After:
<img width="537" alt="Screenshot 2024-12-12 at 14 49 03" src="https://github.com/user-attachments/assets/f60197fe-11dd-450f-a036-7034fd4bacd0" />
