### PR TITLE
Fixed type mismatch in FilterCell component

### DIFF
--- a/src/components/enhanced-table/enum-filter/EnumFilter.tsx
+++ b/src/components/enhanced-table/enum-filter/EnumFilter.tsx
@@ -5,11 +5,7 @@ import ClearIcon from '@mui/icons-material/Clear'
 
 import useMenu from '~/hooks/use-menu'
 import FilterCheckbox from '~/components/enhanced-table/filter-checkbox/FilterCheckbox'
-
-interface FilterEnum {
-  value: string
-  label: string
-}
+import { FilterEnum } from '~/types/components/enum-filter/enumFilter.interface'
 
 interface EnumFilterProps {
   column: {

--- a/src/components/enhanced-table/filter-row/filter-cell/FilterCell.tsx
+++ b/src/components/enhanced-table/filter-row/filter-cell/FilterCell.tsx
@@ -4,9 +4,11 @@ import SearchInput from '~/components/search-input/SearchInput'
 import DateFilter from '~/components/enhanced-table/date-filter/DateFilter'
 import EnumFilter from '~/components/enhanced-table/enum-filter/EnumFilter'
 import { TableColumn } from '~/types'
+import { FilterEnum } from '~/types/components/enum-filter/enumFilter.interface'
 
 interface TableColumnProps<I> extends TableColumn<I> {
   dataType: 'string'
+  filterEnum: FilterEnum[]
 }
 
 interface Filter {
@@ -21,7 +23,7 @@ interface FilterCellProps<I, F> {
   clearFilter: () => void
 }
 
-const FilterCell = <I, F extends Filter | string>({
+const FilterCell = <I, F extends Filter | string | string[]>({
   column,
   filter,
   setFilter,
@@ -31,8 +33,8 @@ const FilterCell = <I, F extends Filter | string>({
     <EnumFilter
       clearFilter={clearFilter}
       column={column}
-      filter={filter}
-      setFilter={setFilter}
+      filter={filter as string[]}
+      setFilter={setFilter as (filter: string[]) => void}
     />
   )
 

--- a/src/types/components/enum-filter/enumFilter.interface.ts
+++ b/src/types/components/enum-filter/enumFilter.interface.ts
@@ -1,0 +1,4 @@
+export interface FilterEnum {
+  value: string
+  label: string
+}


### PR DESCRIPTION
Fixed type mismatch in FilterCell component. Now TypeScript doesn't show any errors. All types are matching.
Problems:
![image](https://github.com/user-attachments/assets/237160c4-ed49-47ed-a133-b3c5e297331f)
Logs:
![image](https://github.com/user-attachments/assets/2d21730a-28ab-42f1-9cec-16ad77baa691)
