### PR TITLE
Add getFullUrl helper function

### DIFF
--- a/src/utils/helper-functions.tsx
+++ b/src/utils/helper-functions.tsx
@@ -225,6 +225,70 @@ export const createUrlPath = (
   return `${trimmedUrl}${paramsString}${queryParamsString}`
 }
 
+const getSearchParametersEntries = (
+  searchParameters: Record<
+    string,
+    string | string[] | number | number[] | undefined
+  >
+) => {
+  const searchParametersEntries: [string, string][] = []
+
+  for (const [searchParameterName, searchParameterValue] of Object.entries(
+    searchParameters
+  )) {
+    if (!searchParameterValue) {
+      continue
+    }
+
+    if (Array.isArray(searchParameterValue)) {
+      for (const parameterValue of searchParameterValue) {
+        searchParametersEntries.push([
+          searchParameterName,
+          String(parameterValue)
+        ])
+      }
+    } else {
+      searchParametersEntries.push([
+        searchParameterName,
+        String(searchParameterValue)
+      ])
+    }
+  }
+
+  return searchParametersEntries
+}
+
+export const getFullUrl = ({
+  parameters,
+  pathname,
+  searchParameters
+}: {
+  parameters?: Record<string, string>
+  pathname: string
+  searchParameters?: Record<
+    string,
+    string | string[] | number | number[] | undefined
+  >
+}) => {
+  let resultUrl = pathname
+
+  if (parameters) {
+    for (const [parameterName, parameterValue] of Object.entries(parameters)) {
+      resultUrl = resultUrl.replace(`:${parameterName}`, parameterValue)
+    }
+  }
+
+  if (!searchParameters) {
+    return resultUrl
+  }
+
+  const searchParametersEntries = getSearchParametersEntries(searchParameters)
+
+  const urlSearchParameters = new URLSearchParams(searchParametersEntries)
+
+  return `${resultUrl}?${String(urlSearchParameters)}`
+}
+
 export const ellipsisTextStyle = (linesCount: number) => ({
   display: '-webkit-box',
   WebkitLineClamp: linesCount,

--- a/tests/unit/utils/get-full-url.spec.js
+++ b/tests/unit/utils/get-full-url.spec.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFullUrl } from '~/utils/helper-functions'
+
+const URL_WITH_SINGLE_PARAMETER_IN_THE_END = '/resources/:id'
+const URL_WITH_SINGLE_PARAMETER_IN_THE_MIDDLE = '/resources/:id/sub-resources'
+const URL_WITH_MULTIPLE_PARAMETERS =
+  '/resources/:resourceId/sub-resources/:subResourceId'
+
+const QUERY_PARAMETERS_WITH_SINGLE_VALUE = {
+  query1: 'value1',
+  query2: 'value2'
+}
+
+const QUERY_PARAMETERS_WITH_MULTIPLE_VALUES = {
+  query1: ['value1', 'value2'],
+  query2: ['value3', 'value4']
+}
+
+const QUERY_PARAMETERS_WITH_UNDEFINED_VALUE = {
+  query1: 'value1',
+  query2: undefined
+}
+
+describe('getFullUrl helper function', () => {
+  it('should return valid url with single dynamic parameter in the end', () => {
+    const resultUrl = getFullUrl({
+      pathname: URL_WITH_SINGLE_PARAMETER_IN_THE_END,
+      parameters: {
+        id: 'someId'
+      }
+    })
+
+    expect(resultUrl).toBe('/resources/someId')
+  })
+
+  it('should return valid url with single dynamic parameter in the middle', () => {
+    const resultUrl = getFullUrl({
+      pathname: URL_WITH_SINGLE_PARAMETER_IN_THE_MIDDLE,
+      parameters: {
+        id: 'someId'
+      }
+    })
+
+    expect(resultUrl).toBe('/resources/someId/sub-resources')
+  })
+
+  it('should return valid url with multiple dynamic parameters', () => {
+    const resultUrl = getFullUrl({
+      pathname: URL_WITH_MULTIPLE_PARAMETERS,
+      parameters: {
+        resourceId: 'firstId',
+        subResourceId: 'secondId'
+      }
+    })
+
+    expect(resultUrl).toBe('/resources/firstId/sub-resources/secondId')
+  })
+
+  it('should return valid url with query parameters with single value', () => {
+    const resultUrl = getFullUrl({
+      pathname: '',
+      searchParameters: QUERY_PARAMETERS_WITH_SINGLE_VALUE
+    })
+
+    expect(resultUrl).toBe('?query1=value1&query2=value2')
+  })
+
+  it('should return valid url with query parameters with multiple values', () => {
+    const resultUrl = getFullUrl({
+      pathname: '',
+      searchParameters: QUERY_PARAMETERS_WITH_MULTIPLE_VALUES
+    })
+
+    expect(resultUrl).toBe(
+      '?query1=value1&query1=value2&query2=value3&query2=value4'
+    )
+  })
+
+  it('should return valid url with query parameters with undefined value', () => {
+    const resultUrl = getFullUrl({
+      pathname: '',
+      searchParameters: QUERY_PARAMETERS_WITH_UNDEFINED_VALUE
+    })
+
+    expect(resultUrl).toBe('?query1=value1')
+  })
+})


### PR DESCRIPTION
`getFullUrl` function has following parameters:
 - `pathname` - template URL with all dynamic parameters (`users/:id/bookmarks/offers`, `cooperations/:cooperationId/notes/:noteId`, etc)
 - `parameters` - object with named parameters from URL and their values ( `{ id: 'someId' } `, `{ cooperationId: 'firstId', noteId: 'secondId' }`)
 - `searchParameters` - object with query parameters ( `{ query1: 'value1', query2: 'value2' }` )
 
Use this function instead of `createUrlPath` in services

If `URLs` doesn't have needed parameters inside a string, and in `createUrlPath` usage result URL was a concatenation result from some other strings, replace it with a new one, that will have that needed parameter inside.

For example - `getBookmarkedOffers` from `userService`

Old version:
```typescript 
  getBookmarkedOffers: async (userId: string, params?: GetOffersParams) => {
    const userPath = createUrlPath(URLs.users.get, userId)

    return await axiosClient.get(`${userPath}${URLs.users.bookmarks}`, {
      params
    })
  }
```

New version (with changes in `URLs.users.bookmarks` from `/bookmarks/offers` to `/users/:id/bookmarks/offers`):
```typescript
  getBookmarkedOffers: (userId: string, params?: GetOffersParams) => {
    const resultUrl = getFullUrl({
      pathname: URLs.users.bookmarks,
      parameters: {
        id: userId
      },
      searchParameters: params
    })

    return baseService.request({
      method: 'GET',
      url: resultUrl
    })
  }
```
  