### PR TITLE
Create base service for all HTTP requests

### DIFF
--- a/src/services/base-service.ts
+++ b/src/services/base-service.ts
@@ -1,21 +1,31 @@
-import { isAxiosError } from 'axios'
+import { isAxiosError, type RawAxiosRequestHeaders } from 'axios'
 import { ResponseError } from '~/exceptions'
 import { axiosClient } from '~/plugins/axiosClient'
 import { type ErrorResponse, type HttpMethod } from '~/types'
 
 type RequestParams = {
   data?: unknown
+  headers?: RawAxiosRequestHeaders
   method: HttpMethod
+  timeout?: number
   url: string
 }
 
 export const baseService = {
-  request: async <T = unknown>({ method, url, data }: RequestParams) => {
+  request: async <T = unknown>({
+    data,
+    headers,
+    method,
+    timeout,
+    url
+  }: RequestParams) => {
     try {
       const response = await axiosClient.request<T>({
-        url,
+        data,
+        headers,
         method,
-        data
+        timeout,
+        url
       })
 
       return response.data

--- a/src/services/base-service.ts
+++ b/src/services/base-service.ts
@@ -1,0 +1,35 @@
+import { isAxiosError } from 'axios'
+import { ResponseError } from '~/exceptions'
+import { axiosClient } from '~/plugins/axiosClient'
+import { type ErrorResponse, type HttpMethod } from '~/types'
+
+type RequestParams = {
+  data?: unknown
+  method: HttpMethod
+  url: string
+}
+
+export const baseService = {
+  request: async <T = unknown>({ method, url, data }: RequestParams) => {
+    try {
+      const response = await axiosClient.request<T>({
+        url,
+        method,
+        data
+      })
+
+      return response.data
+    } catch (error) {
+      if (isAxiosError(error) && error.response) {
+        const serverError = error.response.data as ErrorResponse
+
+        throw new ResponseError(serverError)
+      }
+
+      throw new ResponseError({
+        code: 'UNKNOWN_ERROR',
+        message: 'UNKNOWN_ERROR_MESSAGE'
+      })
+    }
+  }
+}

--- a/src/services/setup-interceptors.ts
+++ b/src/services/setup-interceptors.ts
@@ -22,7 +22,7 @@ export const setupInterceptors = (): void => {
     },
     async (error: AxiosResponseError) => {
       if (error.response?.data.code !== 'UNAUTHORIZED') {
-        return Promise.resolve(error)
+        return Promise.reject(error)
       }
 
       const originalRequest = error.config as InternalAxiosRequestConfig

--- a/src/services/setup-interceptors.ts
+++ b/src/services/setup-interceptors.ts
@@ -1,4 +1,9 @@
-import { InternalAxiosRequestConfig, AxiosHeaders, AxiosResponse } from 'axios'
+import {
+  type AxiosResponse,
+  type InternalAxiosRequestConfig,
+  AxiosError,
+  AxiosHeaders
+} from 'axios'
 import { axiosClient } from '~/plugins/axiosClient'
 import i18n from '~/plugins/i18n'
 import { checkAuth } from '~/redux/reducer'
@@ -22,7 +27,15 @@ export const setupInterceptors = (): void => {
     },
     async (error: AxiosResponseError) => {
       if (error.response?.data.code !== 'UNAUTHORIZED') {
-        return Promise.reject(error)
+        return Promise.reject(
+          new AxiosError(
+            error.message,
+            error.code,
+            error.config,
+            error.request,
+            error.response
+          )
+        )
       }
 
       const originalRequest = error.config as InternalAxiosRequestConfig

--- a/src/types/services/types/services.types.ts
+++ b/src/types/services/types/services.types.ts
@@ -21,3 +21,5 @@ export type ServiceFunction<Response, Params = undefined> = (
 export interface AxiosResponseError extends AxiosError<ErrorResponse> {
   config: InternalAxiosRequestConfig & { _isRetry: boolean }
 }
+
+export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE'

--- a/tests/unit/services/base-service.spec.js
+++ b/tests/unit/services/base-service.spec.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { ResponseError } from '~/exceptions'
+import { baseService } from '~/services/base-service'
+import { mockAxiosClient } from '~tests/test-utils'
+
+const TEST_URL = '/some-url'
+
+const SUCCESSFUL_RESPONSE_DATA = {
+  count: 0,
+  items: []
+}
+
+const SERVER_ERROR_RESPONSE_DATA = {
+  code: 'BAD_REQUEST',
+  message:
+    'The request could not be processed due to invalid or missing parameters.',
+  status: 400
+}
+
+const UNKNOWN_ERROR = {
+  code: 'UNKNOWN_ERROR',
+  message: 'UNKNOWN_ERROR_MESSAGE'
+}
+
+describe('baseService tests', () => {
+  it('should return parsed response data on a successful request', async () => {
+    mockAxiosClient.onGet(TEST_URL).reply(200, SUCCESSFUL_RESPONSE_DATA)
+
+    const data = await baseService.request({ method: 'GET', url: TEST_URL })
+
+    expect(data).toEqual(SUCCESSFUL_RESPONSE_DATA)
+  })
+
+  it('should throw a ResponseError on a response with a failed request', async () => {
+    mockAxiosClient.onGet(TEST_URL).reply(400, SERVER_ERROR_RESPONSE_DATA)
+
+    try {
+      await baseService.request({ method: 'GET', url: TEST_URL })
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResponseError)
+
+      expect(error.message).toBe(SERVER_ERROR_RESPONSE_DATA.message)
+      expect(error.code).toBe(SERVER_ERROR_RESPONSE_DATA.code)
+      expect(error.status).toBe(SERVER_ERROR_RESPONSE_DATA.status)
+    }
+  })
+
+  it('should throw an unknown ResponseError on a non-axios error', async () => {
+    mockAxiosClient.onGet(TEST_URL).networkError()
+
+    try {
+      await baseService.request({ method: 'GET', url: TEST_URL })
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResponseError)
+
+      expect(error.message).toBe(UNKNOWN_ERROR.message)
+      expect(error.code).toBe(UNKNOWN_ERROR.code)
+      expect(error.status).toBe(undefined)
+    }
+  })
+})


### PR DESCRIPTION
`baseService` contains only one function - `request` with the following parameters:
 - `method` - can be one of: `GET`, `POST`, `PATCH` or `DELETE` (required)
 - `url` - request url with dynamic and query parameters (required)
 - `data` - body of the request (optional)
 - `headers` - headers of the request (optional)
 - `timeout` - max time of the request in ms (optional)
 
`request` function has one generic parameter (`unknown` by default) which is used to type the response body. 
**It can't be inferred from the statement, so you should always provide a type that represents the data of the response**.

If an error is thrown inside the `baseService`, the error will be transformed into a `ResponseError` exception.

For `baseService` usage, put `baseService.request` function call inside a particular service instead of `axiosClient`, for example:
```typescript
import { URLs } from '~/constants/request'
import { type Country } from '~/types'
import { createUrlPath } from '~/utils/helper-functions'
import { baseService } from './base-service'

export const LocationService = {
  getCountries: () => {
    return baseService.request<Country[]>({
      method: 'GET',
      url: URLs.location.getCountries
    })
  },
  getCities: (country: string) => {
    return baseService.request<string[]>({
      method: 'GET',
      url: createUrlPath(URLs.location.getCities, country)
    })
  }
}

```