### PR TITLE
Fixed 'Content' description styles in 'Lesson details'

### DIFF
--- a/src/pages/lesson-details/LessonsDetails.styles.ts
+++ b/src/pages/lesson-details/LessonsDetails.styles.ts
@@ -9,7 +9,11 @@ export const styles = {
   titleWithDescription: {
     wrapper: { mb: '24px' },
     title: { typography: TypographyVariantEnum.H4, mb: '16px' },
-    description: { typography: TypographyVariantEnum.Body2 }
+    description: {
+      typography: TypographyVariantEnum.Body2,
+      wordWrap: 'break-word',
+      overflowWrap: 'break-word'
+    }
   },
   content: {
     p: '16px 16px 0',
@@ -18,7 +22,9 @@ export const styles = {
     },
     '& :last-child': {
       mb: '0'
-    }
+    },
+    wordWrap: 'break-word',
+    overflowWrap: 'break-word'
   },
   attachmentList: {
     pt: '16px',


### PR DESCRIPTION
Fix overflow issue in 'Content' description. Add word wrapping to prevent horizontal scroll.

**Before:**
![image](https://github.com/user-attachments/assets/d1569a66-b905-47de-adb5-3668ef54023c)


**After:**
![image](https://github.com/user-attachments/assets/dfa275f5-05bc-4441-87d3-f3bc3c82cce8)
