### PR TITLE
Made checkbox controlled

### DIFF
--- a/src/design-system/components/checkbox/CheckBox.tsx
+++ b/src/design-system/components/checkbox/CheckBox.tsx
@@ -1,5 +1,5 @@
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox'
-import { type ChangeEvent, ReactNode, useCallback, useState } from 'react'
+import { type ChangeEvent, type ReactNode, useCallback, useState } from 'react'
 import Loader from '~/components/loader/Loader'
 import { cn } from '~/utils/cn'
 
@@ -12,12 +12,14 @@ interface CheckBoxProps extends Omit<CheckboxProps, 'size' | 'onChange'> {
   color?: 'primary' | 'secondary' | 'error' | 'success'
   size?: 'sm' | 'md' | 'lg'
   loading?: boolean
-  isChecked?: boolean
+  checked?: boolean
+  defaultChecked?: boolean
   onChange?: (checked: boolean) => void
 }
 
 const CheckBox: React.FC<CheckBoxProps> = ({
-  isChecked: externalIsChecked,
+  checked: externalIsChecked,
+  defaultChecked = false,
   onChange,
   color = 'primary',
   disabled = false,
@@ -28,7 +30,9 @@ const CheckBox: React.FC<CheckBoxProps> = ({
   size = 'md',
   ...props
 }) => {
-  const [internalIsChecked, setInternalIsChecked] = useState<boolean>(false)
+  const [internalIsChecked, setInternalIsChecked] = useState<boolean>(
+    defaultChecked ?? false
+  )
 
   const isCheckboxControllable = externalIsChecked !== undefined
 

--- a/src/design-system/components/checkbox/CheckBox.tsx
+++ b/src/design-system/components/checkbox/CheckBox.tsx
@@ -12,9 +12,16 @@ interface CheckBoxProps extends Omit<CheckboxProps, 'size'> {
   color?: 'primary' | 'secondary' | 'error' | 'success'
   size?: 'sm' | 'md' | 'lg'
   loading?: boolean
+  checked?: boolean
+  onChange?: (
+    event: React.ChangeEvent<HTMLInputElement>,
+    checked: boolean
+  ) => void
 }
 
 const CheckBox: FC<CheckBoxProps> = ({
+  checked,
+  onChange,
   color = 'primary',
   disabled = false,
   label,
@@ -24,10 +31,18 @@ const CheckBox: FC<CheckBoxProps> = ({
   size = 'md',
   ...props
 }) => {
-  const [checked, setChecked] = useState<boolean>(false)
+  const [internalChecked, setInternalChecked] = useState<boolean>(false)
+
+  const isCheckboxControllable = checked !== undefined
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setChecked(event.target.checked)
+    const newChecked = event.target.checked
+
+    if (!isCheckboxControllable) {
+      setInternalChecked(newChecked)
+    }
+
+    onChange?.(event, newChecked)
   }
 
   const loaderSizeMapping: Record<string, number> = {
@@ -37,6 +52,7 @@ const CheckBox: FC<CheckBoxProps> = ({
   }
 
   const loader = <Loader size={loaderSizeMapping[size]} />
+  const resolvedCheck = isCheckboxControllable ? checked : internalChecked
 
   return (
     <label
@@ -60,12 +76,12 @@ const CheckBox: FC<CheckBoxProps> = ({
       ) : (
         <Checkbox
           {...props}
-          checked={checked}
+          checked={resolvedCheck}
           className='s2s-checkbox__input'
           color={color}
           data-testid='checkbox-input'
           disabled={disabled || loading}
-          indeterminate={variant === 'middle' && checked}
+          indeterminate={variant === 'middle' && resolvedCheck}
           onChange={handleChange}
         />
       )}

--- a/src/design-system/components/checkbox/CheckBox.tsx
+++ b/src/design-system/components/checkbox/CheckBox.tsx
@@ -12,7 +12,7 @@ interface CheckBoxProps extends Omit<CheckboxProps, 'size'> {
   color?: 'primary' | 'secondary' | 'error' | 'success'
   size?: 'sm' | 'md' | 'lg'
   loading?: boolean
-  checked?: boolean
+  isChecked?: boolean
   onChange?: (
     event: React.ChangeEvent<HTMLInputElement>,
     checked: boolean
@@ -20,7 +20,7 @@ interface CheckBoxProps extends Omit<CheckboxProps, 'size'> {
 }
 
 const CheckBox: FC<CheckBoxProps> = ({
-  checked,
+  isChecked: externalIsChecked,
   onChange,
   color = 'primary',
   disabled = false,
@@ -31,15 +31,15 @@ const CheckBox: FC<CheckBoxProps> = ({
   size = 'md',
   ...props
 }) => {
-  const [internalChecked, setInternalChecked] = useState<boolean>(false)
+  const [internalIsChecked, setInternalIsChecked] = useState<boolean>(false)
 
-  const isCheckboxControllable = checked !== undefined
+  const isCheckboxControllable = externalIsChecked !== undefined
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newChecked = event.target.checked
 
     if (!isCheckboxControllable) {
-      setInternalChecked(newChecked)
+      setInternalIsChecked(newChecked)
     }
 
     onChange?.(event, newChecked)
@@ -52,7 +52,9 @@ const CheckBox: FC<CheckBoxProps> = ({
   }
 
   const loader = <Loader size={loaderSizeMapping[size]} />
-  const resolvedCheck = isCheckboxControllable ? checked : internalChecked
+  const resolvedIsCheck = isCheckboxControllable
+    ? externalIsChecked
+    : internalIsChecked
 
   return (
     <label
@@ -76,12 +78,12 @@ const CheckBox: FC<CheckBoxProps> = ({
       ) : (
         <Checkbox
           {...props}
-          checked={resolvedCheck}
+          checked={resolvedIsCheck}
           className='s2s-checkbox__input'
           color={color}
           data-testid='checkbox-input'
           disabled={disabled || loading}
-          indeterminate={variant === 'middle' && resolvedCheck}
+          indeterminate={variant === 'middle' && resolvedIsCheck}
           onChange={handleChange}
         />
       )}

--- a/src/design-system/components/checkbox/CheckBox.tsx
+++ b/src/design-system/components/checkbox/CheckBox.tsx
@@ -1,11 +1,11 @@
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox'
-import { FC, ReactNode, useState } from 'react'
+import { FC, ReactNode, useCallback, useState } from 'react'
 import Loader from '~/components/loader/Loader'
 import { cn } from '~/utils/cn'
 
 import './CheckBox.scss'
 
-interface CheckBoxProps extends Omit<CheckboxProps, 'size'> {
+interface CheckBoxProps extends Omit<CheckboxProps, 'size' | 'onChange'> {
   variant: 'check' | 'middle'
   label: ReactNode
   labelPosition?: 'top' | 'bottom' | 'end'
@@ -13,10 +13,7 @@ interface CheckBoxProps extends Omit<CheckboxProps, 'size'> {
   size?: 'sm' | 'md' | 'lg'
   loading?: boolean
   isChecked?: boolean
-  onChange?: (
-    event: React.ChangeEvent<HTMLInputElement>,
-    checked: boolean
-  ) => void
+  onChange?: (checked: boolean) => void
 }
 
 const CheckBox: FC<CheckBoxProps> = ({
@@ -35,15 +32,18 @@ const CheckBox: FC<CheckBoxProps> = ({
 
   const isCheckboxControllable = externalIsChecked !== undefined
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newChecked = event.target.checked
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newChecked = event.target.checked
 
-    if (!isCheckboxControllable) {
-      setInternalIsChecked(newChecked)
-    }
+      if (!isCheckboxControllable) {
+        setInternalIsChecked(newChecked)
+      }
 
-    onChange?.(event, newChecked)
-  }
+      onChange?.(newChecked)
+    },
+    [onChange, isCheckboxControllable]
+  )
 
   const loaderSizeMapping: Record<string, number> = {
     sm: 14,

--- a/src/design-system/components/checkbox/CheckBox.tsx
+++ b/src/design-system/components/checkbox/CheckBox.tsx
@@ -30,9 +30,8 @@ const CheckBox: React.FC<CheckBoxProps> = ({
   size = 'md',
   ...props
 }) => {
-  const [internalIsChecked, setInternalIsChecked] = useState<boolean>(
-    defaultChecked ?? false
-  )
+  const [internalIsChecked, setInternalIsChecked] =
+    useState<boolean>(defaultChecked)
 
   const isCheckboxControlled = externalIsChecked !== undefined
 

--- a/src/design-system/components/checkbox/CheckBox.tsx
+++ b/src/design-system/components/checkbox/CheckBox.tsx
@@ -1,5 +1,5 @@
 import Checkbox, { CheckboxProps } from '@mui/material/Checkbox'
-import { FC, ReactNode, useCallback, useState } from 'react'
+import { type ChangeEvent, ReactNode, useCallback, useState } from 'react'
 import Loader from '~/components/loader/Loader'
 import { cn } from '~/utils/cn'
 
@@ -16,7 +16,7 @@ interface CheckBoxProps extends Omit<CheckboxProps, 'size' | 'onChange'> {
   onChange?: (checked: boolean) => void
 }
 
-const CheckBox: FC<CheckBoxProps> = ({
+const CheckBox: React.FC<CheckBoxProps> = ({
   isChecked: externalIsChecked,
   onChange,
   color = 'primary',
@@ -33,14 +33,12 @@ const CheckBox: FC<CheckBoxProps> = ({
   const isCheckboxControllable = externalIsChecked !== undefined
 
   const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newChecked = event.target.checked
-
+    ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => {
       if (!isCheckboxControllable) {
-        setInternalIsChecked(newChecked)
+        setInternalIsChecked(checked)
       }
 
-      onChange?.(newChecked)
+      onChange?.(checked)
     },
     [onChange, isCheckboxControllable]
   )

--- a/src/design-system/components/checkbox/CheckBox.tsx
+++ b/src/design-system/components/checkbox/CheckBox.tsx
@@ -34,17 +34,17 @@ const CheckBox: React.FC<CheckBoxProps> = ({
     defaultChecked ?? false
   )
 
-  const isCheckboxControllable = externalIsChecked !== undefined
+  const isCheckboxControlled = externalIsChecked !== undefined
 
   const handleChange = useCallback(
     ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => {
-      if (!isCheckboxControllable) {
+      if (!isCheckboxControlled) {
         setInternalIsChecked(checked)
       }
 
       onChange?.(checked)
     },
-    [onChange, isCheckboxControllable]
+    [onChange, isCheckboxControlled]
   )
 
   const loaderSizeMapping: Record<string, number> = {
@@ -54,7 +54,7 @@ const CheckBox: React.FC<CheckBoxProps> = ({
   }
 
   const loader = <Loader size={loaderSizeMapping[size]} />
-  const resolvedIsCheck = isCheckboxControllable
+  const resolvedIsCheck = isCheckboxControlled
     ? externalIsChecked
     : internalIsChecked
 

--- a/src/design-system/stories/CheckBox.stories.tsx
+++ b/src/design-system/stories/CheckBox.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
 import CheckBox from '~scss-components/checkbox/CheckBox'
 
 const meta: Meta<typeof CheckBox> = {
@@ -17,6 +18,10 @@ The \`CheckBox\` component is a highly customizable and user-friendly checkbox d
 - **Sizes:** Select from \`sm\`, \`md\`, or \`lg\` to match the checkbox to the context—whether it’s a compact form or a prominent control.
 - **Loading State:** When an action is in progress, the checkbox displays a spinner and becomes temporarily non-interactive, enhancing user feedback.
 - **Colors:** Use predefined color options like \`primary\`, \`secondary\`, \`success\`, or \`error\` to align the checkbox with your application's theme.
+
+#### Controlled vs. Uncontrolled States:
+- **Controlled Checkbox:** A checkbox is considered controlled when its state is managed by a parent component using the \`checked\` prop. In this case, the parent component controls the checked state, and the checkbox becomes a controlled component, meaning its state can be set externally.
+- **Uncontrolled Checkbox:** In contrast, when the \`checked\` prop is not provided, the checkbox is considered uncontrolled. It manages its own internal state and changes its state based on user interaction.
 
 
 This component is ideal for use in forms, settings pages, or any interface requiring intuitive selection controls. Whether you need a straightforward checkbox or a visually distinctive option with loading feedback, the \`CheckBox\` component adapts to your design and functionality needs.
@@ -61,6 +66,19 @@ This component is ideal for use in forms, settings pages, or any interface requi
     },
     label: {
       description: 'The content to be displayed as the label of the checkbox.'
+    },
+    checked: {
+      description:
+        'When provided, the checkbox becomes controlled. This value determines its checked state, overriding internal state management.',
+      control: 'boolean'
+    },
+    defaultChecked: {
+      description:
+        'Determines the initial checked state of the checkbox when the component is first rendered. It only applies when the checkbox is not controlled via the `checked` prop',
+      control: 'boolean'
+    },
+    onChange: {
+      description: 'Callback fired when the checkbox state changes.'
     }
   }
 }
@@ -83,6 +101,41 @@ export const Default: Story = {
           'The default configuration of the checkbox with a primary color, medium size, and label positioned at the end.'
       }
     }
+  }
+}
+
+export const Controlled: Story = {
+  args: {
+    ...Default.args,
+    label: 'Controlled checkbox',
+    checked: false
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A checkbox controlled by the parent component using the `checked` prop. Changes to its state are managed internally unless the `checked` prop is externally set. In that case, it becomes a controlled component.'
+      }
+    }
+  },
+  render: (args) => {
+    const ControlledCheckBox = () => {
+      const [isChecked, setIsChecked] = useState(args.checked)
+
+      return (
+        <div>
+          <CheckBox
+            {...args}
+            checked={isChecked}
+            onChange={(checked) => {
+              setIsChecked(checked)
+            }}
+          />
+          <p>Checkbox is currently {isChecked ? 'checked' : 'unchecked'}</p>
+        </div>
+      )
+    }
+    return <ControlledCheckBox />
   }
 }
 


### PR DESCRIPTION
Refactored the CheckBox component to support both controlled and uncontrolled states. #2970 
The changes allow external state management via props (`checked` and `onChange`) while preserving internal state handling as a fallback when the `checked` prop is not provided.

Here’s a video demonstrating how the controlled CheckBox interacts with external state:

https://github.com/user-attachments/assets/359751f5-0512-4eb9-b9e9-f31b599ef41e



Summary:

- [x] Added a `checked` prop to enable external control of the checkbox state.
- [x] Introduced an `onChange` callback prop to handle state change events.
- [x] Implemented fallback logic to use internal state when the `checked` prop is not passed.
- [x] Preserved support for uncontrolled usage with the `defaultChecked` prop.
- [x] Added a new "Controlled" story to demonstrate the controlled behavior of the CheckBox component.
- [x] Updated component descriptions to reflect support for both controlled and uncontrolled states.
