### PR TITLE
Replace useAxios with useQuery in LocationSelectionInputs and GeneralInfoStep components

### DIFF
--- a/src/components/location-selection-inputs/LocationSelectionInputs.tsx
+++ b/src/components/location-selection-inputs/LocationSelectionInputs.tsx
@@ -1,4 +1,8 @@
-import { type FilterOptionsState, createFilterOptions } from '@mui/material'
+import {
+  type FilterOptionsState,
+  type SxProps,
+  createFilterOptions
+} from '@mui/material'
 import { type SyntheticEvent, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -8,17 +12,17 @@ import useQuery from '~/hooks/use-query'
 import { locationService } from '~/services/location-service'
 import { type EditProfileForm } from '~/types'
 
-interface LocationSelectionInputsProps<T> {
-  onDataChange: (key: keyof T, value: string | null) => void
-  data: T
+interface LocationSelectionInputsProps {
+  onDataChange: (key: 'country' | 'city', value: string | null) => void
+  data: Pick<EditProfileForm, 'country' | 'city'>
+  sx?: SxProps
 }
 
-const LocationSelectionInputs = <
-  T extends Pick<EditProfileForm, 'country' | 'city'>
->({
+const LocationSelectionInputs: React.FC<LocationSelectionInputsProps> = ({
   onDataChange,
-  data
-}: LocationSelectionInputsProps<T>) => {
+  data,
+  sx
+}) => {
   const { t } = useTranslation()
 
   const {
@@ -87,7 +91,7 @@ const LocationSelectionInputs = <
         loading={isLoadingCountries}
         onChange={handleCountryChange}
         options={countriesNames}
-        sx={{ mb: '25px' }}
+        sx={sx}
         textFieldProps={{
           label: t('common.labels.country')
         }}
@@ -100,7 +104,7 @@ const LocationSelectionInputs = <
         loading={isLoadingCities}
         onChange={handleCityChange}
         options={cities}
-        sx={{ mb: '25px' }}
+        sx={sx}
         textFieldProps={{
           label: t('common.labels.city')
         }}

--- a/src/components/location-selection-inputs/LocationSelectionInputs.tsx
+++ b/src/components/location-selection-inputs/LocationSelectionInputs.tsx
@@ -1,13 +1,13 @@
-import { SyntheticEvent, useCallback, useEffect, useMemo } from 'react'
+import { type FilterOptionsState, createFilterOptions } from '@mui/material'
+import { type SyntheticEvent, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { FilterOptionsState, createFilterOptions } from '@mui/material'
 
-import { LocationService } from '~/services/location-service'
-import useAxios from '~/hooks/use-axios'
 import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
+import { locationService } from '~/services/location-service'
 
 import { defaultResponses } from '~/constants'
-import { Country, EditProfileForm } from '~/types'
+import useQuery from '~/hooks/use-query'
+import { EditProfileForm } from '~/types'
 
 interface LocationSelectionInputsProps<T> {
   onDataChange: (key: keyof T, value: string | null) => void
@@ -23,39 +23,36 @@ const LocationSelectionInputs = <
   const { t } = useTranslation()
 
   const {
-    loading: loadingCountries,
-    response: countries,
-    fetchData: fetchCountries
-  } = useAxios<Country[]>({
-    service: LocationService.getCountries,
-    fetchOnMount: false,
-    defaultResponse: defaultResponses.array
-  })
-
-  const {
-    loading: loadingCities,
-    fetchData: fetchCities,
-    response: cities
-  } = useAxios<string[], string>({
-    service: LocationService.getCities,
-    fetchOnMount: false,
-    defaultResponse: defaultResponses.array
-  })
-
-  const hasCountries = countries.length > 0
-  const hasCities = cities.length > 0
-
-  useEffect(() => {
-    if (hasCountries && !hasCities && data.city) {
-      const countryByName = countries.find(
-        (country) => country.name === data.country
-      )
-
-      if (countryByName) {
-        void fetchCities(countryByName.iso2)
-      }
+    data: countries = defaultResponses.array,
+    isLoading: isLoadingCountries
+  } = useQuery({
+    queryFn: locationService.getCountries,
+    queryKey: ['countries'],
+    options: {
+      staleTime: Infinity
     }
-  }, [countries, data, fetchCities, hasCountries, hasCities])
+  })
+
+  const handleGetCities = useCallback(async () => {
+    const countryByName = countries.find(
+      (country) => country.name === data.country
+    )
+
+    if (countryByName) {
+      return await locationService.getCitiesByCountryName(countryByName.iso2)
+    }
+
+    return defaultResponses.array
+  }, [countries, data.country])
+
+  const { data: cities = defaultResponses.array, isLoading: isLoadingCities } =
+    useQuery({
+      queryFn: handleGetCities,
+      queryKey: ['cities', data.country, countries.length],
+      options: {
+        staleTime: Infinity
+      }
+    })
 
   const handleCountryChange = (
     _: SyntheticEvent,
@@ -65,29 +62,11 @@ const LocationSelectionInputs = <
       onDataChange('city', null)
       onDataChange('country', countryName)
     }
-
-    if (!countryName) {
-      return
-    }
-
-    const countryByName = countries.find(
-      (country) => country.name === countryName
-    )
-
-    if (countryByName) {
-      void fetchCities(countryByName.iso2)
-    }
   }
 
   const handleCityChange = (_: SyntheticEvent, cityName: string | null) => {
     onDataChange('city', cityName)
   }
-
-  const handleSelectorFocus = useCallback(() => {
-    if (!hasCountries) {
-      void fetchCountries()
-    }
-  }, [fetchCountries, hasCountries])
 
   const filterOptions = (
     options: string[],
@@ -106,9 +85,8 @@ const LocationSelectionInputs = <
     <>
       <AppAutoComplete
         fullWidth
-        loading={loadingCountries}
+        loading={isLoadingCountries}
         onChange={handleCountryChange}
-        onFocus={handleSelectorFocus}
         options={countriesNames}
         sx={{ mb: '25px' }}
         textFieldProps={{
@@ -120,9 +98,8 @@ const LocationSelectionInputs = <
         disabled={!data.country}
         filterOptions={filterOptions}
         fullWidth
-        loading={loadingCities}
+        loading={isLoadingCities}
         onChange={handleCityChange}
-        onFocus={handleSelectorFocus}
         options={cities}
         sx={{ mb: '25px' }}
         textFieldProps={{

--- a/src/components/location-selection-inputs/LocationSelectionInputs.tsx
+++ b/src/components/location-selection-inputs/LocationSelectionInputs.tsx
@@ -7,7 +7,7 @@ import { locationService } from '~/services/location-service'
 
 import { defaultResponses } from '~/constants'
 import useQuery from '~/hooks/use-query'
-import { EditProfileForm } from '~/types'
+import { type EditProfileForm } from '~/types'
 
 interface LocationSelectionInputsProps<T> {
   onDataChange: (key: keyof T, value: string | null) => void

--- a/src/components/location-selection-inputs/LocationSelectionInputs.tsx
+++ b/src/components/location-selection-inputs/LocationSelectionInputs.tsx
@@ -3,7 +3,7 @@ import {
   type SxProps,
   createFilterOptions
 } from '@mui/material'
-import { type SyntheticEvent, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
@@ -58,7 +58,7 @@ const LocationSelectionInputs: React.FC<LocationSelectionInputsProps> = ({
     })
 
   const handleCountryChange = (
-    _: SyntheticEvent,
+    _: React.SyntheticEvent,
     countryName: string | null
   ) => {
     if (data.country !== countryName) {
@@ -67,7 +67,10 @@ const LocationSelectionInputs: React.FC<LocationSelectionInputsProps> = ({
     }
   }
 
-  const handleCityChange = (_: SyntheticEvent, cityName: string | null) => {
+  const handleCityChange = (
+    _: React.SyntheticEvent,
+    cityName: string | null
+  ) => {
     onDataChange('city', cityName)
   }
 

--- a/src/components/location-selection-inputs/LocationSelectionInputs.tsx
+++ b/src/components/location-selection-inputs/LocationSelectionInputs.tsx
@@ -3,10 +3,9 @@ import { type SyntheticEvent, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
-import { locationService } from '~/services/location-service'
-
 import { defaultResponses } from '~/constants'
 import useQuery from '~/hooks/use-query'
+import { locationService } from '~/services/location-service'
 import { type EditProfileForm } from '~/types'
 
 interface LocationSelectionInputsProps<T> {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -4,7 +4,7 @@ export const URLs = {
   },
   location: {
     getCountries: '/location/countries',
-    getCities: 'location/cities'
+    getCitiesByCountryName: '/location/cities/:countryName'
   },
   auth: {
     login: '/auth/login',

--- a/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.styles.ts
+++ b/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.styles.ts
@@ -33,6 +33,7 @@ export const styles = {
   section: { display: 'flex', flexDirection: 'column', rowGap: '15px' },
   sectionsTitleWithDesc: { ...titleWithDescription },
   dividedInputs: { display: 'flex', columnGap: '10px' },
+  locationInput: { marginBottom: '25px' },
   professionalSummaryLabel: (text: string) => ({
     color: palette.primary[400],
     top: '-2px',

--- a/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.tsx
+++ b/src/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.tsx
@@ -188,9 +188,10 @@ const ProfileTabForm: FC<ProfileTabFormProps> = ({
           title={t('editProfilePage.profile.generalTab.locationTitle')}
         />
         <Box sx={styles.dividedInputs}>
-          <LocationSelectionInputs<EditProfileForm>
+          <LocationSelectionInputs
             data={data}
             onDataChange={handleNonInputValueChange}
+            sx={styles.locationInput}
           />
         </Box>
       </Box>

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
@@ -1,28 +1,32 @@
-import { useEffect, useCallback, ReactNode, SyntheticEvent } from 'react'
-
-import { useTranslation } from 'react-i18next'
-import { LocationService } from '~/services/location-service'
-import { userService } from '~/services/user-service'
-
 import { createFilterOptions, FilterOptionsState } from '@mui/material'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-
-import AppTextField from '~/components/app-text-field/AppTextField'
-import AppTextArea from '~/components/app-text-area/AppTextArea'
-import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
-import Loader from '~/components/loader/Loader'
-import useBreakpoints from '~/hooks/use-breakpoints'
-import useAxios from '~/hooks/use-axios'
-import useForm from '~/hooks/use-form'
+import {
+  type ReactNode,
+  type SyntheticEvent,
+  useCallback,
+  useEffect,
+  useMemo
+} from 'react'
+import { useTranslation } from 'react-i18next'
 
 import img from '~/assets/img/tutor-home-page/become-tutor/general-info.svg'
-import { useStepContext } from '~/context/step-context'
+import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
+import AppTextArea from '~/components/app-text-area/AppTextArea'
+import AppTextField from '~/components/app-text-field/AppTextField'
+import Loader from '~/components/loader/Loader'
 import { validations } from '~/components/user-steps-wrapper/constants'
-import { styles } from '~/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles'
 import { defaultResponses } from '~/constants'
+import { styles } from '~/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles'
+import { useStepContext } from '~/context/step-context'
+import useAxios from '~/hooks/use-axios'
+import useBreakpoints from '~/hooks/use-breakpoints'
+import useForm from '~/hooks/use-form'
+import useQuery from '~/hooks/use-query'
 import { useAppSelector } from '~/hooks/use-redux'
-import { Country, UserGeneralInfo, UserRole } from '~/types'
+import { locationService } from '~/services/location-service'
+import { userService } from '~/services/user-service'
+import { type UserGeneralInfo, type UserRole } from '~/types'
 
 interface GeneralInfoStepProps {
   btnsBox: ReactNode
@@ -43,18 +47,6 @@ const GeneralInfoStep = ({
   const { userId, userRole } = useAppSelector((state) => state.appMain)
   const generalInfo = stepData.generalInfo
 
-  const getCountries = useCallback(() => LocationService.getCountries(), [])
-
-  const {
-    loading: loadingCountries,
-    response: countries,
-    fetchData: fetchCountries
-  } = useAxios({
-    service: getCountries,
-    fetchOnMount: false,
-    defaultResponse: defaultResponses.array as Country[]
-  })
-
   const {
     handleInputChange,
     handleBlur,
@@ -64,54 +56,77 @@ const GeneralInfoStep = ({
   } = useForm<UserGeneralInfo>({
     initialValues: generalInfo.data,
     initialErrors: {
-      city: generalInfo.errors['city'] || '',
-      country: generalInfo.errors['country'] || '',
-      firstName: generalInfo.errors['firstName'] || '',
-      lastName: generalInfo.errors['lastName'] || '',
-      professionalSummary: generalInfo.errors['professionalSummaryy'] || ''
+      city: generalInfo.errors['city'] ?? '',
+      country: generalInfo.errors['country'] ?? '',
+      firstName: generalInfo.errors['firstName'] ?? '',
+      lastName: generalInfo.errors['lastName'] ?? '',
+      professionalSummary: generalInfo.errors['professionalSummary'] ?? ''
     },
     ...validations
   })
+
+  const {
+    data: countries = defaultResponses.array,
+    isLoading: isLoadingCountries
+  } = useQuery({
+    queryFn: locationService.getCountries,
+    queryKey: ['countries'],
+    options: {
+      staleTime: Infinity
+    }
+  })
+
+  const handleGetCities = useCallback(async () => {
+    const countryByName = countries.find(
+      (country) => country.name === data.country
+    )
+
+    if (countryByName) {
+      return await locationService.getCitiesByCountryName(countryByName.iso2)
+    }
+
+    return defaultResponses.array
+  }, [countries, data.country])
+
+  const { data: cities = defaultResponses.array, isLoading: isLoadingCities } =
+    useQuery({
+      queryFn: handleGetCities,
+      queryKey: ['cities', data.country, countries.length],
+      options: {
+        staleTime: Infinity
+      }
+    })
+
+  const handleCountryChange = (
+    _: SyntheticEvent,
+    countryName: string | null
+  ) => {
+    if (data.country !== countryName) {
+      handleNonInputValueChange('city', null)
+      handleNonInputValueChange('country', countryName)
+    }
+  }
+
+  const handleCityChange = (_: SyntheticEvent, cityName: string | null) => {
+    handleNonInputValueChange('city', cityName)
+  }
 
   const filterOptions = (
     options: string[],
     state: FilterOptionsState<string>
   ) => {
     const defaultFilterOptions = createFilterOptions<string>()
+
     return defaultFilterOptions(options, state).slice(0, 300)
   }
 
-  const onChangeCountry = async (value: string) => {
-    if (data.country !== value) {
-      handleNonInputValueChange('city', null)
-      handleNonInputValueChange('country', value)
-    }
-    if (value) {
-      const selectedCountry = countries.find(
-        (country) => country.name === value
-      )
-      if (selectedCountry) {
-        const countryCode = selectedCountry.iso2
-        await fetchCities(countryCode)
-      }
-    }
-  }
-
-  const onChangeCity = (
-    event: SyntheticEvent<Element, Event>,
-    value: string | null
-  ) => {
-    handleNonInputValueChange('city', value)
-  }
+  const countriesNames = useMemo(() => {
+    return countries.map((country) => country.name)
+  }, [countries])
 
   const getUserById = useCallback(
     () => userService.getUserById(userId, userRole as UserRole),
     [userId, userRole]
-  )
-
-  const getCities = useCallback(
-    (country: string) => LocationService.getCities(country),
-    []
   )
 
   const updateUserName = useCallback(
@@ -136,27 +151,9 @@ const GeneralInfoStep = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const countriesNames = countries.map((country) => country.name)
-
-  const {
-    loading: loadingCities,
-    fetchData: fetchCities,
-    response: cities
-  } = useAxios({
-    service: getCities,
-    fetchOnMount: false,
-    defaultResponse: defaultResponses.array
-  })
-
   useEffect(() => {
     handleGeneralInfo({ data, errors })
   }, [data, errors, handleGeneralInfo])
-
-  const onFocusCountry = async () => {
-    if (!data.country && !countries.length) {
-      await fetchCountries()
-    }
-  }
 
   if (userLoading) {
     return (
@@ -178,7 +175,6 @@ const GeneralInfoStep = ({
           <Typography mb='20px'>
             {t('becomeTutor.generalInfo.title')}
           </Typography>
-
           {isMobile && (
             <Box sx={styles.imgContainer}>
               <Box component='img' src={img} sx={styles.img} />
@@ -208,11 +204,9 @@ const GeneralInfoStep = ({
               type='text'
               value={data.lastName}
             />
-
             <AppAutoComplete
-              loading={loadingCountries}
-              onChange={(_, value) => onChangeCountry(value as string)}
-              onFocus={onFocusCountry}
+              loading={isLoadingCountries}
+              onChange={handleCountryChange}
               options={countriesNames}
               sx={{ mb: '30px' }}
               textFieldProps={{
@@ -220,12 +214,11 @@ const GeneralInfoStep = ({
               }}
               value={data.country}
             />
-
             <AppAutoComplete
               disabled={!data.country}
               filterOptions={filterOptions}
-              loading={loadingCities}
-              onChange={onChangeCity}
+              loading={isLoadingCities}
+              onChange={handleCityChange}
               options={cities}
               sx={{ mb: '30px' }}
               textFieldProps={{

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
@@ -1,30 +1,20 @@
-import { createFilterOptions, FilterOptionsState } from '@mui/material'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import {
-  type ReactNode,
-  type SyntheticEvent,
-  useCallback,
-  useEffect,
-  useMemo
-} from 'react'
+import { type ReactNode, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import img from '~/assets/img/tutor-home-page/become-tutor/general-info.svg'
-import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
 import AppTextArea from '~/components/app-text-area/AppTextArea'
 import AppTextField from '~/components/app-text-field/AppTextField'
 import Loader from '~/components/loader/Loader'
+import LocationSelectionInputs from '~/components/location-selection-inputs/LocationSelectionInputs'
 import { validations } from '~/components/user-steps-wrapper/constants'
-import { defaultResponses } from '~/constants'
 import { styles } from '~/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles'
 import { useStepContext } from '~/context/step-context'
 import useAxios from '~/hooks/use-axios'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import useForm from '~/hooks/use-form'
-import useQuery from '~/hooks/use-query'
 import { useAppSelector } from '~/hooks/use-redux'
-import { locationService } from '~/services/location-service'
 import { userService } from '~/services/user-service'
 import { type UserGeneralInfo, type UserRole } from '~/types'
 
@@ -64,65 +54,6 @@ const GeneralInfoStep = ({
     },
     ...validations
   })
-
-  const {
-    data: countries = defaultResponses.array,
-    isLoading: isLoadingCountries
-  } = useQuery({
-    queryFn: locationService.getCountries,
-    queryKey: ['countries'],
-    options: {
-      staleTime: Infinity
-    }
-  })
-
-  const handleGetCities = useCallback(async () => {
-    const countryByName = countries.find(
-      (country) => country.name === data.country
-    )
-
-    if (countryByName) {
-      return await locationService.getCitiesByCountryName(countryByName.iso2)
-    }
-
-    return defaultResponses.array
-  }, [countries, data.country])
-
-  const { data: cities = defaultResponses.array, isLoading: isLoadingCities } =
-    useQuery({
-      queryFn: handleGetCities,
-      queryKey: ['cities', data.country, countries.length],
-      options: {
-        staleTime: Infinity
-      }
-    })
-
-  const handleCountryChange = (
-    _: SyntheticEvent,
-    countryName: string | null
-  ) => {
-    if (data.country !== countryName) {
-      handleNonInputValueChange('city', null)
-      handleNonInputValueChange('country', countryName)
-    }
-  }
-
-  const handleCityChange = (_: SyntheticEvent, cityName: string | null) => {
-    handleNonInputValueChange('city', cityName)
-  }
-
-  const filterOptions = (
-    options: string[],
-    state: FilterOptionsState<string>
-  ) => {
-    const defaultFilterOptions = createFilterOptions<string>()
-
-    return defaultFilterOptions(options, state).slice(0, 300)
-  }
-
-  const countriesNames = useMemo(() => {
-    return countries.map((country) => country.name)
-  }, [countries])
 
   const getUserById = useCallback(
     () => userService.getUserById(userId, userRole as UserRole),
@@ -204,27 +135,10 @@ const GeneralInfoStep = ({
               type='text'
               value={data.lastName}
             />
-            <AppAutoComplete
-              loading={isLoadingCountries}
-              onChange={handleCountryChange}
-              options={countriesNames}
+            <LocationSelectionInputs
+              data={data}
+              onDataChange={handleNonInputValueChange}
               sx={{ mb: '30px' }}
-              textFieldProps={{
-                label: t('common.labels.country')
-              }}
-              value={data.country}
-            />
-            <AppAutoComplete
-              disabled={!data.country}
-              filterOptions={filterOptions}
-              loading={isLoadingCities}
-              onChange={handleCityChange}
-              options={cities}
-              sx={{ mb: '30px' }}
-              textFieldProps={{
-                label: t('common.labels.city')
-              }}
-              value={data.city}
             />
           </Box>
           <AppTextArea

--- a/src/services/location-service.ts
+++ b/src/services/location-service.ts
@@ -1,15 +1,22 @@
-import { AxiosResponse } from 'axios'
-
-import { createUrlPath } from '~/utils/helper-functions'
 import { URLs } from '~/constants/request'
-import { axiosClient } from '~/plugins/axiosClient'
-import { Country } from '~/types'
+import { type Country } from '~/types'
+import { getFullUrl } from '~/utils/helper-functions'
+import { baseService } from './base-service'
 
-export const LocationService = {
-  getCountries: (): Promise<AxiosResponse<Country[]>> => {
-    return axiosClient.get(URLs.location.getCountries)
+export const locationService = {
+  getCountries: () => {
+    return baseService.request<Country[]>({
+      method: 'GET',
+      url: URLs.location.getCountries
+    })
   },
-  getCities: (country: string = ''): Promise<AxiosResponse<string[]>> => {
-    return axiosClient.get(createUrlPath(URLs.location.getCities, country))
+  getCitiesByCountryName: (countryName: string) => {
+    return baseService.request<string[]>({
+      method: 'GET',
+      url: getFullUrl({
+        pathname: URLs.location.getCitiesByCountryName,
+        parameters: { countryName }
+      })
+    })
   }
 }

--- a/tests/unit/components/location-selection-inputs/LocationSelectionInputs.spec.jsx
+++ b/tests/unit/components/location-selection-inputs/LocationSelectionInputs.spec.jsx
@@ -1,8 +1,12 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import { afterAll, beforeAll, beforeEach, expect, vi } from 'vitest'
 import LocationSelectionInputs from '~/components/location-selection-inputs/LocationSelectionInputs'
-import { mockAxiosClient } from '~tests/test-utils'
 import { URLs } from '~/constants/request'
-import { selectOption } from '~tests/test-utils'
+import {
+  mockAxiosClient,
+  renderWithProviders,
+  selectOption
+} from '~tests/test-utils'
 
 const onDataChangeMock = vi.fn()
 
@@ -16,48 +20,67 @@ const mockCountries = [
 const initialData = { country: 'Country3', city: 'City3' }
 
 describe('LocationSelectionInputs', () => {
-  beforeEach(async () => {
-    await waitFor(() => {
-      mockAxiosClient
-        .onGet(URLs.location.getCountries)
-        .reply(200, mockCountries)
-      mockAxiosClient
-        .onGet(`${URLs.location.getCities}/${mockCountries[0].iso2}`)
-        .reply(200, mockCities)
-      render(
-        <LocationSelectionInputs
-          data={initialData}
-          onDataChange={onDataChangeMock}
-        />
+  beforeAll(() => {
+    mockAxiosClient.onGet(URLs.location.getCountries).reply(200, mockCountries)
+    mockAxiosClient
+      .onGet(
+        new RegExp(
+          URLs.location.getCitiesByCountryName.replace(':countryName', '')
+        )
       )
-    })
+      .reply(200, mockCities)
   })
-  it('renders location selection inputs', () => {
+
+  beforeEach(() => {
+    renderWithProviders(
+      <LocationSelectionInputs
+        data={initialData}
+        onDataChange={onDataChangeMock}
+      />
+    )
+  })
+
+  afterAll(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render location selection inputs', () => {
     expect(screen.getByLabelText('common.labels.country')).toBeInTheDocument()
     expect(screen.getByLabelText('common.labels.city')).toBeInTheDocument()
   })
-  it('changes the value of the country input when a country is selected', async () => {
+
+  it('should change the value of the country input', async () => {
     const newCountry = mockCountries[0].name
 
     const option = screen.getByLabelText('common.labels.country')
     await selectOption(option, newCountry)
+
+    expect(onDataChangeMock).toHaveBeenCalledWith('country', 'Ukraine')
   })
-  it('changes the value of the city input when a city is selected after a country is selected', async () => {
+
+  it('should change the value of the city input after selecting a country', async () => {
     const newCountry = mockCountries[0].name
     const newCity = mockCities[0]
 
     const countryOption = screen.getByLabelText('common.labels.country')
     await selectOption(countryOption, newCountry)
 
+    expect(onDataChangeMock).toHaveBeenCalledWith('city', null)
+    expect(onDataChangeMock).toHaveBeenCalledWith('country', 'Ukraine')
+
     const cityOption = screen.getByLabelText('common.labels.city')
     await selectOption(cityOption, newCity)
+
+    expect(onDataChangeMock).toHaveBeenCalledWith('city', 'City1')
   })
-  it('enables city field after selecting a country', async () => {
+
+  it('should enable city field after selecting a country', async () => {
     const countryOption = screen.getByLabelText('common.labels.country')
     await selectOption(countryOption, 'Ukraine')
 
+    const cityOption = screen.getByLabelText('common.labels.city')
+    expect(cityOption).not.toBeDisabled()
+
     expect(onDataChangeMock).toHaveBeenCalledWith('country', 'Ukraine')
-    expect(screen.getByLabelText('common.labels.city')).not.toBeDisabled()
   })
 })
-

--- a/tests/unit/containers/tutor-home-page/general-info-step/GeneralInfoStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/general-info-step/GeneralInfoStep.spec.jsx
@@ -44,7 +44,11 @@ describe('GeneralInfoStep test', () => {
         .onGet(URLs.location.getCountries)
         .reply(200, countriesDataMock)
       mockAxiosClient
-        .onGet(`${URLs.location.getCities}/${countryCode}`)
+        .onGet(
+          new RegExp(
+            URLs.location.getCitiesByCountryName.replace(':countryName', '')
+          )
+        )
         .reply(200, citiesDataMock)
       renderWithProviders(
         <StepProvider

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, fireEvent, render } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import { renderWithProviders, mockAxiosClient } from '~tests/test-utils'
 import { URLs } from '~/constants/request'
 import { openAlert } from '~/redux/features/snackbarSlice'
@@ -454,7 +454,7 @@ describe('EditProfile', () => {
 
     const mockHandleInputChange = vi.fn();
 
-    render(
+    renderWithProviders(
       <ProfileTabForm
         t={mockT}
         data={mockData}
@@ -489,7 +489,7 @@ describe('EditProfile', () => {
 
     const mockHandleInputChange = vi.fn();
 
-    render(
+    renderWithProviders(
       <ProfileTabForm
         t={mockT}
         data={mockData}

--- a/tests/unit/services/location-service.spec.js
+++ b/tests/unit/services/location-service.spec.js
@@ -1,6 +1,6 @@
 import { URLs } from '~/constants/request'
 import { mockAxiosClient } from '~tests/test-utils'
-import { LocationService } from '~/services/location-service'
+import { locationService } from '~/services/location-service'
 
 const countriesDataMock = ['Ukraine', 'Belgium']
 const citiesDataMock = ['Antwerp', 'Brussels']
@@ -12,18 +12,22 @@ describe('locationService tests', () => {
       .onGet(URLs.location.getCountries)
       .reply(200, countriesDataMock)
 
-    const result = await LocationService.getCountries()
+    const result = await locationService.getCountries()
 
-    expect(result.data).toEqual(countriesDataMock)
+    expect(result).toEqual(countriesDataMock)
   })
 
   it('should return cities', async () => {
     mockAxiosClient
-      .onGet(`${URLs.location.getCities}/${country}`)
+      .onGet(
+        new RegExp(
+          URLs.location.getCitiesByCountryName.replace(':countryName', '')
+        )
+      )
       .reply(200, citiesDataMock)
 
-    const result = await LocationService.getCities(country)
+    const result = await locationService.getCitiesByCountryName(country)
 
-    expect(result.data).toEqual(citiesDataMock)
+    expect(result).toEqual(citiesDataMock)
   })
 })


### PR DESCRIPTION
- `LocationSelectionInputs` component was updated with `useQuery` hook usage, redundant typescript generic usage was removed
- `locationService` was updated with `baseService` usage
- location url constant was updated for `getFullUrl` helper function usage 
`location/cities => /location/cities/:countryName`
- `GeneralInfoStep` component was updated with `LocationSelectionInputs` reusage (`GeneralInfoStep` also was dependent from `locationService`, so for removing duplication `useAxios`/`useQuery` and all related logic was replaced by `LocationSelectionInputs` component)
- updated following tests:
  - `GeneralInfoStep`
  - `EditProfile`
  - `LocationSelectionInputs`
  - `locationService`
  
---

This is how it works (all requests is cashed by `useQuery` so you can see that request for USA cities doesn't happen twice)


https://github.com/user-attachments/assets/354a8a51-d013-4238-a294-e8babde3abd1

