### PR TITLE
Replace useAxios with useQuery on AddResources

### DIFF
--- a/src/containers/add-resources/AddResources.tsx
+++ b/src/containers/add-resources/AddResources.tsx
@@ -3,7 +3,8 @@ import { useCallback, useState } from 'react'
 import { useAppDispatch } from '~/hooks/use-redux'
 import useSelect from '~/hooks/table/use-select'
 import useSort from '~/hooks/table/use-sort'
-import useAxios from '~/hooks/use-axios'
+// import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import useBreakpoints from '~/hooks/use-breakpoints'
 
 import { useModalContext } from '~/context/modal-context'
@@ -82,10 +83,26 @@ const AddResources = <T extends CourseResource | Question>({
     [dispatch]
   )
 
-  const { loading, response } = useAxios<ItemsWithCount<T>>({
-    service: getMyResources,
-    defaultResponse: defaultResponses.itemsWithCount,
-    onResponseError
+  // const { loading, response } = useAxios<ItemsWithCount<T>>({
+  //   service: getMyResources,
+  //   defaultResponse: defaultResponses.itemsWithCount,
+  //   onResponseError
+  // })
+
+  const { isLoading: loading, data } = useQuery<
+    ItemsWithCount<T>,
+    ErrorResponse
+  >({
+    queryKey: ['resources'],
+    queryFn: async () => {
+      try {
+        const response = await getMyResources()
+        return response.data
+      } catch (error) {
+        onResponseError(error as ErrorResponse)
+        return defaultResponses.itemsWithCount
+      }
+    }
   })
 
   const onRowClick = useCallback(
@@ -123,7 +140,8 @@ const AddResources = <T extends CourseResource | Question>({
 
   const getItems = useCallback(
     (inputValue: string, selectedCategories: string[]) => {
-      return response.items.filter((item) => {
+      if (!data?.items) return []
+      return data?.items.filter((item) => {
         const titleMatch =
           'title' in item
             ? item.title
@@ -146,7 +164,7 @@ const AddResources = <T extends CourseResource | Question>({
         return titleMatch && categoryMatch
       })
     },
-    [response.items]
+    [data?.items]
   )
 
   const props = {

--- a/src/containers/add-resources/AddResources.tsx
+++ b/src/containers/add-resources/AddResources.tsx
@@ -131,29 +131,30 @@ const AddResources = <T extends CourseResource | Question>({
 
   const getItems = useCallback(
     (inputValue: string, selectedCategories: string[]) => {
-      if (!data?.items) return []
-      return data?.items.filter((item) => {
-        const titleMatch =
-          'title' in item
-            ? item.title
-                .toLocaleLowerCase()
-                .includes(inputValue.toLocaleLowerCase())
-            : item.fileName
-                .toLocaleLowerCase()
-                .split('.')
-                .slice(0, -1)
-                .join('.')
-                .includes(inputValue.toLocaleLowerCase())
+      return (
+        data?.items.filter((item) => {
+          const titleMatch =
+            'title' in item
+              ? item.title
+                  .toLocaleLowerCase()
+                  .includes(inputValue.toLocaleLowerCase())
+              : item.fileName
+                  .toLocaleLowerCase()
+                  .split('.')
+                  .slice(0, -1)
+                  .join('.')
+                  .includes(inputValue.toLocaleLowerCase())
 
-        const categoryId =
-          typeof item.category !== 'string' ? item.category?._id : null
+          const categoryId =
+            typeof item.category !== 'string' ? item.category?._id : null
 
-        const categoryMatch =
-          selectedCategories.length === 0 ||
-          selectedCategories.includes(String(categoryId))
+          const categoryMatch =
+            selectedCategories.length === 0 ||
+            selectedCategories.includes(String(categoryId))
 
-        return titleMatch && categoryMatch
-      })
+          return titleMatch && categoryMatch
+        }) ?? []
+      )
     },
     [data?.items]
   )

--- a/src/containers/add-resources/AddResources.tsx
+++ b/src/containers/add-resources/AddResources.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useState, useEffect } from 'react'
 
 import { useAppDispatch } from '~/hooks/use-redux'
 import useSelect from '~/hooks/table/use-select'
 import useSort from '~/hooks/table/use-sort'
-// import useAxios from '~/hooks/use-axios'
 import useQuery from '~/hooks/use-query'
 import useBreakpoints from '~/hooks/use-breakpoints'
 
@@ -83,36 +82,19 @@ const AddResources = <T extends CourseResource | Question>({
     [dispatch]
   )
 
-  // const { loading, response } = useAxios<ItemsWithCount<T>>({
-  //   service: getMyResources,
-  //   defaultResponse: defaultResponses.itemsWithCount,
-  //   onResponseError
-  // })
-
-  const {
-    isLoading: loading,
-    data
-    // error
-  } = useQuery<ItemsWithCount<T>, ErrorResponse>({
-    queryKey: ['resources', sort],
+  const { data, isLoading, error, isError } = useQuery<ItemsWithCount<T>>({
+    queryKey: ['resources', sort, resourceTab],
     queryFn: async () => {
-      try {
-        const response = await getMyResources()
-        return response.data
-      } catch (error) {
-        onResponseError(error as ErrorResponse)
-        return defaultResponses.itemsWithCount
-      }
-      // const response = await getMyResources()
-      // return response.data
+      const response = await getMyResources()
+      return response.data ?? defaultResponses.itemsWithCount
     }
   })
 
-  // useEffect(() => {
-  //   if (error) {
-  //     onResponseError(error)
-  //   }
-  // }, [error, onResponseError])
+  useEffect(() => {
+    if (isError) {
+      onResponseError(error as ErrorResponse)
+    }
+  }, [error, isError, onResponseError])
 
   const onRowClick = useCallback(
     (item: T) => {
@@ -149,31 +131,29 @@ const AddResources = <T extends CourseResource | Question>({
 
   const getItems = useCallback(
     (inputValue: string, selectedCategories: string[]) => {
-      // if (!data?.items) return []
-      return (
-        data?.items.filter((item) => {
-          const titleMatch =
-            'title' in item
-              ? item.title
-                  .toLocaleLowerCase()
-                  .includes(inputValue.toLocaleLowerCase())
-              : item.fileName
-                  .toLocaleLowerCase()
-                  .split('.')
-                  .slice(0, -1)
-                  .join('.')
-                  .includes(inputValue.toLocaleLowerCase())
+      if (!data?.items) return []
+      return data?.items.filter((item) => {
+        const titleMatch =
+          'title' in item
+            ? item.title
+                .toLocaleLowerCase()
+                .includes(inputValue.toLocaleLowerCase())
+            : item.fileName
+                .toLocaleLowerCase()
+                .split('.')
+                .slice(0, -1)
+                .join('.')
+                .includes(inputValue.toLocaleLowerCase())
 
-          const categoryId =
-            typeof item.category !== 'string' ? item.category?._id : null
+        const categoryId =
+          typeof item.category !== 'string' ? item.category?._id : null
 
-          const categoryMatch =
-            selectedCategories.length === 0 ||
-            selectedCategories.includes(String(categoryId))
+        const categoryMatch =
+          selectedCategories.length === 0 ||
+          selectedCategories.includes(String(categoryId))
 
-          return titleMatch && categoryMatch
-        }) ?? []
-      )
+        return titleMatch && categoryMatch
+      })
     },
     [data?.items]
   )
@@ -187,7 +167,7 @@ const AddResources = <T extends CourseResource | Question>({
     isSelection: true,
     onAddItems,
     onCreateResourceCopy,
-    data: { loading, getItems },
+    data: { loading: isLoading, getItems },
     onRowClick,
     resourceTab,
     showCheckboxWithTooltip

--- a/src/containers/add-resources/AddResources.tsx
+++ b/src/containers/add-resources/AddResources.tsx
@@ -89,11 +89,12 @@ const AddResources = <T extends CourseResource | Question>({
   //   onResponseError
   // })
 
-  const { isLoading: loading, data } = useQuery<
-    ItemsWithCount<T>,
-    ErrorResponse
-  >({
-    queryKey: ['resources'],
+  const {
+    isLoading: loading,
+    data
+    // error
+  } = useQuery<ItemsWithCount<T>, ErrorResponse>({
+    queryKey: ['resources', sort],
     queryFn: async () => {
       try {
         const response = await getMyResources()
@@ -102,8 +103,16 @@ const AddResources = <T extends CourseResource | Question>({
         onResponseError(error as ErrorResponse)
         return defaultResponses.itemsWithCount
       }
+      // const response = await getMyResources()
+      // return response.data
     }
   })
+
+  // useEffect(() => {
+  //   if (error) {
+  //     onResponseError(error)
+  //   }
+  // }, [error, onResponseError])
 
   const onRowClick = useCallback(
     (item: T) => {
@@ -140,29 +149,31 @@ const AddResources = <T extends CourseResource | Question>({
 
   const getItems = useCallback(
     (inputValue: string, selectedCategories: string[]) => {
-      if (!data?.items) return []
-      return data?.items.filter((item) => {
-        const titleMatch =
-          'title' in item
-            ? item.title
-                .toLocaleLowerCase()
-                .includes(inputValue.toLocaleLowerCase())
-            : item.fileName
-                .toLocaleLowerCase()
-                .split('.')
-                .slice(0, -1)
-                .join('.')
-                .includes(inputValue.toLocaleLowerCase())
+      // if (!data?.items) return []
+      return (
+        data?.items.filter((item) => {
+          const titleMatch =
+            'title' in item
+              ? item.title
+                  .toLocaleLowerCase()
+                  .includes(inputValue.toLocaleLowerCase())
+              : item.fileName
+                  .toLocaleLowerCase()
+                  .split('.')
+                  .slice(0, -1)
+                  .join('.')
+                  .includes(inputValue.toLocaleLowerCase())
 
-        const categoryId =
-          typeof item.category !== 'string' ? item.category?._id : null
+          const categoryId =
+            typeof item.category !== 'string' ? item.category?._id : null
 
-        const categoryMatch =
-          selectedCategories.length === 0 ||
-          selectedCategories.includes(String(categoryId))
+          const categoryMatch =
+            selectedCategories.length === 0 ||
+            selectedCategories.includes(String(categoryId))
 
-        return titleMatch && categoryMatch
-      })
+          return titleMatch && categoryMatch
+        }) ?? []
+      )
     },
     [data?.items]
   )

--- a/src/containers/add-resources/AddResources.tsx
+++ b/src/containers/add-resources/AddResources.tsx
@@ -14,15 +14,14 @@ import AddResourceModal from '~/containers/my-resources/add-resource-modal/AddRe
 import { adjustColumns } from '~/utils/helper-functions'
 import { getErrorKey } from '~/utils/get-error-key'
 import {
-  ErrorResponse,
   GetResourcesParams,
   ItemsWithCount,
   CourseResource,
   TableColumn,
   RemoveColumnRules,
   Question,
-  ServiceFunction,
-  ResourcesTabsEnum
+  ResourcesTabsEnum,
+  ServiceFunctionNew
 } from '~/types'
 
 interface AddResourcesProps<T extends CourseResource | Question> {
@@ -31,7 +30,7 @@ interface AddResourcesProps<T extends CourseResource | Question> {
   resourceTab: ResourcesTabsEnum
   columns: TableColumn<T>[]
   removeColumnRules: RemoveColumnRules<T>
-  requestService: ServiceFunction<ItemsWithCount<T>, GetResourcesParams>
+  requestService: ServiceFunctionNew<ItemsWithCount<T>, GetResourcesParams>
   showCheckboxWithTooltip?: boolean
 }
 
@@ -70,31 +69,24 @@ const AddResources = <T extends CourseResource | Question>({
     [sort, requestService]
   )
 
-  const onResponseError = useCallback(
-    (error?: ErrorResponse) => {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['resources', sort, resourceTab],
+    queryFn: getMyResources,
+    options: {
+      initialData: defaultResponses.itemsWithCount
+    }
+  })
+
+  useEffect(() => {
+    if (error) {
       dispatch(
         openAlert({
           severity: snackbarVariants.error,
           message: getErrorKey(error)
         })
       )
-    },
-    [dispatch]
-  )
-
-  const { data, isLoading, error, isError } = useQuery<ItemsWithCount<T>>({
-    queryKey: ['resources', sort, resourceTab],
-    queryFn: async () => {
-      const response = await getMyResources()
-      return response.data ?? defaultResponses.itemsWithCount
     }
-  })
-
-  useEffect(() => {
-    if (isError) {
-      onResponseError(error as ErrorResponse)
-    }
-  }, [error, isError, onResponseError])
+  }, [error, dispatch])
 
   const onRowClick = useCallback(
     (item: T) => {
@@ -131,32 +123,30 @@ const AddResources = <T extends CourseResource | Question>({
 
   const getItems = useCallback(
     (inputValue: string, selectedCategories: string[]) => {
-      return (
-        data?.items.filter((item) => {
-          const titleMatch =
-            'title' in item
-              ? item.title
-                  .toLocaleLowerCase()
-                  .includes(inputValue.toLocaleLowerCase())
-              : item.fileName
-                  .toLocaleLowerCase()
-                  .split('.')
-                  .slice(0, -1)
-                  .join('.')
-                  .includes(inputValue.toLocaleLowerCase())
+      return data.items.filter((item) => {
+        const titleMatch =
+          'title' in item
+            ? item.title
+                .toLocaleLowerCase()
+                .includes(inputValue.toLocaleLowerCase())
+            : item.fileName
+                .toLocaleLowerCase()
+                .split('.')
+                .slice(0, -1)
+                .join('.')
+                .includes(inputValue.toLocaleLowerCase())
 
-          const categoryId =
-            typeof item.category !== 'string' ? item.category?._id : null
+        const categoryId =
+          typeof item.category !== 'string' ? item.category?._id : null
 
-          const categoryMatch =
-            selectedCategories.length === 0 ||
-            selectedCategories.includes(String(categoryId))
+        const categoryMatch =
+          selectedCategories.length === 0 ||
+          selectedCategories.includes(String(categoryId))
 
-          return titleMatch && categoryMatch
-        }) ?? []
-      )
+        return titleMatch && categoryMatch
+      })
     },
-    [data?.items]
+    [data.items]
   )
 
   const props = {

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -297,7 +297,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
           columns={lessonColumns}
           onAddResources={onAddResourcesWrapper}
           removeColumnRules={removeLessonColumnRules}
-          requestService={ResourceService.getUsersLessons}
+          requestService={ResourceService.getUsersLessonsQuery}
           resourceTab={resourcesData.lessons.resourceTab}
           resources={lessons}
           showCheckboxWithTooltip
@@ -313,7 +313,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
           columns={quizColumns}
           onAddResources={onAddResourcesWrapper}
           removeColumnRules={removeQuizColumnRules}
-          requestService={ResourceService.getQuizzes}
+          requestService={ResourceService.getQuizzesQuery}
           resourceTab={resourcesData.quizzes.resourceTab}
           resources={quizzes}
           showCheckboxWithTooltip
@@ -329,7 +329,7 @@ const CourseSectionContainer: FC<SectionProps> = ({
           columns={attachmentColumns}
           onAddResources={onAddResourcesWrapper}
           removeColumnRules={removeAttachmentColumnRules}
-          requestService={ResourceService.getAttachments}
+          requestService={ResourceService.getAttachmentsQuery}
           resourceTab={resourcesData.attachments.resourceTab}
           resources={attachments}
           showCheckboxWithTooltip

--- a/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
+++ b/src/containers/my-quizzes/create-or-edit-quiz-container/CreateOrEditQuizContainer.tsx
@@ -175,7 +175,7 @@ const CreateOrEditQuizContainer = ({
           columns={columns}
           onAddResources={onAddQuestions}
           removeColumnRules={removeColumnRules}
-          requestService={ResourceService.getQuestions}
+          requestService={ResourceService.getQuestionsQuery}
           resourceTab={ResourcesTabsEnum.Questions}
           resources={questions}
         />

--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
@@ -104,7 +104,7 @@ const CreateOrEditLesson = () => {
           columns={columns}
           onAddResources={handleAddAttachments}
           removeColumnRules={removeColumnRules}
-          requestService={ResourceService.getAttachments}
+          requestService={ResourceService.getAttachmentsQuery}
           resourceTab={ResourcesTabsEnum.Attachments}
           resources={data.attachments}
         />

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -34,14 +34,12 @@ export const ResourceService = {
   ): Promise<AxiosResponse<ItemsWithCount<Lesson>>> =>
     await axiosClient.get(URLs.resources.lessons.get, { params }),
 
-  getUsersLessonsQuery: async (params: GetResourcesParams = {}) => {
-    const { sort, ...rest } = params
-
+  getUsersLessonsQuery: (params?: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Lesson>>({
       method: 'GET',
       url: getFullUrl({
         pathname: URLs.resources.lessons.get,
-        searchParameters: { ...sort, ...rest }
+        searchParameters: params
       })
     })
   },
@@ -61,14 +59,12 @@ export const ResourceService = {
   ): Promise<AxiosResponse<ItemsWithCount<Quiz>>> =>
     await axiosClient.get(URLs.quizzes.get, { params }),
 
-  getQuizzesQuery: async (params: GetResourcesParams = {}) => {
-    const { sort, ...rest } = params
-
+  getQuizzesQuery: (params?: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Quiz>>({
       method: 'GET',
       url: getFullUrl({
         pathname: URLs.quizzes.get,
-        searchParameters: { ...sort, ...rest }
+        searchParameters: params
       })
     })
   },
@@ -88,14 +84,12 @@ export const ResourceService = {
   ): Promise<AxiosResponse<ItemsWithCount<Attachment>>> =>
     await axiosClient.get(URLs.resources.attachments.get, { params }),
 
-  getAttachmentsQuery: async (params: GetResourcesParams = {}) => {
-    const { sort, ...rest } = params
-
+  getAttachmentsQuery: (params?: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Attachment>>({
       method: 'GET',
       url: getFullUrl({
         pathname: URLs.resources.attachments.get,
-        searchParameters: { ...sort, ...rest }
+        searchParameters: params
       })
     })
   },
@@ -119,14 +113,12 @@ export const ResourceService = {
     return axiosClient.get(URLs.resources.questions.get, { params })
   },
 
-  getQuestionsQuery: (params: GetResourcesParams = {}) => {
-    const { sort, ...rest } = params
-
+  getQuestionsQuery: (params?: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Question>>({
       method: 'GET',
       url: getFullUrl({
         pathname: URLs.resources.questions.get,
-        searchParameters: { ...sort, ...rest }
+        searchParameters: params
       })
     })
   },

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -25,13 +25,26 @@ import {
   ApiMethodEnum,
   GetQuestion
 } from '~/types'
-import { createUrlPath } from '~/utils/helper-functions'
+import { createUrlPath, getFullUrl } from '~/utils/helper-functions'
+import { baseService } from './base-service'
 
 export const ResourceService = {
   getUsersLessons: async (
     params?: GetResourcesParams
   ): Promise<AxiosResponse<ItemsWithCount<Lesson>>> =>
     await axiosClient.get(URLs.resources.lessons.get, { params }),
+
+  getUsersLessonsQuery: async (params: GetResourcesParams = {}) => {
+    const { sort, ...rest } = params
+
+    return baseService.request<ItemsWithCount<Lesson>>({
+      method: 'GET',
+      url: getFullUrl({
+        pathname: URLs.resources.lessons.get,
+        searchParameters: { ...sort, ...rest }
+      })
+    })
+  },
   getLesson: async (id?: string): Promise<AxiosResponse<Lesson>> =>
     await axiosClient.get(createUrlPath(URLs.resources.lessons.get, id)),
   deleteLesson: async (id: string): Promise<AxiosResponse<Lesson>> =>
@@ -47,6 +60,18 @@ export const ResourceService = {
     params?: GetResourcesParams
   ): Promise<AxiosResponse<ItemsWithCount<Quiz>>> =>
     await axiosClient.get(URLs.quizzes.get, { params }),
+
+  getQuizzesQuery: async (params: GetResourcesParams = {}) => {
+    const { sort, ...rest } = params
+
+    return baseService.request<ItemsWithCount<Quiz>>({
+      method: 'GET',
+      url: getFullUrl({
+        pathname: URLs.quizzes.get,
+        searchParameters: { ...sort, ...rest }
+      })
+    })
+  },
   getQuiz: async (id?: string): Promise<AxiosResponse<Quiz>> =>
     await axiosClient.get(createUrlPath(URLs.quizzes.get, id)),
   addQuiz: async (data?: CreateQuizParams): Promise<AxiosResponse> =>
@@ -62,6 +87,18 @@ export const ResourceService = {
     params?: GetResourcesParams
   ): Promise<AxiosResponse<ItemsWithCount<Attachment>>> =>
     await axiosClient.get(URLs.resources.attachments.get, { params }),
+
+  getAttachmentsQuery: async (params: GetResourcesParams = {}) => {
+    const { sort, ...rest } = params
+
+    return baseService.request<ItemsWithCount<Attachment>>({
+      method: 'GET',
+      url: getFullUrl({
+        pathname: URLs.resources.attachments.get,
+        searchParameters: { ...sort, ...rest }
+      })
+    })
+  },
   updateAttachment: async (params?: UpdateAttachmentParams) =>
     await axiosClient.patch(
       createUrlPath(URLs.resources.attachments.patch, params?.id),
@@ -80,6 +117,18 @@ export const ResourceService = {
     params?: GetResourcesParams
   ): Promise<AxiosResponse<ItemsWithCount<Question>>> => {
     return axiosClient.get(URLs.resources.questions.get, { params })
+  },
+
+  getQuestionsQuery: (params: GetResourcesParams = {}) => {
+    const { sort, ...rest } = params
+
+    return baseService.request<ItemsWithCount<Question>>({
+      method: 'GET',
+      url: getFullUrl({
+        pathname: URLs.resources.questions.get,
+        searchParameters: { ...sort, ...rest }
+      })
+    })
   },
   getQuestion: async (id?: string): Promise<AxiosResponse<GetQuestion>> =>
     await axiosClient.get(createUrlPath(URLs.resources.questions.get, id)),

--- a/src/types/my-resources/interfaces/myResources.interface.ts
+++ b/src/types/my-resources/interfaces/myResources.interface.ts
@@ -26,7 +26,7 @@ export interface Categories extends CommonEntityFields {
   author: string
 }
 
-export interface GetResourcesParams extends Partial<RequestParams> {
+export type GetResourcesParams = Partial<RequestParams> & {
   title?: string
   fileName?: string
 }

--- a/src/types/services/types/services.types.ts
+++ b/src/types/services/types/services.types.ts
@@ -18,6 +18,10 @@ export type ServiceFunction<Response, Params = undefined> = (
   params: Params extends undefined ? undefined : Params
 ) => Promise<AxiosResponse<Response>>
 
+export type ServiceFunctionNew<Response, Params = undefined> = (
+  params: Params extends undefined ? undefined : Params
+) => Promise<Response>
+
 export interface AxiosResponseError extends AxiosError<ErrorResponse> {
   config: InternalAxiosRequestConfig & { _isRetry: boolean }
 }

--- a/src/utils/get-error-key.ts
+++ b/src/utils/get-error-key.ts
@@ -1,6 +1,7 @@
+import { type ResponseError } from '~/exceptions'
 interface ErrorResponse {
   code: string
 }
 
-export const getErrorKey = (error?: ErrorResponse) =>
+export const getErrorKey = (error?: ErrorResponse | ResponseError) =>
   `errors.${error?.code ? error.code : 'UNKNOWN_ERROR'}`

--- a/tests/unit/containers/add-resources/add-attachments/AddAttachments.spec.jsx
+++ b/tests/unit/containers/add-resources/add-attachments/AddAttachments.spec.jsx
@@ -63,8 +63,8 @@ describe('Tests for AddResources container', () => {
     vi.clearAllMocks()
   })
 
-  it('should display list of all attachments with category', () => {
-    const displayedAttachments = screen.getAllByText(
+  it('should display list of all attachments with category', async () => {
+    const displayedAttachments = await screen.findAllByText(
       attachmentDataMock.category.name
     )
     expect(displayedAttachments.length).toBe(10)

--- a/tests/unit/containers/add-resources/add-attachments/AddAttachments.spec.jsx
+++ b/tests/unit/containers/add-resources/add-attachments/AddAttachments.spec.jsx
@@ -35,7 +35,8 @@ const attachmentMockData = {
 
 const mockRequestService = vi.fn(() =>
   Promise.resolve({
-    data: { items: responseItemsMock, count: responseItemsMock.length }
+    items: responseItemsMock,
+    count: responseItemsMock.length
   })
 )
 const mockOnAddResources = () => {}

--- a/tests/unit/containers/add-resources/add-lessons/AddLessons.spec.jsx
+++ b/tests/unit/containers/add-resources/add-lessons/AddLessons.spec.jsx
@@ -34,9 +34,9 @@ const resourcesMockData = {
 }
 
 const mockRequestService = vi.fn(() =>
-  Promise.resolve({
-    data: { items: responseItemsMock, count: responseItemsMock.length }
-  })
+  Promise.resolve(
+{ items: responseItemsMock, count: responseItemsMock.length }
+  )
 )
 
 const mockOnAddResources = () => {}

--- a/tests/unit/containers/add-resources/add-lessons/AddLessons.spec.jsx
+++ b/tests/unit/containers/add-resources/add-lessons/AddLessons.spec.jsx
@@ -66,10 +66,10 @@ describe('Tests for AddResources container', () => {
   })
 
   it('should display list of all resources with category', async () => {
-    const displayedLessons = screen.getAllByText(
+    const displayedLessons = await screen.findAllByText(
       lessonDataMock.category.name
-    ).length
-    expect(displayedLessons).toBe(10)
+    )
+    expect(displayedLessons.length).toBe(10)
   })
 
   it('should filter resources', () => {

--- a/tests/unit/containers/add-resources/add-questions/AddQuestions.spec.jsx
+++ b/tests/unit/containers/add-resources/add-questions/AddQuestions.spec.jsx
@@ -36,7 +36,8 @@ const questionResponseMock = {
 
 const mockRequestService = vi.fn(() =>
   Promise.resolve({
-    data: { items: responseItemsMock, count: responseItemsMock.length }
+    items: responseItemsMock,
+    count: responseItemsMock.length
   })
 )
 

--- a/tests/unit/containers/add-resources/add-questions/AddQuestions.spec.jsx
+++ b/tests/unit/containers/add-resources/add-questions/AddQuestions.spec.jsx
@@ -65,11 +65,11 @@ describe('AddQuestions', () => {
     vi.clearAllMocks()
   })
 
-  it('should render title and question', () => {
-    const title = screen.getByText('myResourcesPage.questions.add')
+  it('should render title and question', async () => {
+    const title = await screen.findByText('myResourcesPage.questions.add')
     expect(title).toBeInTheDocument()
 
-    const questions = screen.getByText('1First Question')
+    const questions = await screen.findByText('1First Question')
     expect(questions).toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/add-resources/add-quizzes/AddQuizzes.spec.jsx
+++ b/tests/unit/containers/add-resources/add-quizzes/AddQuizzes.spec.jsx
@@ -34,7 +34,8 @@ const quizResponseMock = {
 
 const mockRequestService = vi.fn(() =>
   Promise.resolve({
-    data: { items: responseItemsMock, count: responseItemsMock.length }
+    items: responseItemsMock,
+    count: responseItemsMock.length
   })
 )
 

--- a/tests/unit/pages/create-or-edit-lesson/CreateOrEditLesson.spec.jsx
+++ b/tests/unit/pages/create-or-edit-lesson/CreateOrEditLesson.spec.jsx
@@ -11,7 +11,6 @@ import { createUrlPath } from '~/utils/helper-functions'
 import { authRoutes } from '~/router/constants/authRoutes'
 
 import CreateOrEditLesson from '~/pages/create-or-edit-lesson/CreateOrEditLesson'
-
 const mockNavigate = vi.fn()
 const mockedCategory = { _id: 'categoryId', name: 'categoryName' }
 
@@ -44,7 +43,7 @@ vi.mock('react-router-dom', async () => ({
 describe('CreateOrEditLesson component test', () => {
   beforeAll(() => {
     mockAxiosClient
-      .onGet(URLs.resources.attachments.get)
+      .onGet(new RegExp(URLs.resources.attachments.get))
       .reply(200, mockedAttachmentsResponse)
 
     mockAxiosClient


### PR DESCRIPTION
#3015 
- [x] Replaced all instances of `useAxios` with `useQuery` in AddResources.
- [x] Updated tests to accommodate the new implementation.
- [x] Verified that the data fetching and error handling work as intended with useQuery.

Created new service functions (`getUsersLessonsQuery`, `getQuizzesQuery`, `getAttachmentsQuery`, `getQuestionsQuery`) that utilize the `baseService` for API calls instead of directly using `axiosClient`.

The existing service functions (`getUsersLessons`, `getQuizzes`, `getAttachments`, `getQuestions`) remain unmodified to ensure backward compatibility and uninterrupted functionality of components relying on them.
These new functions are designed to replace the old ones once all relevant components transition to using useAxios.
