### PR TITLE
Enhance useQuery hook

### DIFF
--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './response-error'

--- a/src/exceptions/response-error.ts
+++ b/src/exceptions/response-error.ts
@@ -1,0 +1,15 @@
+import { type ErrorResponse } from '~/types'
+
+class ResponseError extends Error {
+  code?: string
+  status?: number
+
+  constructor({ code, message, status }: Partial<ErrorResponse>) {
+    super(message)
+
+    this.code = code
+    this.status = status
+  }
+}
+
+export { ResponseError }

--- a/src/hooks/use-query.tsx
+++ b/src/hooks/use-query.tsx
@@ -8,7 +8,7 @@ import {
   useQuery as useReactQuery
 } from '@tanstack/react-query'
 
-import { type ResponseError } from '~/types'
+import { type ResponseError } from '~/exceptions'
 
 type RequiredQueryOptions = 'queryFn' | 'queryKey'
 type OptionalQueryOptions = 'enabled' | 'initialData' | 'select' | 'staleTime'

--- a/src/hooks/use-query.tsx
+++ b/src/hooks/use-query.tsx
@@ -1,28 +1,104 @@
 import {
-  useQuery as useReactQuery,
-  QueryKey,
-  UseQueryOptions
+  type DefinedInitialDataOptions,
+  type DefinedUseQueryResult,
+  type QueryKey,
+  type UndefinedInitialDataOptions,
+  type UseQueryOptions,
+  type UseQueryResult,
+  useQuery as useReactQuery
 } from '@tanstack/react-query'
-import { ErrorResponse } from '~/types'
 
-interface UseQueryProps<TData, TError, TSelect> {
-  queryKey: QueryKey
-  queryFn: () => Promise<TData>
-  options?: UseQueryOptions<TData, TError, TSelect>
-}
+import { type ResponseError } from '~/types'
 
-const useQuery = <TData, TError = ErrorResponse, TSelect = TData>({
-  queryKey,
-  queryFn,
-  options
-}: UseQueryProps<TData, TError, TSelect>) => {
-  const query = useReactQuery<TData, TError, TSelect>({
-    queryKey,
-    queryFn,
-    ...options
-  })
+type RequiredQueryOptions = 'queryFn' | 'queryKey'
+type OptionalQueryOptions = 'enabled' | 'initialData' | 'select' | 'staleTime'
+type ReturningQueryParams =
+  | 'data'
+  | 'error'
+  | 'isError'
+  | 'isFetching'
+  | 'isLoading'
+  | 'refetch'
 
-  return query
+type RequiredQueryProperties<
+  TQueryFnData,
+  TError = ResponseError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+> = Required<
+  Pick<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    RequiredQueryOptions
+  >
+>
+
+type Properties<
+  TQueryFnData,
+  TError = ResponseError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+> = {
+  options?: Pick<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+    OptionalQueryOptions
+  >
+} & RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
+
+function useQuery<
+  TQueryFnData,
+  TError = ResponseError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  properties: {
+    options: Pick<
+      DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+      OptionalQueryOptions
+    >
+  } & RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
+): Pick<DefinedUseQueryResult<TData, TError>, ReturningQueryParams>
+
+function useQuery<
+  TQueryFnData,
+  TError = ResponseError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  properties: {
+    options: Pick<
+      UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+      OptionalQueryOptions
+    >
+  } & RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
+): Pick<UseQueryResult<TData, TError>, ReturningQueryParams>
+
+function useQuery<
+  TQueryFnData,
+  TError = ResponseError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  properties: RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
+): Pick<UseQueryResult<TData, TError>, ReturningQueryParams>
+
+function useQuery<
+  TQueryFnData,
+  TError = ResponseError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey
+>(
+  properties: Properties<TQueryFnData, TError, TData, TQueryKey>
+): Pick<UseQueryResult<TData, TError>, ReturningQueryParams> {
+  const { options, queryFn, queryKey } = properties
+
+  const { data, error, isError, isFetching, isLoading, refetch } =
+    useReactQuery<TQueryFnData, TError, TData, TQueryKey>({
+      queryFn,
+      queryKey,
+      ...options
+    })
+
+  return { data, error, isError, isFetching, isLoading, refetch }
 }
 
 export default useQuery

--- a/src/hooks/use-query.tsx
+++ b/src/hooks/use-query.tsx
@@ -44,6 +44,16 @@ type Properties<
   >
 } & RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
 
+type DefaultUseQueryResult<TData, TError> = Pick<
+  UseQueryResult<TData, TError>,
+  ReturningQueryParams
+>
+
+type UseQueryResultWithInitialData<TData, TError> = Pick<
+  DefinedUseQueryResult<TData, TError>,
+  ReturningQueryParams
+>
+
 function useQuery<
   TQueryFnData,
   TError = ResponseError,
@@ -56,7 +66,7 @@ function useQuery<
       OptionalQueryOptions
     >
   } & RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
-): Pick<DefinedUseQueryResult<TData, TError>, ReturningQueryParams>
+): UseQueryResultWithInitialData<TData, TError>
 
 function useQuery<
   TQueryFnData,
@@ -70,7 +80,7 @@ function useQuery<
       OptionalQueryOptions
     >
   } & RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
-): Pick<UseQueryResult<TData, TError>, ReturningQueryParams>
+): DefaultUseQueryResult<TData, TError>
 
 function useQuery<
   TQueryFnData,
@@ -79,7 +89,7 @@ function useQuery<
   TQueryKey extends QueryKey = QueryKey
 >(
   properties: RequiredQueryProperties<TQueryFnData, TError, TData, TQueryKey>
-): Pick<UseQueryResult<TData, TError>, ReturningQueryParams>
+): DefaultUseQueryResult<TData, TError>
 
 function useQuery<
   TQueryFnData,
