### PR TITLE
 [Edit Tutor's Profile Password & Security]: Added error alert if current password is incorrect

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -15,8 +15,7 @@ export const URLs = {
     confirm: '/auth/confirm-email',
     forgotPassword: '/auth/forgot-password',
     resetPassword: '/auth/reset-password',
-    changePassword: '/auth/change-password',
-    validatePassword: '/auth/validate-password'
+    changePassword: '/auth/change-password'
   },
   users: {
     get: '/users',

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -15,7 +15,8 @@ export const URLs = {
     confirm: '/auth/confirm-email',
     forgotPassword: '/auth/forgot-password',
     resetPassword: '/auth/reset-password',
-    changePassword: '/auth/change-password'
+    changePassword: '/auth/change-password',
+    validatePassword: '/auth/validate-password'
   },
   users: {
     get: '/users',

--- a/src/constants/translations/en/common.json
+++ b/src/constants/translations/en/common.json
@@ -93,7 +93,8 @@
     "subject": "Please select a subject",
     "proficiencyLevel": "Please select at least one proficiency level",
     "youtubeLink": "Please provide a YouTube video link",
-    "currentAndNewPasswordsMatch": "Current and new passwords match."
+    "currentAndNewPasswordsMatch": "Current and new passwords match.",
+    "incorrectCurrentPassword": "Current password is incorrect"
   },
   "levels": {
     "beginner": "Beginner",

--- a/src/constants/translations/en/common.json
+++ b/src/constants/translations/en/common.json
@@ -93,7 +93,7 @@
     "subject": "Please select a subject",
     "proficiencyLevel": "Please select at least one proficiency level",
     "youtubeLink": "Please provide a YouTube video link",
-    "currentAndNewPasswordsMatch": "Current and new passwords match.",
+    "currentAndNewPasswordsMatch": "Current and new passwords match",
     "incorrectCurrentPassword": "Current password is incorrect"
   },
   "levels": {

--- a/src/constants/translations/uk/common.json
+++ b/src/constants/translations/uk/common.json
@@ -95,7 +95,8 @@
     "subject": "Будь ласка, виберіть предмет",
     "proficiencyLevel": "Будь ласка, виберіть принаймні один рівень знань",
     "youtubeLink": "Будь ласка, надайте посилання на YouTube відео",
-    "currentAndNewPasswordsMatch": "Поточний та новий паролі збігаються"
+    "currentAndNewPasswordsMatch": "Поточний та новий паролі збігаються",
+    "incorrectCurrentPassword": "Поточний пароль неправильний"
   },
   "levels": {
     "beginner": "Початковий",

--- a/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
+++ b/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
@@ -22,7 +22,6 @@ import { snackbarVariants } from '~/constants'
 import { openAlert } from '~/redux/features/snackbarSlice'
 
 import { styles } from '~/containers/edit-profile/password-security-tab/PasswordSecurityTab.styles'
-
 import {
   ButtonVariantEnum,
   ComponentEnum,
@@ -60,7 +59,43 @@ const ChangePasswordModal = () => {
       })
     }
   }
-
+  // const handleSubmitChangePassword = async () => {
+  //   try {
+  //     const response = await AuthService.validateCurrentPassword(
+  //       userId,
+  //       data.currentPassword
+  //     )
+  //     console.log(response)
+  //     if (!response.data.isValid) {
+  //       handleErrors(
+  //         'currentPassword',
+  //         t('common.errorMessages.incorrectCurrentPassword')
+  //       )
+  //       return
+  //     }
+  //     const confirmed = await checkConfirmation({
+  //       message: t(
+  //         'editProfilePage.profile.passwordSecurityTab.changePasswordConfirm'
+  //       ),
+  //       title: 'titles.confirmTitle',
+  //       check: true,
+  //     });
+  //     if (!confirmed) {
+  //       return;
+  //     }
+  //     resetErrors();
+  //     await sendChangedPassword({
+  //       password: data.password,
+  //       currentPassword: data.currentPassword,
+  //     });
+  //   } catch (error) {
+  //     console.error('Error during validateCurrentPassword:', error);
+  //     handleErrors(
+  //       'currentPassword',
+  //       t('common.errorMessages.incorrectCurrentPassword')
+  //     );
+  //   }
+  // }
   const handleResponse = () => {
     dispatch(
       openAlert({
@@ -79,7 +114,12 @@ const ChangePasswordModal = () => {
   )
 
   const handleResponseError = (error?: ErrorResponse) => {
-    if (error?.code === 'INCORRECT_CREDENTIALS') {
+    if (error?.code === 'WRONG_CURRENT_PASSWORD') {
+      handleErrors(
+        'currentPassword',
+        t('common.errorMessages.incorrectCurrentPassword')
+      )
+    } else if (error?.code === 'INCORRECT_CREDENTIALS') {
       handleErrors('password', t('common.errorMessages.samePasswords'))
     } else {
       handleErrors('currentPassword', t('common.errorMessages.currentPassword'))
@@ -89,7 +129,11 @@ const ChangePasswordModal = () => {
   const { loading, fetchData: sendChangedPassword } = useAxios({
     service: changePassword,
     onResponse: handleResponse,
-    onResponseError: handleResponseError,
+    // onResponseError: handleResponseError,
+    onResponseError: (error) => {
+      console.error('Error from service:', error)
+      handleResponseError(error)
+    },
     fetchOnMount: false
   })
 
@@ -107,7 +151,7 @@ const ChangePasswordModal = () => {
     initialValues: initialValues,
     validations: validations
   })
-
+  console.log(errors)
   const {
     inputVisibility: currentPasswordVisibility,
     showInputText: showCurrentPassword
@@ -151,7 +195,8 @@ const ChangePasswordModal = () => {
           <Box sx={styles.form}>
             <AppTextField
               InputProps={currentPasswordVisibility}
-              errorMsg={t(errors.currentPassword)}
+              // errorMsg={t(errors.currentPassword)}
+              errorMsg={errors.currentPassword ? t(errors.currentPassword) : ''}
               fullWidth
               label={t(
                 'editProfilePage.profile.passwordSecurityTab.currentPassword'

--- a/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
+++ b/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
@@ -51,51 +51,16 @@ const ChangePasswordModal = () => {
       title: 'titles.confirmTitle',
       check: true
     })
-    if (confirmed) {
-      resetErrors()
+    if (!confirmed) return
+    try {
       await sendChangedPassword({
         password: data.password,
         currentPassword: data.currentPassword
       })
+    } catch (err) {
+      data.currentPassword = ''
     }
   }
-  // const handleSubmitChangePassword = async () => {
-  //   try {
-  //     const response = await AuthService.validateCurrentPassword(
-  //       userId,
-  //       data.currentPassword
-  //     )
-  //     console.log(response)
-  //     if (!response.data.isValid) {
-  //       handleErrors(
-  //         'currentPassword',
-  //         t('common.errorMessages.incorrectCurrentPassword')
-  //       )
-  //       return
-  //     }
-  //     const confirmed = await checkConfirmation({
-  //       message: t(
-  //         'editProfilePage.profile.passwordSecurityTab.changePasswordConfirm'
-  //       ),
-  //       title: 'titles.confirmTitle',
-  //       check: true,
-  //     });
-  //     if (!confirmed) {
-  //       return;
-  //     }
-  //     resetErrors();
-  //     await sendChangedPassword({
-  //       password: data.password,
-  //       currentPassword: data.currentPassword,
-  //     });
-  //   } catch (error) {
-  //     console.error('Error during validateCurrentPassword:', error);
-  //     handleErrors(
-  //       'currentPassword',
-  //       t('common.errorMessages.incorrectCurrentPassword')
-  //     );
-  //   }
-  // }
   const handleResponse = () => {
     dispatch(
       openAlert({
@@ -129,14 +94,12 @@ const ChangePasswordModal = () => {
   const { loading, fetchData: sendChangedPassword } = useAxios({
     service: changePassword,
     onResponse: handleResponse,
-    // onResponseError: handleResponseError,
-    onResponseError: (error) => {
-      console.error('Error from service:', error)
+    onResponseError: (error: ErrorResponse) => {
       handleResponseError(error)
+      throw error
     },
     fetchOnMount: false
   })
-
   const {
     data,
     handleSubmit,
@@ -151,7 +114,6 @@ const ChangePasswordModal = () => {
     initialValues: initialValues,
     validations: validations
   })
-  console.log(errors)
   const {
     inputVisibility: currentPasswordVisibility,
     showInputText: showCurrentPassword
@@ -195,7 +157,6 @@ const ChangePasswordModal = () => {
           <Box sx={styles.form}>
             <AppTextField
               InputProps={currentPasswordVisibility}
-              // errorMsg={t(errors.currentPassword)}
               errorMsg={errors.currentPassword ? t(errors.currentPassword) : ''}
               fullWidth
               label={t(

--- a/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
+++ b/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
@@ -51,7 +51,9 @@ const ChangePasswordModal = () => {
       title: 'titles.confirmTitle',
       check: true
     })
-    if (!confirmed) return
+    if (!confirmed) {
+      return
+    }
     try {
       await sendChangedPassword({
         password: data.password,

--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -52,6 +52,8 @@ const useAxios = <
       try {
         setLoading(true)
         const res = await service(params)
+        if ((res.status >= 400 && res.status <= 405) || res.status === 500)
+          throw res
         const responseData = transform ? transform(res.data) : res.data
         setResponse(responseData as TransformedResponse)
         setError(null)

--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -52,7 +52,16 @@ const useAxios = <
       try {
         setLoading(true)
         const res = await service(params)
-        if (res.status >= 400 && res.status <= 526) throw res
+        if (res.status >= 400 && res.status <= 526) {
+          // throw res
+          throw new AxiosError(
+            'Request failed',
+            res.statusText,
+            res.config,
+            res.request,
+            res
+          )
+        }
         const responseData = transform ? transform(res.data) : res.data
         setResponse(responseData as TransformedResponse)
         setError(null)

--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -52,8 +52,7 @@ const useAxios = <
       try {
         setLoading(true)
         const res = await service(params)
-        if ((res.status >= 400 && res.status <= 405) || res.status === 500)
-          throw res
+        if (res.status >= 400 && res.status <= 526) throw res
         const responseData = transform ? transform(res.data) : res.data
         setResponse(responseData as TransformedResponse)
         setError(null)

--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -53,14 +53,7 @@ const useAxios = <
         setLoading(true)
         const res = await service(params)
         if (res.status >= 400 && res.status <= 526) {
-          // throw res
-          throw new AxiosError(
-            'Request failed',
-            res.statusText,
-            res.config,
-            res.request,
-            res
-          )
+          throw res
         }
         const responseData = transform ? transform(res.data) : res.data
         setResponse(responseData as TransformedResponse)

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -38,19 +38,11 @@ export const AuthService = {
   changePassword: (
     userId: string,
     params: { password: string; currentPassword: string }
-  ): Promise<AxiosResponse<null>> => {
+  ): Promise<AxiosResponse> => {
     return axiosClient.patch(
       createUrlPath(URLs.auth.changePassword, userId),
       params
     )
-  },
-  validateCurrentPassword: (
-    userId: string,
-    currentPassword: string
-  ): Promise<AxiosResponse<{ isValid: boolean }>> => {
-    console.log(currentPassword)
-    const url = createUrlPath(URLs.auth.validatePassword, userId)
-    return axiosClient.post(url, { currentPassword })
   }
 }
 

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -43,6 +43,14 @@ export const AuthService = {
       createUrlPath(URLs.auth.changePassword, userId),
       params
     )
+  },
+  validateCurrentPassword: (
+    userId: string,
+    currentPassword: string
+  ): Promise<AxiosResponse<{ isValid: boolean }>> => {
+    console.log(currentPassword)
+    const url = createUrlPath(URLs.auth.validatePassword, userId)
+    return axiosClient.post(url, { currentPassword })
   }
 }
 

--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -197,7 +197,7 @@ describe('ChangePasswordModal', () => {
     fireEvent.change(currentPasswordInput, { target: { value: 'oldPassword' } })
     expect(currentPasswordInput).toHaveValue('oldPassword')
   })
-  it('displays an error message for incorrect current password', async () => {
+  it('should display an error message for incorrect current password', async () => {
     AuthService.changePassword.mockImplementation((id, data) => {
       if (data.currentPassword !== userDataMock.currentPassword) {
         return Promise.reject({

--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -235,7 +235,6 @@ describe('ChangePasswordModal', () => {
       fireEvent.click(confirmButton)
     })
     await waitFor(() => {
-      screen.debug()
       expect(screen.getByText(/common.errorMessages.incorrectCurrentPassword/i)).toBeInTheDocument()
       expect(currentPasswordInput).toHaveValue('')
     })

--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -1,5 +1,5 @@
 import { vi } from 'vitest'
-import { screen, fireEvent, waitFor } from '@testing-library/react'
+import { screen, fireEvent, waitFor, render } from '@testing-library/react'
 import {
   renderWithProviders,
   mockAxiosClient,
@@ -8,9 +8,9 @@ import {
 import ChangePasswordModal from '~/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal'
 import { AuthService } from '~/services/auth-service'
 import { URLs } from '~/constants/request'
-
 const userDataMock = {
-  _id: 123456
+  _id: 123456,
+  currentPassword: '12345qwert',
 }
 
 const handleSubmit = vi.fn()
@@ -197,4 +197,47 @@ describe('ChangePasswordModal', () => {
     fireEvent.change(currentPasswordInput, { target: { value: 'oldPassword' } })
     expect(currentPasswordInput).toHaveValue('oldPassword')
   })
+  it('displays an error message for incorrect current password', async () => {
+    AuthService.changePassword.mockImplementation((id, data) => {
+      if (data.currentPassword !== userDataMock.currentPassword) {
+        return Promise.reject({
+          response: {
+            status: 400,
+            data: {
+              code: 'WRONG_CURRENT_PASSWORD',
+              message: 'Wrong current password',
+            },
+          },
+        })
+      }
+      return Promise.resolve()
+    })
+    
+    const currentPasswordInput = screen.getByLabelText(
+      /editProfilePage.profile.passwordSecurityTab.currentPassword/i
+    )
+    const saveButton = screen.getByText(
+      /editProfilePage.profile.passwordSecurityTab.savePassword/i
+    )
+    fireEvent.change(currentPasswordInput, { target: { value: 'wrongPassword1' } })
+    fireEvent.change(screen.getByLabelText(/newPassword/i), {
+      target: { value: '12345qwertY' },
+    })
+    fireEvent.change(screen.getByLabelText(/retypePassword/i), {
+      target: { value: '12345qwertY' },
+    })
+    await waitFor(() => {
+      fireEvent.click(saveButton)
+    })
+  
+    const confirmButton = await screen.findByText(/common.yes/i)
+    await waitFor(() => {
+      fireEvent.click(confirmButton)
+    })
+    await waitFor(() => {
+      screen.debug()
+      expect(screen.getByText(/common.errorMessages.incorrectCurrentPassword/i)).toBeInTheDocument()
+      expect(currentPasswordInput).toHaveValue('')
+    })
+  })  
 })


### PR DESCRIPTION
Before: if in currentPassword field input incorrect user password successful alert appends.

After:
We input incorrect current password
![image](https://github.com/user-attachments/assets/00ad6bdb-d055-4bed-bc46-54e1d54859c3)
After confirmation we have error input field and previous field clears
![image](https://github.com/user-attachments/assets/bff8e484-a02f-4648-aa25-025f023e3c5e)


Also added: 

1.  axious error responses handling which we are getting from backend.

2.  added translation for current password is incorrect

Made 3 tasks:

- [x] https://github.com/ita-social-projects/SpaceToStudy-Client/issues/2954
- [x] https://github.com/ita-social-projects/SpaceToStudy-Client/issues/2891
- [x] https://github.com/ita-social-projects/SpaceToStudy-Client/issues/2995
