### PR TITLE
Added translation for availabilityStatus on CooperationActivities page

### DIFF
--- a/src/containers/course-section/resource-item/ResourceItem.tsx
+++ b/src/containers/course-section/resource-item/ResourceItem.tsx
@@ -132,7 +132,8 @@ const ResourceItem: FC<ResourceItemProps> = ({
       }}
     >
       {availabilityIcon}
-      {formattedDate ?? status}
+      {formattedDate ??
+        t(`cooperationDetailsPage.resourceSelection.${status}`, status)}
     </Box>
   )
 


### PR DESCRIPTION
Added translation for availabilityStatus on CooperationActivities page

Before: 
![image](https://github.com/user-attachments/assets/90b74959-fae1-44db-ad6d-5a7e1086bbd6)

After:
![image](https://github.com/user-attachments/assets/46594f7d-41c7-4535-bab8-3999e7aa5f74)

