### PR TITLE
[Edit Profile. Profile] Fixed the ability for the user to enter all allowed values ​​in the 'First name' and 'Last name' fields

### DIFF
--- a/src/hooks/use-form.tsx
+++ b/src/hooks/use-form.tsx
@@ -70,7 +70,7 @@ export const useForm = <T extends object>({
 
   const handleInputChange =
     (key: keyof T) => (event: React.ChangeEvent<HTMLInputElement>) => {
-      const nameRegex = /[^a-zA-Z\u0400-\u04FF]/g
+      const nameRegex = /[^a-zA-Z\u0400-\u04FF'\- ]/g
 
       let value =
         event.target.type === 'checkbox'


### PR DESCRIPTION
Added to regex allowed symbols `'` ` ` and `-`
![image](https://github.com/user-attachments/assets/44255eac-3910-47dd-99bb-fb99dbad511f)
