### PR TITLE
Multiple query key invalidation inside useMutation hook

### DIFF
--- a/src/hooks/use-mutation.tsx
+++ b/src/hooks/use-mutation.tsx
@@ -8,9 +8,23 @@ import {
 import { queryClient } from '~/plugins/queryClient'
 import { type ErrorResponse } from '~/types'
 
-type UseMutationProps<TData, TError, TVariables, TContext> = {
-  queryKey?: QueryKey
-} & UseMutationOptions<TData, TError, TVariables, TContext>
+type InvalidateKeysOptions =
+  | {
+      queryKey?: QueryKey
+      queryKeys?: never
+    }
+  | {
+      queryKey?: never
+      queryKeys?: QueryKey[]
+    }
+
+type UseMutationProps<TData, TError, TVariables, TContext> = UseMutationOptions<
+  TData,
+  TError,
+  TVariables,
+  TContext
+> &
+  InvalidateKeysOptions
 
 const useMutation = <
   TData = unknown,
@@ -19,6 +33,7 @@ const useMutation = <
   TContext = unknown
 >({
   queryKey,
+  queryKeys,
   ...mutationOptions
 }: UseMutationProps<TData, TError, TVariables, TContext>): UseMutationResult<
   TData,
@@ -34,6 +49,13 @@ const useMutation = <
       }
       if (queryKey) {
         await queryClient.invalidateQueries({ queryKey })
+      }
+      if (queryKeys) {
+        await Promise.all(
+          queryKeys.map((key) => {
+            return queryClient.invalidateQueries({ queryKey: key })
+          })
+        )
       }
     }
   })

--- a/tests/unit/hooks/use-mutation.spec.js
+++ b/tests/unit/hooks/use-mutation.spec.js
@@ -48,7 +48,30 @@ describe('useMutation', () => {
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey })
   })
 
-  it('should not call invalidateQueries if queryKey is not provided', async () => {
+  it('should call invalidateQueries for each queryKey if queryKeys is provided', async () => {
+    const queryKeys = [['testKey1'], ['testKey2']]
+
+    const { result } = renderHook(
+      () =>
+        useMutation({
+          mutationFn,
+          queryKeys
+        }),
+      { wrapper: QueryProvider }
+    )
+
+    await act(() => result.current.mutateAsync())
+
+    expect(mutationFn).toHaveBeenCalled()
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys[0]
+    })
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys[1]
+    })
+  })
+
+  it('should not call invalidateQueries if queryKey or queryKeys are not provided', async () => {
     const { result } = renderHook(
       () =>
         useMutation({


### PR DESCRIPTION
- Added the `queryKeys` option to the `useMutation` hook
- Added an ability to provide one and only one of the invalidation options (if `queryKey` was used, it is forbidden to use also `queryKeys` at the same time, and vice versa)
- Updated unit tests