### PR TITLE
Fix getFullUrl import in the location-service

### DIFF
--- a/src/services/location-service.ts
+++ b/src/services/location-service.ts
@@ -1,6 +1,6 @@
 import { URLs } from '~/constants/request'
 import { type Country } from '~/types'
-import { getFullUrl } from '~/utils/helper-functions'
+import { getFullUrl } from '~/utils/get-full-url'
 import { baseService } from './base-service'
 
 export const locationService = {


### PR DESCRIPTION
Replace `import { getFullUrl } from '~/utils/helper-functions'` with `import { getFullUrl } from '~/utils/get-full-url'` in `location-service`