@@ -88,7 +98,7 @@ function useQuery<
   TQueryKey extends QueryKey = QueryKey
 >(
   properties: Properties<TQueryFnData, TError, TData, TQueryKey>
-): Pick<UseQueryResult<TData, TError>, ReturningQueryParams> {
+): DefaultUseQueryResult<TData, TError> {
   const { options, queryFn, queryKey } = properties
 
   const { data, error, isError, isFetching, isLoading, refetch } =

--- a/src/types/services/types/services.types.ts
+++ b/src/types/services/types/services.types.ts
@@ -21,15 +21,3 @@ export type ServiceFunction<Response, Params = undefined> = (
 export interface AxiosResponseError extends AxiosError<ErrorResponse> {
   config: InternalAxiosRequestConfig & { _isRetry: boolean }
 }
-
-export class ResponseError extends Error {
-  code?: string
-  status?: number
-
-  constructor({ code, message, status }: Partial<ErrorResponse>) {
-    super(message)
-
-    this.code = code
-    this.status = status
-  }
-}

--- a/src/types/services/types/services.types.ts
+++ b/src/types/services/types/services.types.ts
@@ -21,3 +21,15 @@ export type ServiceFunction<Response, Params = undefined> = (
 export interface AxiosResponseError extends AxiosError<ErrorResponse> {
   config: InternalAxiosRequestConfig & { _isRetry: boolean }
 }
+
+export class ResponseError extends Error {
+  code?: string
+  status?: number
+
+  constructor({ code, message, status }: Partial<ErrorResponse>) {
+    super(message)
+
+    this.code = code
+    this.status = status
+  }
+}

--- a/tests/unit/exceptions/response-error.spec.js
+++ b/tests/unit/exceptions/response-error.spec.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { ResponseError } from '~/exceptions'
+
+describe('ResponseError', () => {
+  it('should create ResponseError exception with all options', () => {
+    const errorData = {
+      code: 'UNKNOWN_ERROR',
+      message: 'UNKNOWN_ERROR_MESSAGE',
+      status: 400
+    }
+
+    const error = new ResponseError(errorData)
+
+    expect(error).toBeInstanceOf(ResponseError)
+    expect(error.message).toBe(errorData.message)
+    expect(error.code).toBe(errorData.code)
+    expect(error.status).toBe(errorData.status)
+  })
+
+  it('should create ResponseError exception with required options', () => {
+    const errorData = {
+      message: 'UNKNOWN_ERROR_MESSAGE'
+    }
+
+    const error = new ResponseError(errorData)
+
+    expect(error).toBeInstanceOf(ResponseError)
+    expect(error.message).toBe(errorData.message)
+    expect(error.code).toBeUndefined()
+    expect(error.status).toBeUndefined()
+  })
+
+  it('should be instance of default Error exception', () => {
+    const errorData = {
+      message: 'UNKNOWN_ERROR_MESSAGE'
+    }
+
+    const error = new ResponseError(errorData)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error.name).toBe('Error')
+  })
+})


### PR DESCRIPTION
### `useQuery` hook can be used with the next properties:
- `queryFn` - async function for querying data (required)
- `queryKey` - an array of unique keys for each `useQuery` call (required)
- `options` - additional properties for query settings (optional)
    - `enabled` - is auto fetching enabled (can be derived from falsy or truthy value)
    - `initialData` - initial value of the query result (should be used if `data` can't be `undefined`)
    - `select` - function for modifying `data` object structure (should be used if data needs to be transformed to another shape)
    - `staleTime` - number of times that query result should be **valid** (if `Infinity` then data is always valid, and fetching will not run). **Do not use with `initialData` because it will maintain `initialData` as a result of the query forever**.
    
### `useQuery` hook returns the next parameters:
- `data` - a result of the query (`undefined` if no `initialData` was provided)
- `error` - an error that was catched by hook (currently it's `ResponseError` class)
- `isError` - `boolean` representation of `error`
- `isFetching` - returns `true` on each run of `queryFn`
- `isLoading` - returns `true` only on the first run of `queryFn`
- `refetch` - function that triggers refetching (if `enabled` is `false` then only `refetch` call can run fetching)

### `data` type behaviour:
- when the `options` prop isn't provided:

  <img width="295" alt="image_2024-12-30_12-49-21" src="https://github.com/user-attachments/assets/749a7627-1e5f-4da5-8d86-fd80df8c681b" />

- when provided an empty `options` prop:

  <img width="283" alt="image_2024-12-30_12-49-53" src="https://github.com/user-attachments/assets/7bcb6ad6-741d-4fc2-a7a5-7f2a91a968e2" />

- when the `select` function is provided:

  <img width="295" alt="image_2024-12-30_12-50-44" src="https://github.com/user-attachments/assets/488e2918-ade3-4ac2-acb2-d8e369c55ad2" />

- when the `initialData` prop is provided:

  <img width="260" alt="image_2024-12-30_12-50-11" src="https://github.com/user-attachments/assets/073b74e3-dff1-4b4f-b169-4c9b52b1fe53" />

- when the `select` and `initialData` are provided:

  <img width="264" alt="image_2024-12-30_12-52-36" src="https://github.com/user-attachments/assets/34355637-e650-469f-875a-8052f85bb791" />

Also created `ResponseError` class that will be used in base service for each HTTP request for consistency:
```typescript
export class ResponseError extends Error {
  code?: string
  status?: number

  constructor({ code, message, status }: Partial<ErrorResponse>) {
    super(message)

    this.code = code
    this.status = status
  }
}
```
