### PR TITLE
Fixed incorrect bookmark height on bigger screens

### DIFF
--- a/src/containers/find-offer/offer-container/OfferContainer.styles.ts
+++ b/src/containers/find-offer/offer-container/OfferContainer.styles.ts
@@ -18,6 +18,7 @@ export const styles = {
   },
   appCardSquare: {
     minHeight: '460px',
+    maxHeight: '491px',
     p: '24px 20px',
     boxSizing: 'border-box'
   }


### PR DESCRIPTION
Fixed incorrect bookmark height while on grid view on bigger screens.
Before:
![image](https://github.com/user-attachments/assets/06a149d1-4763-4e47-83b5-daafd0ece25e)
After: 
![image](https://github.com/user-attachments/assets/4d2299fd-9a4b-4001-86a6-3e33476b4929)
