### PR TITLE
Replaced useAxios on useQuery in ChangeResourceConfirmModal

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,9 +61,9 @@ jobs:
 
       - name: Upload artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage-artifacts
+          name: coverage-artifacts-${{ matrix.shardIndex }}
           path: coverage/
         
      # - name: Upload blob report to GitHub Actions Artifacts
@@ -84,10 +84,11 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: coverage-artifacts
           path: coverage
+          pattern: coverage-artifacts-*
+          merge-multiple: true
 
       - name: Run script to merge all the xml files
         run: | 

--- a/src/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.tsx
+++ b/src/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.tsx
@@ -8,7 +8,7 @@ import AppButton from '~/components/app-button/AppButton'
 import { styles } from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.styles'
 import { useModalContext } from '~/context/modal-context'
 import Loader from '~/components/loader/Loader'
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import { CoursesAndCooperationsService } from '~/services/course-cooperation-service'
 import { ButtonVariantEnum, CourseCooperationResponse, SizeEnum } from '~/types'
 
@@ -26,27 +26,25 @@ const ChangeResourceConfirmModal = ({
   const { t } = useTranslation()
   const { closeModal } = useModalContext()
 
-  const getCoursesAndCooperationsByResourceId = useCallback(
-    () => CoursesAndCooperationsService.getByResourceId(resourceId),
-    [resourceId]
-  )
-
-  const { response, loading } = useAxios({
-    service: getCoursesAndCooperationsByResourceId,
-    defaultResponse: {
-      courses: [],
-      cooperations: []
-    } as CourseCooperationResponse,
-    fetchOnMount: true
+  const { data, isLoading } = useQuery<CourseCooperationResponse>({
+    queryKey: ['getCoursesAndCooperationsByResourceId', resourceId],
+    queryFn: () => CoursesAndCooperationsService.getByResourceId(resourceId),
+    options: {
+      initialData: {
+        courses: [],
+        cooperations: []
+      },
+      enabled: !!resourceId
+    }
   })
 
-  const courses = response.courses.map((course) => ({
+  const courses = data.courses.map((course) => ({
     id: course._id,
     title: course.title,
     subTitle: 'course'
   }))
 
-  const cooperations = response?.cooperations.map((cooperation) => ({
+  const cooperations = data?.cooperations.map((cooperation) => ({
     id: cooperation._id,
     title: cooperation.title,
     subTitle: 'cooperation'
@@ -63,12 +61,12 @@ const ChangeResourceConfirmModal = ({
   }, [closeModal, onConfirm])
 
   useEffect(() => {
-    if (!loading && !affectedItems.length) {
+    if (!isLoading && !affectedItems.length) {
       handleConfirm()
     }
-  }, [affectedItems, handleConfirm, loading])
+  }, [affectedItems, handleConfirm, isLoading])
 
-  if (loading) {
+  if (isLoading) {
     return (
       <Box sx={styles.root}>
         <Loader />
@@ -76,7 +74,7 @@ const ChangeResourceConfirmModal = ({
     )
   }
 
-  if (!loading && !affectedItems?.length) {
+  if (!isLoading && !affectedItems?.length) {
     return null
   }
 

--- a/src/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.tsx
+++ b/src/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.tsx
@@ -34,7 +34,7 @@ const ChangeResourceConfirmModal = ({
         courses: [],
         cooperations: []
       },
-      enabled: !!resourceId
+      enabled: Boolean(resourceId)
     }
   })
 
@@ -44,7 +44,7 @@ const ChangeResourceConfirmModal = ({
     subTitle: 'course'
   }))
 
-  const cooperations = data?.cooperations.map((cooperation) => ({
+  const cooperations = data.cooperations.map((cooperation) => ({
     id: cooperation._id,
     title: cooperation.title,
     subTitle: 'cooperation'

--- a/src/services/course-cooperation-service.ts
+++ b/src/services/course-cooperation-service.ts
@@ -4,15 +4,13 @@ import { baseService } from '~/services/base-service'
 import { getFullUrl } from '~/utils/get-full-url'
 
 export const CoursesAndCooperationsService = {
-  getByResourceId: async (
-    resourceId: string
-  ): Promise<CourseCooperationResponse> => {
+  getByResourceId: async (resourceId: string) => {
     const url = getFullUrl({
       pathname: URLs.coursesAndCooperations.getByResourceId,
       searchParameters: { resourceId }
     })
 
-    return await baseService.request<CourseCooperationResponse>({
+    return baseService.request<CourseCooperationResponse>({
       url,
       method: 'GET'
     })

--- a/src/services/course-cooperation-service.ts
+++ b/src/services/course-cooperation-service.ts
@@ -1,14 +1,20 @@
-import { AxiosResponse } from 'axios'
-import { URLs } from '~/constants/request'
-import { axiosClient } from '~/plugins/axiosClient'
 import { CourseCooperationResponse } from '~/types'
-import { createUrlPath } from '~/utils/helper-functions'
+import { URLs } from '~/constants/request'
+import { baseService } from '~/services/base-service'
+import { getFullUrl } from '~/utils/get-full-url'
 
 export const CoursesAndCooperationsService = {
   getByResourceId: async (
     resourceId: string
-  ): Promise<AxiosResponse<CourseCooperationResponse>> =>
-    await axiosClient.get(
-      createUrlPath(URLs.coursesAndCooperations.getByResourceId, resourceId)
-    )
+  ): Promise<CourseCooperationResponse> => {
+    const url = getFullUrl({
+      pathname: URLs.coursesAndCooperations.getByResourceId,
+      searchParameters: { resourceId }
+    })
+
+    return await baseService.request<CourseCooperationResponse>({
+      url,
+      method: 'GET'
+    })
+  }
 }

--- a/src/services/course-cooperation-service.ts
+++ b/src/services/course-cooperation-service.ts
@@ -4,7 +4,7 @@ import { baseService } from '~/services/base-service'
 import { getFullUrl } from '~/utils/get-full-url'
 
 export const CoursesAndCooperationsService = {
-  getByResourceId: async (resourceId: string) => {
+  getByResourceId: (resourceId: string) => {
     const url = getFullUrl({
       pathname: URLs.coursesAndCooperations.getByResourceId,
       searchParameters: { resourceId }

--- a/tests/unit/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.spec.jsx
+++ b/tests/unit/containers/change-resource-confirm-modal/ChangeResourceConfirmModal.spec.jsx
@@ -1,12 +1,18 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '~tests/test-utils'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 
 const handleConfirm = vi.fn()
 const closeModal = vi.fn()
 
-vi.mock('~/hooks/use-axios')
+vi.mock('~/hooks/use-query', async () => {
+  const actual = await vi.importActual('~/hooks/use-query')
+  return {
+    ...actual,
+    default: vi.fn()
+  }
+})
 
 vi.mock('~/context/modal-context', async () => {
   const actual = await vi.importActual('~/context/modal-context')
@@ -80,9 +86,9 @@ const fakeData = {
 
 describe('ChangeResourceConfirmModal component tests', () => {
   it('should render properly', async () => {
-    useAxios.mockImplementation(() => ({
-      loading: false,
-      response: fakeData
+    useQuery.mockImplementation(() => ({
+      isLoading: false,
+      data: fakeData
     }))
     renderWithProviders(<ChangeResourceConfirmModal {...props} />)
 
@@ -93,9 +99,9 @@ describe('ChangeResourceConfirmModal component tests', () => {
   })
 
   it('should render course list items with titles', async () => {
-    useAxios.mockImplementation(() => ({
-      loading: false,
-      response: fakeData
+    useQuery.mockImplementation(() => ({
+      isLoading: false,
+      data: fakeData
     }))
     renderWithProviders(<ChangeResourceConfirmModal {...props} />)
     const courseTitle1 = await screen.findByText('Course 1')
@@ -106,9 +112,9 @@ describe('ChangeResourceConfirmModal component tests', () => {
   })
 
   it('should render loader', async () => {
-    useAxios.mockImplementation(() => ({
-      loading: true,
-      response: fakeData
+    useQuery.mockImplementation(() => ({
+      isLoading: true,
+      data: fakeData
     }))
     renderWithProviders(<ChangeResourceConfirmModal {...props} />)
     const loader = await screen.findByTestId('loader')
@@ -117,9 +123,9 @@ describe('ChangeResourceConfirmModal component tests', () => {
   })
 
   it('should run onConfirm', async () => {
-    useAxios.mockImplementation(() => ({
-      loading: false,
-      response: fakeData
+    useQuery.mockImplementation(() => ({
+      isLoading: false,
+      data: fakeData
     }))
     renderWithProviders(
       <ChangeResourceConfirmModal
@@ -128,7 +134,15 @@ describe('ChangeResourceConfirmModal component tests', () => {
         title='title'
       />
     )
-    waitFor(() => expect(handleConfirm).toHaveBeenCalled())
-    waitFor(() => expect(closeModal).toHaveBeenCalled())
+
+    const confirmButton = await screen.findByText('changeConfirm.confirmButton')
+    expect(confirmButton).toBeInTheDocument()
+  
+    fireEvent.click(confirmButton)
+
+    await waitFor(() => {
+      expect(handleConfirm).toHaveBeenCalled()
+      expect(closeModal).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
**ChangeResorceConfirmModal.tsx:**
- Replaced `useAxios` on `useQuery` hook. Used `queryKey, queryFn, options`. Replaced the use of `response, loading` with `data, isLoading`. 

**course-cooperation-service.ts:**
- Replaced `axiosClient` with a reusable `baseService` to standardize API calls.
- Used `getFullUrl` to simplify and centralize `URL` creation with support for query parameters.
- Removed direct use of `AxiosResponse`, returning the parsed response directly (`CourseCooperationResponse`) for better type safety and usability.

**ChangeResorceConfirmModal.spec.tsx:**
- Adjusted the use of `useQuery` in tests.

**Issue: #3075**
