### PR TITLE
Fix type error caused by spliceSx helper function

### DIFF
--- a/src/utils/helper-functions.tsx
+++ b/src/utils/helper-functions.tsx
@@ -184,11 +184,10 @@ export const adjustColumns = <
 export const spliceSx = (
   defaultStyles?: SxProps<Theme>,
   newStyles?: SxProps<Theme>
-) =>
-  ({
-    ...defaultStyles,
-    ...newStyles
-  }) as SxProps
+) => ({
+  ...defaultStyles,
+  ...newStyles
+})
 
 export const studentOrTutor = (userRole: '' | UserRole) =>
   userRole === UserRoleEnum.Tutor ? UserRoleEnum.Tutor : UserRoleEnum.Student


### PR DESCRIPTION
A TypeScript error with the `style` prop inside `NotFoundResults` was caused by a redundant type assertion inside the `spliceSx` helper function, and it has been fixed here.