### PR TITLE
incorrect description of Badge maxContent prop in storybook

### DIFF
--- a/src/design-system/stories/Badge.stories.tsx
+++ b/src/design-system/stories/Badge.stories.tsx
@@ -50,7 +50,7 @@ The \`Badge\` component is a versatile and reusable component designed to enhanc
     },
     maxContent: {
       description:
-        'Controls the visibility of the badge. When set to `false`, the badge content is hidden.',
+        'Specifies the maximum value displayed by the badge. When set to `0`, the badge content is hidden.',
       control: { type: 'number' },
       defaultValue: 10
     },


### PR DESCRIPTION
#2938 
before
<img width="729" alt="Screenshot 2024-12-11 at 20 25 20" src="https://github.com/user-attachments/assets/29180c0e-f007-415b-86fd-576a04c5f42d" />

after
<img width="587" alt="Screenshot 2024-12-11 at 20 24 47" src="https://github.com/user-attachments/assets/04fbb7be-365a-460a-a634-7dbde46117b7" />

- [x] fixed incorrect description of Badge maxContent prop in storybook