### PR TITLE
Replaced useAxios hook with useQuery on CompleteProfileBlock

### DIFF
--- a/src/components/complete-profile/CompleteProfileBlock.tsx
+++ b/src/components/complete-profile/CompleteProfileBlock.tsx
@@ -61,19 +61,13 @@ const CompleteProfileBlock: FC<CompleteProfileBlockProps> = ({
     [userId]
   )
 
-  const { data: queryData, refetch } = useQuery({
-    queryKey: ['complete-profile-block', userId],
+  const { data: queryData } = useQuery({
+    queryKey: ['complete-profile-block', userId, isOfferCreated],
     queryFn: async () => {
       const response = await getMyOffers()
       return response.data as { items: Offer[]; count: number }
     }
   })
-
-  useEffect(() => {
-    if (isOfferCreated) {
-      void refetch()
-    }
-  }, [isOfferCreated, refetch])
 
   const checkIfHasNonEmptyFields = (
     obj: Record<string, string | undefined>

--- a/src/components/complete-profile/CompleteProfileBlock.tsx
+++ b/src/components/complete-profile/CompleteProfileBlock.tsx
@@ -19,7 +19,7 @@ import { authRoutes } from '~/router/constants/authRoutes'
 import { guestRoutes } from '~/router/constants/guestRoutes'
 import { ProfileItemType } from '../profile-item/complete-profile.constants'
 import { useAppSelector } from '~/hooks/use-redux'
-import { Offer, UserResponse, UserRole, VideoUserRole } from '~/types'
+import { UserResponse, UserRole, VideoUserRole } from '~/types'
 import { styles } from '~/components/complete-profile/CompleteProfileBlock.styles'
 import { OfferService } from '~/services/offer-service'
 import { useDrawer } from '~/hooks/use-drawer'
@@ -53,12 +53,13 @@ const CompleteProfileBlock: FC<CompleteProfileBlockProps> = ({
     }
   }, [openAccordion])
 
-  const getMyOffers = useCallback(async () => {
-    const response = await OfferService.getUsersOffers({
-      id: userId
-    })
-    return response.data as { items: Offer[]; count: number }
-  }, [userId])
+  const getMyOffers = useCallback(
+    () =>
+      OfferService.getUsersOffers({
+        id: userId
+      }),
+    [userId]
+  )
 
   const { data: queryData } = useQuery({
     queryKey: ['complete-profile-block', userId, isOfferCreated],

--- a/src/components/complete-profile/CompleteProfileBlock.tsx
+++ b/src/components/complete-profile/CompleteProfileBlock.tsx
@@ -19,14 +19,13 @@ import { authRoutes } from '~/router/constants/authRoutes'
 import { guestRoutes } from '~/router/constants/guestRoutes'
 import { ProfileItemType } from '../profile-item/complete-profile.constants'
 import { useAppSelector } from '~/hooks/use-redux'
-import { UserResponse, UserRole, VideoUserRole } from '~/types'
+import { Offer, UserResponse, UserRole, VideoUserRole } from '~/types'
 import { styles } from '~/components/complete-profile/CompleteProfileBlock.styles'
-import useAxios from '~/hooks/use-axios'
 import { OfferService } from '~/services/offer-service'
-import { defaultResponse } from '~/pages/my-offers/MyOffers.constants'
 import { useDrawer } from '~/hooks/use-drawer'
 import AppDrawer from '~/components/app-drawer/AppDrawer'
 import CreateOffer from '~/containers/offer-page/create-offer/CreateOffer'
+import useQuery from '~/hooks/use-query'
 
 interface CompleteProfileBlockProps {
   profileItems: ProfileItemType[]
@@ -62,16 +61,19 @@ const CompleteProfileBlock: FC<CompleteProfileBlockProps> = ({
     [userId]
   )
 
-  const { response, fetchData } = useAxios({
-    service: getMyOffers,
-    defaultResponse
+  const { data: queryData, refetch } = useQuery({
+    queryKey: ['complete-profile-block', userId],
+    queryFn: async () => {
+      const response = await getMyOffers()
+      return response.data as { items: Offer[]; count: number }
+    }
   })
 
   useEffect(() => {
     if (isOfferCreated) {
-      void fetchData()
+      void refetch()
     }
-  }, [isOfferCreated, fetchData])
+  }, [isOfferCreated, refetch])
 
   const checkIfHasNonEmptyFields = (
     obj: Record<string, string | undefined>
@@ -95,12 +97,12 @@ const CompleteProfileBlock: FC<CompleteProfileBlockProps> = ({
           case 'video':
             return data.videoLink?.[userRole as VideoUserRole]
           case 'offer':
-            return response.items.length
+            return queryData?.items.length
           default:
             return data[item.id as keyof UserResponse]
         }
       }),
-    [data, profileItems, response, userRole]
+    [data, profileItems, queryData, userRole]
   )
 
   const valueProgressBar = Math.floor(

--- a/src/components/complete-profile/CompleteProfileBlock.tsx
+++ b/src/components/complete-profile/CompleteProfileBlock.tsx
@@ -53,20 +53,16 @@ const CompleteProfileBlock: FC<CompleteProfileBlockProps> = ({
     }
   }, [openAccordion])
 
-  const getMyOffers = useCallback(
-    () =>
-      OfferService.getUsersOffers({
-        id: userId
-      }),
-    [userId]
-  )
+  const getMyOffers = useCallback(async () => {
+    const response = await OfferService.getUsersOffers({
+      id: userId
+    })
+    return response.data as { items: Offer[]; count: number }
+  }, [userId])
 
   const { data: queryData } = useQuery({
     queryKey: ['complete-profile-block', userId, isOfferCreated],
-    queryFn: async () => {
-      const response = await getMyOffers()
-      return response.data as { items: Offer[]; count: number }
-    }
+    queryFn: getMyOffers
   })
 
   const checkIfHasNonEmptyFields = (

--- a/src/components/complete-profile/CompleteProfileBlock.tsx
+++ b/src/components/complete-profile/CompleteProfileBlock.tsx
@@ -26,6 +26,7 @@ import { useDrawer } from '~/hooks/use-drawer'
 import AppDrawer from '~/components/app-drawer/AppDrawer'
 import CreateOffer from '~/containers/offer-page/create-offer/CreateOffer'
 import useQuery from '~/hooks/use-query'
+import { defaultResponse } from '~/pages/my-offers/MyOffers.constants'
 
 interface CompleteProfileBlockProps {
   profileItems: ProfileItemType[]
@@ -63,7 +64,10 @@ const CompleteProfileBlock: FC<CompleteProfileBlockProps> = ({
 
   const { data: queryData } = useQuery({
     queryKey: ['complete-profile-block', userId, isOfferCreated],
-    queryFn: getMyOffers
+    queryFn: getMyOffers,
+    options: {
+      initialData: defaultResponse
+    }
   })
 
   const checkIfHasNonEmptyFields = (

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -24,7 +24,8 @@ export const URLs = {
     deactivate: '/users/deactivate',
     activate: '/users/activate',
     myProfile: '/users/myProfile',
-    bookmarks: '/bookmarks/offers'
+    bookmarks: '/bookmarks/offers',
+    offers: '/users/:id/offers'
   },
   offers: {
     create: '/offers',

--- a/src/pages/my-offers/MyOffers.tsx
+++ b/src/pages/my-offers/MyOffers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Box from '@mui/material/Box'
@@ -17,10 +17,9 @@ import { useSearchParams } from 'react-router-dom'
 import useFilter from '~/hooks/table/use-filter'
 import usePagination from '~/hooks/table/use-pagination'
 import useSort from '~/hooks/table/use-sort'
-import useAxios from '~/hooks/use-axios'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { useDrawer } from '~/hooks/use-drawer'
-import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
+import { useAppSelector } from '~/hooks/use-redux'
 import { OfferService } from '~/services/offer-service'
 import { getScreenBasedLimit } from '~/utils/helper-functions'
 
@@ -34,7 +33,7 @@ import {
   tabsInfo
 } from '~/pages/my-offers/MyOffers.constants'
 import { CardsViewEnum } from '~/types'
-import { setPageLoad } from '~/redux/reducer'
+import { useQuery } from '@tanstack/react-query'
 
 type TabName = keyof typeof tabsInfo
 
@@ -43,7 +42,6 @@ const MyOffers = () => {
     CardsViewEnum.Inline
   )
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const breakpoints = useBreakpoints()
   const [searchParams, setSearchParams] = useSearchParams()
   const activeTab = searchParams.get('tab')
@@ -88,9 +86,12 @@ const MyOffers = () => {
     [userId, filters, page, itemsPerPage, sort]
   )
 
-  const { loading, response } = useAxios({
-    service: getMyOffers,
-    defaultResponse
+  const { isLoading, data } = useQuery({
+    queryKey: ['offers', userId, filters, sort, page],
+    queryFn: getMyOffers,
+    options: {
+      initialData: defaultResponse
+    }
   })
 
   const handleTabClick = (tabName: string, tabValue: string) => {
@@ -104,10 +105,6 @@ const MyOffers = () => {
     title: t(title),
     value
   }))
-
-  useLayoutEffect(() => {
-    void dispatch(setPageLoad(loading))
-  }, [dispatch, loading])
 
   return (
     <PageWrapper>
@@ -136,19 +133,19 @@ const MyOffers = () => {
         view={itemsView}
         withoutSort={showTable}
       />
-      {loading ? (
+      {isLoading ? (
         <Loader pageLoad size={50} />
       ) : (
         <>
           <MyOffersContainer
-            items={response.items}
+            items={data.items}
             showTable={showTable}
             sort={sortOptions}
           />
           <AppPagination
             onChange={handleChangePage}
             page={page}
-            pageCount={Math.ceil(response.count / itemsPerPage)}
+            pageCount={Math.ceil(data.count / itemsPerPage)}
             sx={styles.pagination}
           />
         </>

--- a/src/pages/my-offers/MyOffers.tsx
+++ b/src/pages/my-offers/MyOffers.tsx
@@ -33,7 +33,7 @@ import {
   tabsInfo
 } from '~/pages/my-offers/MyOffers.constants'
 import { CardsViewEnum } from '~/types'
-import { useQuery } from '@tanstack/react-query'
+import useQuery from '~/hooks/use-query'
 
 type TabName = keyof typeof tabsInfo
 

--- a/src/services/offer-service.ts
+++ b/src/services/offer-service.ts
@@ -34,9 +34,9 @@ export const OfferService = {
     await axiosClient.get(createUrlPath(URLs.offers.get, id)),
 
   getUsersOffers: (params: GetMyOffersParams) => {
-    const user = createUrlPath(URLs.users.get, params.id)
     const resultUrl = getFullUrl({
-      pathname: `${user}${URLs.offers.get}`,
+      pathname: URLs.users.offers,
+      parameters: { id: params.id },
       searchParameters: params
     })
     return baseService.request<ItemsWithCount<Offer>>({

--- a/src/services/offer-service.ts
+++ b/src/services/offer-service.ts
@@ -1,15 +1,17 @@
 import { AxiosResponse } from 'axios'
 import { URLs } from '~/constants/request'
 import { axiosClient } from '~/plugins/axiosClient'
-import { createUrlPath } from '~/utils/helper-functions'
+import { createUrlPath, getFullUrl } from '~/utils/helper-functions'
 import {
   Offer,
   PriceRangeParams,
   PriceRangeResponse,
   GetOffersParams,
   CreateOrUpdateOfferData,
-  GetMyOffersParams
+  GetMyOffersParams,
+  ItemsWithCount
 } from '~/types'
+import { baseService } from './base-service'
 
 export const OfferService = {
   getOffers: async (params?: GetOffersParams): Promise<AxiosResponse> => {
@@ -31,9 +33,17 @@ export const OfferService = {
   getOffer: async (id: string): Promise<AxiosResponse<Offer>> =>
     await axiosClient.get(createUrlPath(URLs.offers.get, id)),
 
-  getUsersOffers: async (params: GetMyOffersParams): Promise<AxiosResponse> => {
+  getUsersOffers: (params: GetMyOffersParams) => {
+    const { sort, ...rest } = params
     const user = createUrlPath(URLs.users.get, params.id)
-    return await axiosClient.get(`${user}${URLs.offers.get}`, { params })
+    const resultUrl = getFullUrl({
+      pathname: `${user}${URLs.offers.get}`,
+      searchParameters: { ...sort, ...rest }
+    })
+    return baseService.request<ItemsWithCount<Offer>>({
+      method: 'GET',
+      url: resultUrl
+    })
   },
 
   getPriceRange: async (

--- a/src/services/offer-service.ts
+++ b/src/services/offer-service.ts
@@ -34,11 +34,10 @@ export const OfferService = {
     await axiosClient.get(createUrlPath(URLs.offers.get, id)),
 
   getUsersOffers: (params: GetMyOffersParams) => {
-    const { sort, ...rest } = params
     const user = createUrlPath(URLs.users.get, params.id)
     const resultUrl = getFullUrl({
       pathname: `${user}${URLs.offers.get}`,
-      searchParameters: { ...sort, ...rest }
+      searchParameters: { ...params }
     })
     return baseService.request<ItemsWithCount<Offer>>({
       method: 'GET',

--- a/src/services/offer-service.ts
+++ b/src/services/offer-service.ts
@@ -37,7 +37,7 @@ export const OfferService = {
     const user = createUrlPath(URLs.users.get, params.id)
     const resultUrl = getFullUrl({
       pathname: `${user}${URLs.offers.get}`,
-      searchParameters: { ...params }
+      searchParameters: params
     })
     return baseService.request<ItemsWithCount<Offer>>({
       method: 'GET',

--- a/src/types/my-offers/interfaces/myOffers.interfaces.ts
+++ b/src/types/my-offers/interfaces/myOffers.interfaces.ts
@@ -1,8 +1,7 @@
 import { RequestParams } from '~/types/services/services.index'
 import { MyCooperationsFilters, Offer } from '~/types'
 
-export interface GetMyOffersParams
-  extends Partial<MyCooperationsFilters>,
-    RequestParams {
-  id: Offer['author']['_id']
-}
+export type GetMyOffersParams = Partial<MyCooperationsFilters> &
+  RequestParams & {
+    id: Offer['author']['_id']
+  }

--- a/tests/unit/components/complete-profile/CompleteProfileBlock.spec.jsx
+++ b/tests/unit/components/complete-profile/CompleteProfileBlock.spec.jsx
@@ -6,9 +6,9 @@ import {
   profileItemsStudent
 } from '~/components/profile-item/complete-profile.constants'
 import { renderWithProviders } from '~tests/test-utils'
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 
-vi.mock('~/hooks/use-axios')
+vi.mock('~/hooks/use-query')
 vi.mock('~/services/offer-service')
 
 const badRoute = '/tutor/myProfile'
@@ -47,8 +47,8 @@ const mockDataEmpty = {
 
 describe('CompleteProfile test when user data is filled', () => {
   beforeEach(() => {
-    useAxios.mockReturnValue({
-      response: { items: ['item1'], count: 1 },
+    useQuery.mockReturnValue({
+      data: { items: ['item1'], count: 1 },
       loading: false
     })
   })
@@ -88,8 +88,8 @@ describe('CompleteProfile test when user data is filled', () => {
 
 describe('CompleteProfile test when user data is empty', () => {
   beforeEach(() => {
-    useAxios.mockReturnValue({
-      response: { items: [], count: 0 },
+    useQuery.mockReturnValue({
+      data: { items: [], count: 0 },
       loading: false
     })
   })

--- a/tests/unit/components/complete-profile/CompleteProfileBlock.spec.jsx
+++ b/tests/unit/components/complete-profile/CompleteProfileBlock.spec.jsx
@@ -1,5 +1,5 @@
 import { vi } from 'vitest'
-import { screen, fireEvent } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import CompleteProfileBlock from '~/components/complete-profile/CompleteProfileBlock'
 import {
   profileItemsTutor,
@@ -7,6 +7,7 @@ import {
 } from '~/components/profile-item/complete-profile.constants'
 import { renderWithProviders } from '~tests/test-utils'
 import useQuery from '~/hooks/use-query'
+import { OfferService } from '~/services/offer-service'
 
 vi.mock('~/hooks/use-query')
 vi.mock('~/services/offer-service')
@@ -44,6 +45,35 @@ const mockDataEmpty = {
     tutor: ''
   }
 }
+
+describe('getUsersOffers should return correct response', () => {
+  it('should call getUsersOffers and return data', async () => {
+    OfferService.getUsersOffers.mockResolvedValue({
+      data: { items: [{ title: 'Mock offer', price: 100 }], count: 1 }
+    })
+
+    useQuery.mockImplementation(({ queryFn }) => ({
+      queryData: queryFn(),
+      isLoading: false,
+      error: null
+    }))
+
+    renderWithProviders(
+      <CompleteProfileBlock
+        data={mockDataFilled}
+        profileItems={profileItemsTutor}
+      />,
+      {
+        initialEntries: badRoute,
+        preloadedState: { appMain: { userRole: 'tutor' } }
+      }
+    )
+
+    await waitFor(() => {
+      expect(OfferService.getUsersOffers).toHaveBeenCalled()
+    })
+  })
+})
 
 describe('CompleteProfile test when user data is filled', () => {
   beforeEach(() => {

--- a/tests/unit/components/complete-profile/CompleteProfileBlock.spec.jsx
+++ b/tests/unit/components/complete-profile/CompleteProfileBlock.spec.jsx
@@ -48,8 +48,7 @@ const mockDataEmpty = {
 describe('CompleteProfile test when user data is filled', () => {
   beforeEach(() => {
     useQuery.mockReturnValue({
-      data: { items: ['item1'], count: 1 },
-      loading: false
+      data: { items: ['item1'], count: 1 }
     })
   })
 
@@ -89,8 +88,7 @@ describe('CompleteProfile test when user data is filled', () => {
 describe('CompleteProfile test when user data is empty', () => {
   beforeEach(() => {
     useQuery.mockReturnValue({
-      data: { items: [], count: 0 },
-      loading: false
+      data: { items: [], count: 0 }
     })
   })
 


### PR DESCRIPTION
Replaced useAxios hook with useQuery hook on CompleteProfileBlock. Replaced logic for getting offers using useQuery instead of useAxios hook. Adjusted tests for new fetching logic. It is working as expected. 
![image](https://github.com/user-attachments/assets/24a0ed88-94a4-44dc-927d-31382a79ad53)

Replaced useAxios hook with useQuery hook on MyOffers page. Replaced logic for getting offers using useQuery instead of useAxios hook. Adjusted tests for new fetching logic. It is working as expected. 
![image](https://github.com/user-attachments/assets/ea1334e5-1151-48a0-8c9b-ea5062a4224a)
