### PR TITLE
Fix margin in add categories modal

### DIFF
--- a/src/containers/my-resources/add-categories-modal/AddCategories.styles.ts
+++ b/src/containers/my-resources/add-categories-modal/AddCategories.styles.ts
@@ -3,7 +3,7 @@ import { TypographyVariantEnum } from '~/types'
 export const styles = {
   root: { p: '32px', width: '481px' },
   title: { typography: TypographyVariantEnum.H6 },
-  form: { pt: '24px' },
+  form: { pt: '24px', mb: '24px' },
   textField: {
     '.MuiInputLabel-asterisk': {
       display: 'none'


### PR DESCRIPTION
Before (the input overlaps the buttons creating a bad user experience):
![image](https://github.com/user-attachments/assets/25273601-9611-4077-a76f-026ef22b30f0)

After:
![image](https://github.com/user-attachments/assets/87369a1c-0626-49b0-8ed7-a97b27f098f0)
