### PR TITLE
Added tests for Deactivate account

### DIFF
--- a/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
@@ -2,7 +2,8 @@ import { vi } from 'vitest'
 import {
   screen,
   fireEvent,
-  waitForElementToBeRemoved
+  waitForElementToBeRemoved,
+  within
 } from '@testing-library/react'
 import { renderWithProviders, TestSnackbar } from '~tests/test-utils'
 import PasswordSecurityTab from '~/containers/edit-profile/password-security-tab/PasswordSecurityTab'
@@ -92,5 +93,51 @@ describe('PasswordSecurityTab', () => {
     })
 
     expect(deactivateDescription).not.toBeInTheDocument()
+  })
+  it('should open the modal when clicking the Deactivate account button', async () => {
+    const deactivateAccountButton = screen.getByText(
+      'editProfilePage.profile.passwordSecurityTab.deactivateAccount'
+    )
+    fireEvent.click(deactivateAccountButton)
+
+    const modal = screen.getByRole('dialog')
+    const deactivateTitle = within(modal).getByText(
+      'editProfilePage.profile.passwordSecurityTab.deactivateTitle'
+    )
+    const deactivateDescription = within(modal).getByText(
+      'editProfilePage.profile.passwordSecurityTab.deactivateDescription'
+    )
+    expect(deactivateTitle).toBeInTheDocument()
+    expect(deactivateDescription).toBeInTheDocument()
+  })
+  it('should render Deactivate and Cancel buttons in the modal', async () => {
+    const deactivateAccountButton = screen.getByText(
+      'editProfilePage.profile.passwordSecurityTab.deactivateAccount'
+    )
+    fireEvent.click(deactivateAccountButton)
+  
+    const deactivateButton = screen.getByText('editProfilePage.profile.passwordSecurityTab.deactivateBtn')
+    const cancelButton = screen.getByText('common.cancel')
+  
+    expect(deactivateButton).toBeInTheDocument()
+    expect(cancelButton).toBeInTheDocument()
+  })  
+  it('should close modal on Deactivate button click and stays on Password & Security tab', async () => {
+    const deactivateAccountButton = screen.getByText(
+      'editProfilePage.profile.passwordSecurityTab.deactivateAccount'
+    )
+    fireEvent.click(deactivateAccountButton)
+  
+    const deactivateButton = screen.getByText('editProfilePage.profile.passwordSecurityTab.deactivateBtn')
+    fireEvent.click(deactivateButton)
+  
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText('editProfilePage.profile.passwordSecurityTab.deactivateDescription')
+    )
+  
+    const tabTitle = screen.getByText(
+      'editProfilePage.profile.passwordSecurityTab.title'
+    )
+    expect(tabTitle).toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
@@ -122,7 +122,7 @@ describe('PasswordSecurityTab', () => {
     expect(deactivateButton).toBeInTheDocument()
     expect(cancelButton).toBeInTheDocument()
   })  
-  it('should close modal on Deactivate button click and stays on Password & Security tab', async () => {
+  it('should close modal on Cancel button click and stays on Password & Security tab', async () => {
     const deactivateAccountButton = screen.getByText(
       'editProfilePage.profile.passwordSecurityTab.deactivateAccount'
     )
@@ -132,7 +132,7 @@ describe('PasswordSecurityTab', () => {
     fireEvent.click(deactivateButton)
   
     await waitForElementToBeRemoved(() =>
-      screen.queryByText('editProfilePage.profile.passwordSecurityTab.deactivateDescription')
+      screen.getByText('common.cancel')
     )
   
     const tabTitle = screen.getByText(

--- a/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
@@ -128,13 +128,9 @@ describe('PasswordSecurityTab', () => {
     )
     fireEvent.click(deactivateAccountButton)
   
-    const deactivateButton = screen.getByText('editProfilePage.profile.passwordSecurityTab.deactivateBtn')
-    fireEvent.click(deactivateButton)
-  
-    await waitForElementToBeRemoved(() =>
-      screen.getByText('common.cancel')
-    )
-  
+    const cancelButton = screen.getByText('common.cancel')
+    fireEvent.click(cancelButton)
+    
     const tabTitle = screen.getByText(
       'editProfilePage.profile.passwordSecurityTab.title'
     )


### PR DESCRIPTION
Verified:
1) opening the modal when clicking the `Deactivate account` button;
2) rendering `Deactivate` and `Cancel` buttons in the modal;
3) closing modal on `Cancel` button click and stays on `Password & Security` tab.

Issue: #2779 