### PR TITLE
Fixed type incompatibility for size prop of AppButton in OfferActions Component

### DIFF
--- a/src/components/app-button/AppButton.tsx
+++ b/src/components/app-button/AppButton.tsx
@@ -12,7 +12,7 @@ interface AppButtonProps extends Omit<ButtonProps, 'size'> {
   disabled?: boolean
   component?: ElementType
   to?: string
-  size?: 'small' | 'medium' | 'large' | 'extraLarge' | 'xxl' | SizeEnum | null
+  size?: `${SizeEnum}` | SizeEnum | null
 }
 
 const AppButton: FC<AppButtonProps> = ({

--- a/src/components/app-button/AppButton.tsx
+++ b/src/components/app-button/AppButton.tsx
@@ -12,7 +12,7 @@ interface AppButtonProps extends Omit<ButtonProps, 'size'> {
   disabled?: boolean
   component?: ElementType
   to?: string
-  size?: SizeEnum | null
+  size?: 'small' | 'medium' | 'large' | 'extraLarge' | 'xxl' | SizeEnum | null
 }
 
 const AppButton: FC<AppButtonProps> = ({


### PR DESCRIPTION
Extended the `size` prop type for the `AppButton` component to include the `SizeEnum` values (`'small' | 'medium' | 'large' | 'extraLarge' | 'xxl' `). This enables passing `size` values as strings, improving compatibility with MUI.

This change is aligned with SizeEnum definitions:
`common.enums.ts`:
![image](https://github.com/user-attachments/assets/ded350d1-edfe-4c75-83e3-ec75b15fc437)

