### PR TITLE
Fixed needAction according to backend changes

### DIFF
--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -50,7 +50,7 @@ const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
   const dispatch = useAppDispatch()
   const [minPrice, maxPrice] = minMaxPrice(cooperation.offer.price, 0.25)
 
-  const needAction = cooperation.user.role !== cooperation.needAction
+  const needAction = cooperation.user.role !== cooperation.needAction.role
 
   const handleUpdateCooperation = (
     params?: UpdateCooperationsParams

--- a/src/containers/my-cooperations/cooperation-card/CooperationCard.tsx
+++ b/src/containers/my-cooperations/cooperation-card/CooperationCard.tsx
@@ -38,7 +38,7 @@ const CooperationCard: FC<CooperationCardProps> = ({
   } = cooperation
 
   const cooperationStatus =
-    user.role !== needAction && status === StatusEnum.Pending
+    user.role !== needAction.role && status === StatusEnum.Pending
       ? StatusEnum.NeedAction
       : status
 

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.constants.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.constants.tsx
@@ -8,6 +8,7 @@ import MyCooperationsDetails from '../my-cooperations-details/MyCooperationsDeta
 import {
   Cooperation,
   CooperationTabsEnum,
+  NeedActionTypeEnum,
   ProficiencyLevelEnum,
   StatusEnum,
   UserRoleEnum
@@ -72,7 +73,7 @@ export const defaultResponse: Cooperation = {
   status: StatusEnum.Active,
   needAction: {
     role: UserRoleEnum.Tutor,
-    type: '',
+    type: NeedActionTypeEnum.Price,
     messages: []
   },
   sections: [],

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.constants.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.constants.tsx
@@ -70,9 +70,23 @@ export const defaultResponse: Cooperation = {
   price: 0,
   proficiencyLevel: ProficiencyLevelEnum.Beginner,
   status: StatusEnum.Active,
-  needAction: UserRoleEnum.Tutor,
+  needAction: {
+    role: UserRoleEnum.Tutor,
+    type: '',
+    messages: []
+  },
   sections: [],
   createdAt: '',
   updatedAt: '',
-  _id: ''
+  _id: '',
+  initiator: {
+    firstName: '',
+    lastName: ''
+  },
+  initiatorRole: 'tutor',
+  receiver: {
+    firstName: '',
+    lastName: ''
+  },
+  receiverRole: 'student'
 }

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -153,7 +153,7 @@ const CooperationDetails = () => {
   }
 
   const closeCooperationInitiator =
-    response.needAction === response.receiverRole
+    response.needAction.role === response.receiverRole
       ? response.initiator
       : response.receiver
 
@@ -167,7 +167,7 @@ const CooperationDetails = () => {
   )
 
   const isCooperationClosingRequestSend =
-    response.needAction === userRole &&
+    response.needAction.role === userRole &&
     response.status === StatusEnum.RequestToClose
 
   const iconConditionals = isNotesOpen ? (

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.constants.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.constants.tsx
@@ -63,7 +63,7 @@ export const columns: TableColumn<Cooperation>[] = [
     label: 'cooperationsPage.tableHeaders.status',
     calculatedCellValue: ({ user, needAction, status }: Cooperation) => {
       const cooperationStatus =
-        user.role !== needAction && status === StatusEnum.Pending
+        user.role !== needAction.role && status === StatusEnum.Pending
           ? StatusEnum.NeedAction
           : status
       return <StatusChip status={cooperationStatus} />

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.constants.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.constants.tsx
@@ -63,7 +63,7 @@ export const columns: TableColumn<Cooperation>[] = [
     label: 'cooperationsPage.tableHeaders.status',
     calculatedCellValue: ({ user, needAction, status }: Cooperation) => {
       const cooperationStatus =
-        user.role !== needAction.role && status === StatusEnum.Pending
+        user.role !== needAction?.role && status === StatusEnum.Pending
           ? StatusEnum.NeedAction
           : status
       return <StatusChip status={cooperationStatus} />

--- a/src/types/cooperation/interfaces/cooperation.interface.ts
+++ b/src/types/cooperation/interfaces/cooperation.interface.ts
@@ -12,9 +12,9 @@ import {
 } from '~/types'
 
 export enum NeedActionTypeEnum {
-  WaitingForAnswer = 'Waiting for answer',
-  WaitingForApproval = 'Waiting for approval',
-  Price = 'Price'
+  WaitingForAnswer = 'waiting for answer',
+  WaitingForApproval = 'waiting for approval',
+  Price = 'price'
 }
 
 export interface Cooperation extends CommonEntityFields {

--- a/src/types/cooperation/interfaces/cooperation.interface.ts
+++ b/src/types/cooperation/interfaces/cooperation.interface.ts
@@ -11,6 +11,12 @@ import {
   CourseSection
 } from '~/types'
 
+export enum NeedActionTypeEnum {
+  WaitingForAnswer = 'Waiting for answer',
+  WaitingForApproval = 'Waiting for approval',
+  Price = 'Price'
+}
+
 export interface Cooperation extends CommonEntityFields {
   offer: Pick<Offer, 'subject' | 'title' | 'category' | 'price' | '_id'>
   user: Pick<UserResponse, 'firstName' | 'lastName' | 'photo' | '_id'> & {
@@ -24,7 +30,7 @@ export interface Cooperation extends CommonEntityFields {
   status: StatusEnum
   needAction: {
     role: UserRoleEnum
-    type: string
+    type: NeedActionTypeEnum
     messages: string[]
   }
   receiver: Pick<UserResponse, 'firstName' | 'lastName'>

--- a/src/types/cooperation/interfaces/cooperation.interface.ts
+++ b/src/types/cooperation/interfaces/cooperation.interface.ts
@@ -22,7 +22,11 @@ export interface Cooperation extends CommonEntityFields {
   price: Offer['price']
   proficiencyLevel: ProficiencyLevelEnum
   status: StatusEnum
-  needAction: UserRoleEnum
+  needAction: {
+    role: UserRoleEnum
+    type: string
+    messages: string[]
+  }
   receiver: Pick<UserResponse, 'firstName' | 'lastName'>
   receiverRole: 'tutor' | 'student'
   sections: CourseSection[]

--- a/tests/unit/containers/my-cooperations/MyCooperations.spec.constants.js
+++ b/tests/unit/containers/my-cooperations/MyCooperations.spec.constants.js
@@ -17,6 +17,8 @@ export const mockedCoop = {
   price: 1800,
   proficiencyLevel: 'Beginner',
   status: 'pending',
-  needAction: 'tutor',
+  needAction: {
+    role: 'tutor'
+  },
   createdAt: '2023-05-13T13:44:25.716Z'
 }

--- a/tests/unit/containers/my-cooperations/MyCooperations.spec.constants.js
+++ b/tests/unit/containers/my-cooperations/MyCooperations.spec.constants.js
@@ -18,7 +18,9 @@ export const mockedCoop = {
   proficiencyLevel: 'Beginner',
   status: 'pending',
   needAction: {
-    role: 'tutor'
+    role: 'tutor',
+    type: 'price',
+    messages: []
   },
   createdAt: '2023-05-13T13:44:25.716Z'
 }

--- a/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
@@ -26,7 +26,9 @@ const cooperationMock = {
   price: 100,
   proficiencyLevel: 'Beginner',
   status: 'active',
-  needAction: 'tutor',
+  needAction: {
+    role: 'tutor'
+  },
   title: 'Cooperation title',
   initiator: { _id: userId, role: ['tutor'] },
   receiver: { _id: '123123', role: ['student'] },

--- a/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
@@ -27,7 +27,9 @@ const cooperationMock = {
   proficiencyLevel: 'Beginner',
   status: 'active',
   needAction: {
-    role: 'tutor'
+    role: 'tutor',
+    type: 'price',
+    messages: []
   },
   title: 'Cooperation title',
   initiator: { _id: userId, role: ['tutor'] },


### PR DESCRIPTION
Use backend 1016 branch to test it.
Changed all needAction logic according to new structure:
https://github.com/ita-social-projects/SpaceToStudy-BackEnd/issues/1016

```
status: "Request to close",
needAction: {
    role: "tutor"
    type: "waiting for approval"
    messages: []
}
```
It should be merged only after backend PR.