### PR TITLE
Fixed type errors in QuizSettingsContainer

### DIFF
--- a/src/containers/my-quizzes/quiz-settings-container/QuizSettingsContainer.tsx
+++ b/src/containers/my-quizzes/quiz-settings-container/QuizSettingsContainer.tsx
@@ -30,7 +30,8 @@ import {
   Quiz,
   QuizTabsEnum,
   ComponentEnum,
-  QuizSettings
+  QuizSettings,
+  ResourcesTypesEnum
 } from '~/types'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
@@ -102,7 +103,7 @@ const QuizSettingsContainer = ({
   const { fetchData: createQuiz } = useAxios<Quiz, CreateQuizParams>({
     service: createQuizService,
     fetchOnMount: false,
-    defaultResponse,
+    defaultResponse: { ...defaultResponse, id: '' },
     onResponse,
     onResponseError
   })
@@ -117,8 +118,10 @@ const QuizSettingsContainer = ({
               title,
               description,
               items: questions,
-              category,
-              settings: data
+              category: { _id: '', name: category as string },
+              settings: data,
+              id: '',
+              resourceType: ResourcesTypesEnum.Quiz
             })
       }
     })


### PR DESCRIPTION
Fixed type errors in QuizSettingsContainer. There were some missing properties that were required by createQuiz function, and in defaultResponse there was no id passed.

Erros in code before the fix:
![image](https://github.com/user-attachments/assets/230e54af-670e-443f-aaf4-fca666f91f9e)
Logs:
![image](https://github.com/user-attachments/assets/b97077b0-a1e1-4761-878b-376b1120a2b4)
