### PR TITLE
Replaced `useAxios` with `useQuery` on the My Cooperations page

### DIFF
--- a/src/components/active-students/ActiveStudentsBlock.tsx
+++ b/src/components/active-students/ActiveStudentsBlock.tsx
@@ -4,15 +4,14 @@ import { useCallback } from 'react'
 
 import useQuery from '~/hooks/use-query'
 import { cooperationService } from '~/services/cooperation-service'
-import { defaultResponse } from '~/pages/my-cooperations/MyCooperations.constants'
 import Loader from '../loader/Loader'
-import { Cooperation, ItemsWithCount } from '~/types'
 import ActiveStudent from './ActiveStudent'
 import AppIconButton from '../app-icon-button/AppIconButton'
 import { Add, MoreHoriz } from '@mui/icons-material'
 import { styles } from './ActiveStudentsBlock.styles'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
+import { defaultResponses } from '~/constants'
 
 const ActiveStudentsBlock = () => {
   const { t } = useTranslation()
@@ -23,13 +22,12 @@ const ActiveStudentsBlock = () => {
     []
   )
 
-  const {
-    isLoading,
-    data = defaultResponse,
-    error
-  } = useQuery<ItemsWithCount<Cooperation>>({
+  const { isLoading, data, error } = useQuery({
     queryKey: ['cooperations'],
-    queryFn: getMyCooperations
+    queryFn: getMyCooperations,
+    options: {
+      initialData: defaultResponses.itemsWithCount
+    }
   })
 
   if (isLoading) {

--- a/src/components/active-students/ActiveStudentsBlock.tsx
+++ b/src/components/active-students/ActiveStudentsBlock.tsx
@@ -2,7 +2,7 @@ import { Typography } from '@mui/material'
 import Box from '@mui/system/Box'
 import { useCallback } from 'react'
 
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import { cooperationService } from '~/services/cooperation-service'
 import { defaultResponse } from '~/pages/my-cooperations/MyCooperations.constants'
 import Loader from '../loader/Loader'
@@ -23,13 +23,22 @@ const ActiveStudentsBlock = () => {
     []
   )
 
-  const { loading, response, error } = useAxios<ItemsWithCount<Cooperation>>({
-    service: getMyCooperations,
-    defaultResponse
+  const {
+    isLoading,
+    data = defaultResponse,
+    error
+  } = useQuery<ItemsWithCount<Cooperation>>({
+    queryKey: ['cooperations'],
+    queryFn: getMyCooperations
   })
 
-  if (loading) return <Loader pageLoad size={50} />
-  if (error) return null
+  if (isLoading) {
+    return <Loader pageLoad size={50} />
+  }
+
+  if (error) {
+    return null
+  }
 
   const onShowMoreClick = () => {
     navigate('/my-cooperations')
@@ -39,7 +48,7 @@ const ActiveStudentsBlock = () => {
     navigate('/categories/subjects/find-offers')
   }
 
-  if (!response.items.length)
+  if (!data.items.length)
     return (
       <>
         <Typography sx={styles.title}>{t('activeStudents.title')}</Typography>
@@ -61,7 +70,7 @@ const ActiveStudentsBlock = () => {
       </>
     )
 
-  const activeStudents = response.items.map((cooperation) => (
+  const activeStudents = data.items.map((cooperation) => (
     <ActiveStudent
       cooperationId={cooperation._id}
       firstName={cooperation.user.firstName}

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -1,6 +1,7 @@
 import { FC, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AxiosResponse } from 'axios'
+import { type QueryObserverResult } from '@tanstack/react-query'
 
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
@@ -33,11 +34,12 @@ import { styles } from '~/containers/my-cooperations/accept-cooperation-modal/Ac
 import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
-import { type QueryObserverResult } from '@tanstack/react-query'
 
 interface AcceptCooperationModalProps {
   cooperation: Cooperation
-  getCooperations: () => Promise<QueryObserverResult<unknown, ErrorResponse>>
+  getCooperations: () => Promise<
+    QueryObserverResult<{ items: Cooperation[]; count: number }>
+  >
 }
 
 const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -33,10 +33,11 @@ import { styles } from '~/containers/my-cooperations/accept-cooperation-modal/Ac
 import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
+import { type QueryObserverResult } from '@tanstack/react-query'
 
 interface AcceptCooperationModalProps {
   cooperation: Cooperation
-  getCooperations: () => Promise<void>
+  getCooperations: () => Promise<QueryObserverResult<unknown, ErrorResponse>>
 }
 
 const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -26,7 +26,7 @@ import {
   ComponentEnum,
   Cooperation,
   ErrorResponse,
-  ItemsWithCount,
+  type ItemsWithCount,
   StatusEnum,
   UpdateCooperationsParams
 } from '~/types'

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -26,6 +26,7 @@ import {
   ComponentEnum,
   Cooperation,
   ErrorResponse,
+  ItemsWithCount,
   StatusEnum,
   UpdateCooperationsParams
 } from '~/types'
@@ -38,7 +39,7 @@ import { getErrorKey } from '~/utils/get-error-key'
 interface AcceptCooperationModalProps {
   cooperation: Cooperation
   getCooperations: () => Promise<
-    QueryObserverResult<{ items: Cooperation[]; count: number }>
+    QueryObserverResult<ItemsWithCount<Cooperation>>
   >
 }
 

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -15,7 +15,7 @@ import {
   removeColumnRules
 } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.constants'
 import { styles } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
-import { Cooperation, ItemsWithCount, SizeEnum, StatusEnum } from '~/types'
+import { Cooperation, type ItemsWithCount, SizeEnum, StatusEnum } from '~/types'
 import { useNavigate } from 'react-router-dom'
 
 interface CooperationContainerProps {

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -14,14 +14,15 @@ import {
   removeColumnRules
 } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.constants'
 import { styles } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
-import { Cooperation, SizeEnum, StatusEnum } from '~/types'
+import { Cooperation, ErrorResponse, SizeEnum, StatusEnum } from '~/types'
 import { useNavigate } from 'react-router-dom'
+import { type QueryObserverResult } from '@tanstack/react-query'
 
 interface CooperationContainerProps {
   items: Cooperation[]
   showTable: boolean
   sort: SortHook
-  getCooperations: () => Promise<void>
+  getCooperations: () => Promise<QueryObserverResult<unknown, ErrorResponse>>
 }
 
 const CooperationContainer: FC<CooperationContainerProps> = ({

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box'
 import { FC } from 'react'
+import { type QueryObserverResult } from '@tanstack/react-query'
 
 import EnhancedTable from '~/components/enhanced-table/EnhancedTable'
 import AcceptCooperationModal from '~/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal'
@@ -14,15 +15,16 @@ import {
   removeColumnRules
 } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.constants'
 import { styles } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
-import { Cooperation, ErrorResponse, SizeEnum, StatusEnum } from '~/types'
+import { Cooperation, SizeEnum, StatusEnum } from '~/types'
 import { useNavigate } from 'react-router-dom'
-import { type QueryObserverResult } from '@tanstack/react-query'
 
 interface CooperationContainerProps {
   items: Cooperation[]
   showTable: boolean
   sort: SortHook
-  getCooperations: () => Promise<QueryObserverResult<unknown, ErrorResponse>>
+  getCooperations: () => Promise<
+    QueryObserverResult<{ items: Cooperation[]; count: number }>
+  >
 }
 
 const CooperationContainer: FC<CooperationContainerProps> = ({

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -15,7 +15,7 @@ import {
   removeColumnRules
 } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.constants'
 import { styles } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
-import { Cooperation, SizeEnum, StatusEnum } from '~/types'
+import { Cooperation, ItemsWithCount, SizeEnum, StatusEnum } from '~/types'
 import { useNavigate } from 'react-router-dom'
 
 interface CooperationContainerProps {
@@ -23,7 +23,7 @@ interface CooperationContainerProps {
   showTable: boolean
   sort: SortHook
   getCooperations: () => Promise<
-    QueryObserverResult<{ items: Cooperation[]; count: number }>
+    QueryObserverResult<ItemsWithCount<Cooperation>>
   >
 }
 

--- a/src/pages/my-cooperations/MyCooperations.tsx
+++ b/src/pages/my-cooperations/MyCooperations.tsx
@@ -28,7 +28,12 @@ import {
   tabsInfo
 } from '~/pages/my-cooperations/MyCooperations.constants'
 import { itemsLoadLimit } from '~/constants'
-import { CardsViewEnum, Cooperation, UserRoleEnum } from '~/types'
+import {
+  CardsViewEnum,
+  Cooperation,
+  ItemsWithCount,
+  UserRoleEnum
+} from '~/types'
 import { styles } from '~/pages/my-cooperations/MyCooperations.styles'
 import TabFilterList from '~/components/tab-filter-list/TabFilterList'
 
@@ -81,10 +86,7 @@ const MyCooperations = () => {
     isLoading,
     data = defaultResponse,
     refetch
-  } = useQuery<{
-    items: Cooperation[]
-    count: number
-  }>({
+  } = useQuery<ItemsWithCount<Cooperation>>({
     queryKey: ['cooperations', filters, sort, page],
     queryFn: getMyCooperations
   })

--- a/src/pages/my-cooperations/MyCooperations.tsx
+++ b/src/pages/my-cooperations/MyCooperations.tsx
@@ -21,19 +21,13 @@ import { getScreenBasedLimit } from '~/utils/helper-functions'
 
 import { authRoutes } from '~/router/constants/authRoutes'
 import {
-  defaultResponse,
   initialFilters,
   initialSort,
   sortTranslationKeys,
   tabsInfo
 } from '~/pages/my-cooperations/MyCooperations.constants'
-import { itemsLoadLimit } from '~/constants'
-import {
-  CardsViewEnum,
-  Cooperation,
-  ItemsWithCount,
-  UserRoleEnum
-} from '~/types'
+import { defaultResponses, itemsLoadLimit } from '~/constants'
+import { CardsViewEnum, UserRoleEnum } from '~/types'
 import { styles } from '~/pages/my-cooperations/MyCooperations.styles'
 import TabFilterList from '~/components/tab-filter-list/TabFilterList'
 
@@ -82,13 +76,12 @@ const MyCooperations = () => {
     [filters, page, itemsPerPage, sort]
   )
 
-  const {
-    isLoading,
-    data = defaultResponse,
-    refetch
-  } = useQuery<ItemsWithCount<Cooperation>>({
+  const { isLoading, data, refetch } = useQuery({
     queryKey: ['cooperations', filters, sort, page],
-    queryFn: getMyCooperations
+    queryFn: getMyCooperations,
+    options: {
+      initialData: defaultResponses.itemsWithCount
+    }
   })
 
   const handleTabClick = (tabName: string, tabValue: string) => {

--- a/src/pages/my-cooperations/MyCooperations.tsx
+++ b/src/pages/my-cooperations/MyCooperations.tsx
@@ -77,7 +77,7 @@ const MyCooperations = () => {
   )
 
   const { isLoading, data, refetch } = useQuery({
-    queryKey: ['cooperations'],
+    queryKey: ['cooperations', filters, sort, page, activeTab],
     queryFn: async () => {
       const response = await getMyCooperations()
 

--- a/src/pages/my-cooperations/MyCooperations.tsx
+++ b/src/pages/my-cooperations/MyCooperations.tsx
@@ -7,7 +7,7 @@ import Typography from '@mui/material/Typography'
 import { setPageLoad } from '~/redux/reducer'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 import usePagination from '~/hooks/table/use-pagination'
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import useSort from '~/hooks/table/use-sort'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import useFilter from '~/hooks/table/use-filter'
@@ -22,14 +22,13 @@ import { getScreenBasedLimit } from '~/utils/helper-functions'
 
 import { authRoutes } from '~/router/constants/authRoutes'
 import {
-  defaultResponse,
   initialFilters,
   initialSort,
   sortTranslationKeys,
   tabsInfo
 } from '~/pages/my-cooperations/MyCooperations.constants'
 import { itemsLoadLimit } from '~/constants'
-import { CardsViewEnum, UserRoleEnum } from '~/types'
+import { CardsViewEnum, Cooperation, UserRoleEnum } from '~/types'
 import { styles } from '~/pages/my-cooperations/MyCooperations.styles'
 import TabFilterList from '~/components/tab-filter-list/TabFilterList'
 
@@ -79,13 +78,13 @@ const MyCooperations = () => {
     [filters, page, itemsPerPage, sort]
   )
 
-  const {
-    loading,
-    response,
-    fetchData: getCooperations
-  } = useAxios({
-    service: getMyCooperations,
-    defaultResponse
+  const { isLoading, data, refetch } = useQuery({
+    queryKey: ['cooperations'],
+    queryFn: async () => {
+      const response = await getMyCooperations()
+
+      return response.data as { items: Cooperation[]; count: number }
+    }
   })
 
   const handleTabClick = (tabName: string, tabValue: string) => {
@@ -101,8 +100,8 @@ const MyCooperations = () => {
   }))
 
   useLayoutEffect(() => {
-    void dispatch(setPageLoad(loading))
-  }, [dispatch, loading])
+    void dispatch(setPageLoad(isLoading))
+  }, [dispatch, isLoading])
 
   return (
     <PageWrapper>
@@ -133,20 +132,20 @@ const MyCooperations = () => {
         view={itemsView}
         withoutSort={showTable}
       />
-      {loading ? (
+      {isLoading ? (
         <Loader pageLoad size={50} />
       ) : (
         <>
           <CooperationContainer
-            getCooperations={getCooperations}
-            items={response.items}
+            getCooperations={refetch}
+            items={data?.items ?? []}
             showTable={showTable}
             sort={sortOptions}
           />
           <AppPagination
             onChange={handleChangePage}
             page={page}
-            pageCount={Math.ceil(response.count / itemsPerPage)}
+            pageCount={data?.count ? Math.ceil(data.count / itemsPerPage) : 0}
             sx={styles.pagination}
           />
         </>

--- a/src/pages/my-cooperations/MyCooperations.tsx
+++ b/src/pages/my-cooperations/MyCooperations.tsx
@@ -21,6 +21,7 @@ import { getScreenBasedLimit } from '~/utils/helper-functions'
 
 import { authRoutes } from '~/router/constants/authRoutes'
 import {
+  defaultResponse,
   initialFilters,
   initialSort,
   sortTranslationKeys,
@@ -76,13 +77,16 @@ const MyCooperations = () => {
     [filters, page, itemsPerPage, sort]
   )
 
-  const { isLoading, data, refetch } = useQuery({
-    queryKey: ['cooperations', filters, sort, page, activeTab],
-    queryFn: async () => {
-      const response = await getMyCooperations()
-
-      return response.data as { items: Cooperation[]; count: number }
-    }
+  const {
+    isLoading,
+    data = defaultResponse,
+    refetch
+  } = useQuery<{
+    items: Cooperation[]
+    count: number
+  }>({
+    queryKey: ['cooperations', filters, sort, page],
+    queryFn: getMyCooperations
   })
 
   const handleTabClick = (tabName: string, tabValue: string) => {
@@ -132,14 +136,14 @@ const MyCooperations = () => {
         <>
           <CooperationContainer
             getCooperations={refetch}
-            items={data?.items ?? []}
+            items={data.items}
             showTable={showTable}
             sort={sortOptions}
           />
           <AppPagination
             onChange={handleChangePage}
             page={page}
-            pageCount={data?.count ? Math.ceil(data.count / itemsPerPage) : 0}
+            pageCount={Math.ceil(data.count / itemsPerPage)}
             sx={styles.pagination}
           />
         </>

--- a/src/pages/my-cooperations/MyCooperations.tsx
+++ b/src/pages/my-cooperations/MyCooperations.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useSearchParams } from 'react-router-dom'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 
-import { setPageLoad } from '~/redux/reducer'
-import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
+import { useAppSelector } from '~/hooks/use-redux'
 import usePagination from '~/hooks/table/use-pagination'
 import useQuery from '~/hooks/use-query'
 import useSort from '~/hooks/table/use-sort'
@@ -39,7 +38,6 @@ const MyCooperations = () => {
     CardsViewEnum.Inline
   )
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const breakpoints = useBreakpoints()
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab = searchParams.get('tab')
@@ -98,10 +96,6 @@ const MyCooperations = () => {
     title: t(title),
     value
   }))
-
-  useLayoutEffect(() => {
-    void dispatch(setPageLoad(isLoading))
-  }, [dispatch, isLoading])
 
   return (
     <PageWrapper>

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -9,15 +9,29 @@ import {
   CreateOrUpdateNoteParams,
   Offer,
   MyCooperationDetails,
-  UpdateCooperationsSections
+  UpdateCooperationsSections,
+  Cooperation
 } from '~/types'
-import { createUrlPath } from '~/utils/helper-functions'
+import { createUrlPath, getFullUrl } from '~/utils/helper-functions'
+import { baseService } from '~/services/base-service'
 
 export const cooperationService = {
-  getCooperations: async (
-    params: GetCooperationsParams
-  ): Promise<AxiosResponse> =>
-    await axiosClient.get(URLs.cooperations.get, { params }),
+  getCooperations: async (params: GetCooperationsParams) => {
+    const { status, search } = params
+
+    const url = getFullUrl({
+      pathname: URLs.cooperations.get,
+      searchParameters: { status, search }
+    })
+
+    return baseService.request<{
+      items: Cooperation[]
+      count: number
+    }>({
+      method: 'GET',
+      url
+    })
+  },
   createCooperation: async (
     data: CreateCooperationsParams
   ): Promise<AxiosResponse> =>

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -10,7 +10,8 @@ import {
   Offer,
   MyCooperationDetails,
   UpdateCooperationsSections,
-  Cooperation
+  Cooperation,
+  ItemsWithCount
 } from '~/types'
 import { createUrlPath, getFullUrl } from '~/utils/helper-functions'
 import { baseService } from '~/services/base-service'
@@ -24,10 +25,7 @@ export const cooperationService = {
       searchParameters: { status, search }
     })
 
-    return baseService.request<{
-      items: Cooperation[]
-      count: number
-    }>({
+    return baseService.request<ItemsWithCount<Cooperation>>({
       method: 'GET',
       url
     })

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -20,7 +20,7 @@ export const cooperationService = {
   getCooperations: async (params: GetCooperationsParams) => {
     const url = getFullUrl({
       pathname: URLs.cooperations.get,
-      searchParameters: { ...params }
+      searchParameters: params
     })
 
     return baseService.request<ItemsWithCount<Cooperation>>({

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -10,8 +10,8 @@ import {
   Offer,
   MyCooperationDetails,
   UpdateCooperationsSections,
-  Cooperation,
-  ItemsWithCount
+  type Cooperation,
+  type ItemsWithCount
 } from '~/types'
 import { createUrlPath, getFullUrl } from '~/utils/helper-functions'
 import { baseService } from '~/services/base-service'

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -18,11 +18,9 @@ import { baseService } from '~/services/base-service'
 
 export const cooperationService = {
   getCooperations: async (params: GetCooperationsParams) => {
-    const { status, search } = params
-
     const url = getFullUrl({
       pathname: URLs.cooperations.get,
-      searchParameters: { status, search }
+      searchParameters: { ...params }
     })
 
     return baseService.request<ItemsWithCount<Cooperation>>({

--- a/src/types/my-cooperations/interfaces/myCooperations.interfaces.ts
+++ b/src/types/my-cooperations/interfaces/myCooperations.interfaces.ts
@@ -17,9 +17,8 @@ export interface MyCooperationsFilters {
   search: string
 }
 
-export interface GetCooperationsParams
-  extends Partial<MyCooperationsFilters>,
-    RequestParams {}
+export type GetCooperationsParams = Partial<MyCooperationsFilters> &
+  RequestParams
 
 export interface ScreenBasedLimits {
   desktop?: number

--- a/src/types/services/types/services.types.ts
+++ b/src/types/services/types/services.types.ts
@@ -1,7 +1,7 @@
 import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { Sort } from '~/types'
 
-export interface RequestParams {
+export type RequestParams = {
   limit?: number
   skip?: number
   sort?: Sort

--- a/tests/unit/components/active-students/ActiveStudentsBlock.spec.jsx
+++ b/tests/unit/components/active-students/ActiveStudentsBlock.spec.jsx
@@ -2,9 +2,9 @@ import { screen, fireEvent, waitFor } from '@testing-library/react'
 
 import { renderWithProviders } from '~tests/test-utils'
 import ActiveStudentsBlock from '~/components/active-students/ActiveStudentsBlock'
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 
-vi.mock('~/hooks/use-axios')
+vi.mock('~/hooks/use-query')
 
 const navigateMock = vi.fn()
 
@@ -59,33 +59,33 @@ const mockedCooperations = [
 ]
 
 const mockedData = {
-  loading: false,
-  response: {
+  isLoading: false,
+  data: {
     items: mockedCooperations,
     count: 1
   },
-  fetchData: vi.fn()
+  refetch: vi.fn()
 }
 
 const mockedLoading = {
-  loading: true,
+  isLoading: true,
   response: null,
-  fetchData: vi.fn()
+  refetch: vi.fn()
 }
 
 const noCooperationsMock = {
-  loading: false,
-  response: {
+  isLoading: false,
+  data: {
     items: [],
     count: 0
   },
   error: null,
-  fetchData: vi.fn()
+  refetch: vi.fn()
 }
 
 const errorCooperationsMock = {
-  loading: false,
-  response: {
+  isLoading: false,
+  data: {
     items: [],
     count: 0
   },
@@ -94,11 +94,11 @@ const errorCooperationsMock = {
     message: 'cooperation not found',
     status: '404'
   },
-  fetchData: vi.fn()
+  refetch: vi.fn()
 }
 
 describe('ActiveStudentsBlock', () => {
-  useAxios.mockImplementation(() => mockedData)
+  useQuery.mockImplementation(() => mockedData)
 
   it('should render active students', () => {
     renderWithProviders(<ActiveStudentsBlock />)
@@ -124,21 +124,21 @@ describe('ActiveStudentsBlock', () => {
   })
 
   it('should render Loader when loading', () => {
-    useAxios.mockImplementation(() => mockedLoading)
+    useQuery.mockImplementation(() => mockedLoading)
     renderWithProviders(<ActiveStudentsBlock />)
 
     expect(screen.getByTestId('loader')).toBeInTheDocument()
   })
 
   it('should render add student button when no active cooperations available', () => {
-    useAxios.mockImplementation(() => noCooperationsMock)
+    useQuery.mockImplementation(() => noCooperationsMock)
     renderWithProviders(<ActiveStudentsBlock />)
     const addStudent = screen.getByTestId('addStudent')
     expect(addStudent).toBeInTheDocument()
   })
 
   it('should navigate to /categories/subjects/find-offers on add student button click', () => {
-    useAxios.mockImplementation(() => noCooperationsMock)
+    useQuery.mockImplementation(() => noCooperationsMock)
     renderWithProviders(<ActiveStudentsBlock />)
 
     const showMoreButton = screen.getByTestId('addStudent')
@@ -148,7 +148,7 @@ describe('ActiveStudentsBlock', () => {
   })
 
   it('should not render on error', () => {
-    useAxios.mockImplementation(() => errorCooperationsMock)
+    useQuery.mockImplementation(() => errorCooperationsMock)
     renderWithProviders(<ActiveStudentsBlock />)
 
     expect(screen.queryByText('activeStudents.title')).not.toBeInTheDocument()


### PR DESCRIPTION
Replaced the `useAxios` hook with a custom `useQuery` hook on the My Cooperations page to improve data fetching, caching, and error handling. Also, I did the same in the Active Students block because it uses the same service.


<img width="1709" alt="Screenshot 2025-01-01 at 18 09 40" src="https://github.com/user-attachments/assets/481cf938-f1ec-43b6-a3f3-405568f66e4e" />


<img width="1728" alt="Screenshot 2025-01-01 at 18 10 05" src="https://github.com/user-attachments/assets/948f2365-3c3e-47a6-be71-3f95451039bd" />

