### PR TITLE
Replace useAxios with useQuery and useMutation on Cooperation related pages

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -56,9 +56,10 @@ export const URLs = {
   },
   cooperations: {
     get: '/cooperations',
-    getById: '/cooperations/id',
+    getById: '/cooperations/:id',
     create: '/cooperations',
     update: '/cooperations',
+    updateById: '/cooperations/:id',
     delete: '/cooperations'
   },
   notes: {

--- a/src/containers/cooperation-details/cooperation-activities/CooperationActivities.constants.tsx
+++ b/src/containers/cooperation-details/cooperation-activities/CooperationActivities.constants.tsx
@@ -1,3 +1,4 @@
+import { ResponseError } from '~/exceptions'
 import { ResourcesAvailabilityEnum } from '~/types'
 
 export const cooperationTranslationKeys = [
@@ -11,9 +12,9 @@ export const cooperationTranslationKeys = [
   }
 ]
 
-export const OpenFromError = {
+export const OpenFromError = new ResponseError({
   status: 409,
   code: 'VALIDATION_ERROR',
   message:
     'Cooperation validation failed: OpenFrom:OpenFrom should be with date.'
-}
+})

--- a/src/containers/cooperation-details/cooperation-activities/CooperationActivities.tsx
+++ b/src/containers/cooperation-details/cooperation-activities/CooperationActivities.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FC, SetStateAction, useCallback } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
@@ -28,23 +28,21 @@ import { snackbarVariants } from '~/constants'
 import {
   ResourcesAvailabilityEnum,
   ButtonTypeEnum,
-  ErrorResponse,
-  UpdateCooperationsSections,
-  UpdateCooperationsParams,
   ResourceAvailabilityStatusEnum
 } from '~/types'
+import { type ResponseError } from '~/exceptions'
 
-import useAxios from '~/hooks/use-axios'
+import useMutation from '~/hooks/use-mutation'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 import { getErrorKey } from '~/utils/get-error-key'
 import { getErrorMessage } from '~/utils/error-with-message'
 
 interface CooperationActivitiesProps {
-  cooperationId?: string
-  setEditMode: Dispatch<SetStateAction<boolean>>
+  cooperationId: string
+  setEditMode: React.Dispatch<React.SetStateAction<boolean>>
 }
 
-const CooperationActivities: FC<CooperationActivitiesProps> = ({
+const CooperationActivities: React.FC<CooperationActivitiesProps> = ({
   cooperationId,
   setEditMode
 }) => {
@@ -58,30 +56,19 @@ const CooperationActivities: FC<CooperationActivitiesProps> = ({
     dispatch(setResourcesAvailability(status))
   }
 
-  const checkDate = () => {
-    return sections.some((section) =>
-      section.resources.some((res) => {
-        const availability = res?.availability
-        if (
-          availability?.status === ResourceAvailabilityStatusEnum.OpenFrom &&
-          availability.date === null
-        ) {
-          onResponseError(OpenFromError)
-          return true
-        }
-        return false
+  const checkIfOpenFromDateCorrect = useCallback(() => {
+    return sections.every((section) => {
+      return section.resources.every((resource) => {
+        const { availability } = resource
+
+        return (
+          !availability ||
+          availability.status !== ResourceAvailabilityStatusEnum.OpenFrom ||
+          availability.date !== null
+        )
       })
-    )
-  }
-
-  const onSaveCooperation = () => {
-    if (checkDate()) return
-
-    void updateCooperation({
-      _id: cooperationId,
-      sections
     })
-  }
+  }, [sections])
 
   const onUpdateResponse = useCallback(() => {
     dispatch(
@@ -94,36 +81,48 @@ const CooperationActivities: FC<CooperationActivitiesProps> = ({
   }, [dispatch, setEditMode])
 
   const onResponseError = useCallback(
-    (error?: ErrorResponse) => {
-      const errorKey = getErrorKey(error)
+    (error: ResponseError) => {
       dispatch(
         openAlert({
           severity: snackbarVariants.error,
-          message: error
-            ? {
-                text: errorKey,
-                options: {
-                  message: getErrorMessage(error.message)
-                }
-              }
-            : errorKey
+          message: {
+            text: getErrorKey(error),
+            options: {
+              message: getErrorMessage(error.message)
+            }
+          }
         })
       )
     },
     [dispatch]
   )
 
-  const updateCooperationService = (
-    data: UpdateCooperationsParams | UpdateCooperationsSections
-  ) => cooperationService.updateCooperation(data)
-
-  const { fetchData: updateCooperation } = useAxios({
-    service: updateCooperationService,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponse: onUpdateResponse,
-    onResponseError
+  const { mutate: updateCooperation } = useMutation({
+    mutationFn: cooperationService.updateCooperation,
+    onSuccess: onUpdateResponse,
+    onError: onResponseError
   })
+
+  const handleSaveCooperation = useCallback(() => {
+    const isOpenFromCorrect = checkIfOpenFromDateCorrect()
+
+    if (!isOpenFromCorrect) {
+      onResponseError(OpenFromError)
+
+      return
+    }
+
+    updateCooperation({
+      _id: cooperationId,
+      sections
+    })
+  }, [
+    checkIfOpenFromDateCorrect,
+    cooperationId,
+    onResponseError,
+    sections,
+    updateCooperation
+  ])
 
   const cooperationOption = cooperationTranslationKeys.map(
     ({ title, value }) => ({
@@ -174,7 +173,7 @@ const CooperationActivities: FC<CooperationActivitiesProps> = ({
           {t('common.cancel')}
         </Button>
         <Button
-          onClick={onSaveCooperation}
+          onClick={handleSaveCooperation}
           size='lg'
           type={ButtonTypeEnum.Submit}
         >

--- a/src/containers/layout/navbar/NavBar.tsx
+++ b/src/containers/layout/navbar/NavBar.tsx
@@ -57,8 +57,11 @@ const Navbar = () => {
   }, [userRole])
 
   const accountItems = useMemo(() => {
-    if (userRole === UserRoleEnum.Student || userRole === UserRoleEnum.Tutor)
-      return Object.values(authRoutes.accountMenu[userRole])
+    if (userRole === UserRoleEnum.Student) {
+      return Object.values(authRoutes.accountMenu.student)
+    } else if (userRole === UserRoleEnum.Tutor) {
+      return Object.values(authRoutes.accountMenu.tutor)
+    }
     return []
   }, [userRole])
 

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -23,9 +23,9 @@ import {
   ButtonTypeEnum,
   ComponentEnum,
   type Cooperation,
-  ErrorResponse,
+  type ErrorResponse,
   StatusEnum,
-  UpdateCooperationsParams
+  type UpdateCooperationsParams
 } from '~/types'
 import { snackbarVariants } from '~/constants'
 import { styles } from '~/containers/my-cooperations/accept-cooperation-modal/AcceptCooperation.styles'

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -1,7 +1,5 @@
-import { FC, useCallback } from 'react'
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AxiosResponse } from 'axios'
-import { type QueryObserverResult } from '@tanstack/react-query'
 
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
@@ -13,6 +11,7 @@ import Button from '~scss-components/button/Button'
 import Loader from '~/components/loader/Loader'
 import useForm from '~/hooks/use-form'
 import useAxios from '~/hooks/use-axios'
+import useMutation from '~/hooks/use-mutation'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import useConfirm from '~/hooks/use-confirm'
 import { useModalContext } from '~/context/modal-context'
@@ -23,9 +22,8 @@ import { OfferService } from '~/services/offer-service'
 import {
   ButtonTypeEnum,
   ComponentEnum,
-  Cooperation,
+  type Cooperation,
   ErrorResponse,
-  type ItemsWithCount,
   StatusEnum,
   UpdateCooperationsParams
 } from '~/types'
@@ -37,14 +35,10 @@ import { getErrorKey } from '~/utils/get-error-key'
 
 interface AcceptCooperationModalProps {
   cooperation: Cooperation
-  getCooperations: () => Promise<
-    QueryObserverResult<ItemsWithCount<Cooperation>>
-  >
 }
 
-const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
-  cooperation,
-  getCooperations
+const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
+  cooperation
 }) => {
   const { t } = useTranslation()
   const { isDesktop } = useBreakpoints()
@@ -55,13 +49,15 @@ const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
 
   const needAction = cooperation.user.role !== cooperation.needAction.role
 
-  const handleUpdateCooperation = (
-    params?: UpdateCooperationsParams
-  ): Promise<AxiosResponse> =>
-    cooperationService.updateCooperation({
-      _id: cooperation._id,
-      ...params
-    })
+  const handleUpdateCooperation = useCallback(
+    (params: Omit<UpdateCooperationsParams, '_id'>) => {
+      return cooperationService.updateCooperation({
+        _id: cooperation._id,
+        ...params
+      })
+    },
+    [cooperation._id]
+  )
 
   const updateOffer = useCallback(
     () =>
@@ -77,7 +73,6 @@ const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
       })
     )
     closeModal()
-    void getCooperations()
   }
 
   const onResponseError = (error?: ErrorResponse) => {
@@ -89,13 +84,13 @@ const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
     )
   }
 
-  const { loading, fetchData } = useAxios({
-    service: handleUpdateCooperation,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponse,
-    onResponseError
-  })
+  const { isPending: isUpdateCooperationPending, mutate: updateCooperation } =
+    useMutation({
+      mutationFn: handleUpdateCooperation,
+      queryKey: ['cooperations'],
+      onSuccess: onResponse,
+      onError: onResponseError
+    })
 
   const { loading: updateLoading, fetchData: fetchUpdateOffer } = useAxios({
     service: updateOffer,
@@ -104,7 +99,7 @@ const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
     onResponseError
   })
 
-  const handleAcceptCooperation = async () => {
+  const handleAcceptCooperation = useCallback(async () => {
     const confirmed = await checkConfirmation({
       message: t('cooperationsPage.acceptModal.confirm.accept', {
         price: cooperation.price
@@ -112,35 +107,50 @@ const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
       title: 'titles.confirmTitle',
       check: true
     })
-    if (confirmed) return fetchData({ status: StatusEnum.Active })
-  }
 
-  const handleDeclineCooperation = async () => {
+    if (confirmed) {
+      updateCooperation({ status: StatusEnum.Active })
+    }
+  }, [checkConfirmation, cooperation.price, t, updateCooperation])
+
+  const handleDeclineCooperation = useCallback(async () => {
     const confirmed = await checkConfirmation({
       message: t('cooperationsPage.acceptModal.confirm.decline'),
       title: 'titles.confirmTitle',
       check: true
     })
+
     if (confirmed) {
       await fetchUpdateOffer()
-      return fetchData({ status: StatusEnum.Closed })
+      updateCooperation({ status: StatusEnum.Closed })
     }
-  }
+  }, [checkConfirmation, fetchUpdateOffer, t, updateCooperation])
 
-  const handleResendCooperation = async (): Promise<void> => {
-    const confirmed = await checkConfirmation({
-      message: t('cooperationsPage.acceptModal.confirm.resend', {
-        price: data.price
-      }),
-      title: 'titles.confirmTitle',
-      check: true
-    })
-    if (confirmed) return fetchData({ price: data.price })
-  }
+  const handleResendCooperation = useCallback(
+    async (data?: Record<'price', number>) => {
+      if (!data) {
+        return
+      }
 
-  const { data, isDirty, handleNonInputValueChange, handleSubmit } = useForm({
+      const confirmed = await checkConfirmation({
+        message: t('cooperationsPage.acceptModal.confirm.resend', {
+          price: data.price
+        }),
+        title: 'titles.confirmTitle',
+        check: true
+      })
+
+      if (confirmed) {
+        updateCooperation({ price: data.price })
+      }
+    },
+    [checkConfirmation, t, updateCooperation]
+  )
+
+  const { isDirty, handleNonInputValueChange, handleSubmit } = useForm({
     initialValues: { price: cooperation.price },
-    onSubmit: handleResendCooperation
+    onSubmit: handleResendCooperation,
+    submitWithData: true
   })
 
   const handlePriceChange = (value: number) => {
@@ -157,7 +167,7 @@ const AcceptCooperationModal: FC<AcceptCooperationModalProps> = ({
     : ButtonTypeEnum.Button
 
   const buttons =
-    loading || updateLoading ? (
+    isUpdateCooperationPending || updateLoading ? (
       <Loader size={50} />
     ) : (
       <Box sx={styles.buttonRow}>

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.constants.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.constants.tsx
@@ -5,14 +5,7 @@ import TodayIcon from '@mui/icons-material/Today'
 import EmptyActivities from '~/containers/my-cooperations/empty-cooperation-activities/EmptyCooperationActivities'
 import MyCooperationsDetails from '../my-cooperations-details/MyCooperationsDetails'
 
-import {
-  Cooperation,
-  CooperationTabsEnum,
-  NeedActionTypeEnum,
-  ProficiencyLevelEnum,
-  StatusEnum,
-  UserRoleEnum
-} from '~/types'
+import { CooperationTabsEnum } from '~/types'
 
 export type MyCooperationsTabsData = {
   [key in CooperationTabsEnum]: {
@@ -35,59 +28,4 @@ export const tabsData: MyCooperationsTabsData = {
     title: 'cooperationsPage.tabs.details',
     content: <MyCooperationsDetails />
   }
-}
-
-export const defaultResponse: Cooperation = {
-  offer: {
-    title: '',
-    category: {
-      _id: '',
-      name: '',
-      appearance: {
-        icon: '',
-        color: ''
-      },
-      totalOffers: {
-        [UserRoleEnum.Student]: 0,
-        [UserRoleEnum.Tutor]: 0
-      },
-      createdAt: '',
-      updatedAt: ''
-    },
-    subject: {
-      _id: '',
-      name: ''
-    },
-    price: 0,
-    _id: ''
-  },
-  user: {
-    _id: '',
-    firstName: '',
-    lastName: '',
-    role: UserRoleEnum.Tutor
-  },
-  title: '',
-  price: 0,
-  proficiencyLevel: ProficiencyLevelEnum.Beginner,
-  status: StatusEnum.Active,
-  needAction: {
-    role: UserRoleEnum.Tutor,
-    type: NeedActionTypeEnum.Price,
-    messages: []
-  },
-  sections: [],
-  createdAt: '',
-  updatedAt: '',
-  _id: '',
-  initiator: {
-    firstName: '',
-    lastName: ''
-  },
-  initiatorRole: 'tutor',
-  receiver: {
-    firstName: '',
-    lastName: ''
-  },
-  receiverRole: 'student'
 }

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
-import { AxiosResponse } from 'axios'
 
 import Box from '@mui/material/Box'
 import KeyboardDoubleArrowLeftIcon from '@mui/icons-material/KeyboardDoubleArrowLeft'
@@ -15,7 +14,8 @@ import Loader from '~/components/loader/Loader'
 import StatusChip from '~/components/status-chip/StatusChip'
 import Button from '~scss-components/button/Button'
 
-import useAxios from '~/hooks/use-axios'
+import useMutation from '~/hooks/use-mutation'
+import useQuery from '~/hooks/use-query'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 
@@ -24,7 +24,6 @@ import CooperationNotes from '~/containers/my-cooperations/cooperation-notes/Coo
 import CooperationActivitiesView from '~/containers/cooperation-details/cooperation-activities-view/CooperationActivitiesView'
 import {
   tabsData,
-  defaultResponse,
   MyCooperationsTabsData
 } from '~/containers/my-cooperations/cooperation-details/CooperationDetails.constants'
 import { styles } from '~/containers/my-cooperations/cooperation-details/CooperationDetails.styles'
@@ -32,12 +31,7 @@ import { styles } from '~/containers/my-cooperations/cooperation-details/Coopera
 import { errorRoutes } from '~/router/constants/errorRoutes'
 import { cooperationService } from '~/services/cooperation-service'
 
-import {
-  CooperationTabsEnum,
-  PositionEnum,
-  Cooperation,
-  StatusEnum
-} from '~/types'
+import { CooperationTabsEnum, PositionEnum, StatusEnum } from '~/types'
 import {
   cooperationsSelector,
   setCooperationSections,
@@ -50,7 +44,7 @@ const CooperationDetails = () => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const { t } = useTranslation()
-  const { id } = useParams()
+  const { id = '' } = useParams()
   const { isDesktop } = useBreakpoints()
   const { isActivityCreated } = useAppSelector(cooperationsSelector)
   const [isNotesOpen, setIsNotesOpen] = useState<boolean>(false)
@@ -75,26 +69,32 @@ const CooperationDetails = () => {
     }
   }, [defaultTab, isTabInSearchParams, setSearchParams])
 
-  const responseError = useCallback(
-    () => navigate(errorRoutes.notFound.path),
-    [navigate]
-  )
-
-  const getCooperation = useCallback((): Promise<AxiosResponse> => {
+  const getCooperation = useCallback(() => {
     return cooperationService.getCooperationById(id)
   }, [id])
 
-  const { loading, response } = useAxios<Cooperation, string>({
-    service: getCooperation,
-    defaultResponse,
-    onResponseError: responseError
+  const {
+    data: cooperation,
+    isLoading,
+    isError
+  } = useQuery({
+    queryFn: getCooperation,
+    queryKey: ['cooperation', id]
   })
 
   useEffect(() => {
-    dispatch(setCooperationSections(response.sections))
-    dispatch(setCooperationStatus(response.status))
-    setEditMode(Boolean(response?.sections?.length))
-  }, [response.sections, response.status, dispatch])
+    if (isError) {
+      navigate(errorRoutes.notFound.path)
+    }
+  }, [isError, navigate])
+
+  useEffect(() => {
+    if (cooperation) {
+      dispatch(setCooperationSections(cooperation.sections))
+      dispatch(setCooperationStatus(cooperation.status))
+      setEditMode(Boolean(cooperation.sections?.length))
+    }
+  }, [cooperation, dispatch])
 
   const handleEditMode = useCallback(() => {
     setEditMode((prev) => !prev)
@@ -106,15 +106,20 @@ const CooperationDetails = () => {
       _id: id,
       status: StatusEnum.Closed
     })
+  }, [id])
+
+  const handleCooperationStatusUpdateSuccess = useCallback(() => {
     setIsClosed(true)
     dispatch(setCooperationStatus(StatusEnum.Closed))
-  }, [id, dispatch])
+  }, [dispatch])
 
-  const handleCooperationCloseAccept = useCallback(() => {
-    void handleCooperationStatusUpdate()
-  }, [handleCooperationStatusUpdate])
+  const { mutate: handleCooperationClosingAccept } = useMutation({
+    mutationFn: handleCooperationStatusUpdate,
+    onSuccess: handleCooperationStatusUpdateSuccess,
+    queryKeys: [['cooperations'], ['cooperation', id]]
+  })
 
-  if (loading) {
+  if (isLoading || !cooperation) {
     return <Loader pageLoad />
   }
 
@@ -151,22 +156,22 @@ const CooperationDetails = () => {
   }
 
   const closeCooperationInitiator =
-    response.needAction.role === response.receiverRole
-      ? response.initiator
-      : response.receiver
+    cooperation.needAction.role === cooperation.receiverRole
+      ? cooperation.initiator
+      : cooperation.receiver
 
   const acceptClosingProcess = !isClosed && (
     <AcceptCooperationClosing
       isReasonSubmitted={false}
-      onAccept={handleCooperationCloseAccept}
+      onAccept={handleCooperationClosingAccept}
       onReasonSubmit={() => {}}
       user={closeCooperationInitiator.firstName}
     />
   )
 
   const isCooperationClosingRequestSend =
-    response.needAction.role === userRole &&
-    response.status === StatusEnum.RequestToClose
+    cooperation.needAction.role === userRole &&
+    cooperation.status === StatusEnum.RequestToClose
 
   const iconConditionals = isNotesOpen ? (
     <KeyboardDoubleArrowRightIcon />
@@ -181,7 +186,7 @@ const CooperationDetails = () => {
         <TitleWithDescription
           key={crypto.randomUUID()}
           style={styles.cooperationTitle}
-          title={response.title}
+          title={cooperation.title}
         />
       </Box>
       <Box sx={styles.tabsWrapper}>

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -1,6 +1,4 @@
 import Box from '@mui/material/Box'
-import { FC } from 'react'
-import { type QueryObserverResult } from '@tanstack/react-query'
 
 import EnhancedTable from '~/components/enhanced-table/EnhancedTable'
 import AcceptCooperationModal from '~/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal'
@@ -15,23 +13,19 @@ import {
   removeColumnRules
 } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.constants'
 import { styles } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
-import { Cooperation, type ItemsWithCount, SizeEnum, StatusEnum } from '~/types'
+import { type Cooperation, SizeEnum, StatusEnum } from '~/types'
 import { useNavigate } from 'react-router-dom'
 
 interface CooperationContainerProps {
   items: Cooperation[]
   showTable: boolean
   sort: SortHook
-  getCooperations: () => Promise<
-    QueryObserverResult<ItemsWithCount<Cooperation>>
-  >
 }
 
-const CooperationContainer: FC<CooperationContainerProps> = ({
+const CooperationContainer: React.FC<CooperationContainerProps> = ({
   items,
   sort,
-  showTable,
-  getCooperations
+  showTable
 }) => {
   const breakpoints = useBreakpoints()
   const { openModal } = useModalContext()
@@ -46,12 +40,7 @@ const CooperationContainer: FC<CooperationContainerProps> = ({
   const handleCardClick = (item: Cooperation) => {
     item.status === StatusEnum.Pending
       ? openModal({
-          component: (
-            <AcceptCooperationModal
-              cooperation={item}
-              getCooperations={getCooperations}
-            />
-          )
+          component: <AcceptCooperationModal cooperation={item} />
         })
       : (item.status === StatusEnum.Active ||
           item.status === StatusEnum.RequestToClose) &&

--- a/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.tsx
+++ b/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.tsx
@@ -1,14 +1,14 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import DoneIcon from '@mui/icons-material/Done'
 import PersonIcon from '@mui/icons-material/Person'
 import MessageIcon from '@mui/icons-material/Message'
-
-import useAxios from '~/hooks/use-axios'
+import useMutation from '~/hooks/use-mutation'
+import useQuery from '~/hooks/use-query'
 import { cooperationService } from '~/services/cooperation-service'
 import AvatarIcon from '~/components/avatar-icon/AvatarIcon'
 import SubjectLevelChips from '~/components/subject-level-chips/SubjectLevelChips'
@@ -16,31 +16,20 @@ import Button from '~scss-components/button/Button'
 import ShowMoreCollapse from '~/components/show-more-collapse/ShowMoreCollapse'
 import Loader from '~/components/loader/Loader'
 import useConfirm from '~/hooks/use-confirm'
-
-import {
-  ButtonVariantEnum,
-  MyCooperationDetails,
-  Offer,
-  ServiceFunction,
-  StatusEnum,
-  UpdateCooperationStatusParams,
-  UserRoleEnum
-} from '~/types'
+import { ButtonVariantEnum, StatusEnum, UserRoleEnum } from '~/types'
 import { style } from '~/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.styles'
-import { createUrlPath } from '~/utils/helper-functions'
+import { getFullUrl } from '~/utils/get-full-url'
 import { authRoutes } from '~/router/constants/authRoutes'
 import { useChatContext } from '~/context/chat-context'
 import CooperationCompletion from '../cooperation-completion/CooperationCompletion'
 import { getCategoryIcon } from '~/services/category-icon-service'
 import { getValidatedHexColor } from '~/utils/get-validated-hex-color'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
-import { AxiosResponse } from 'axios'
 import { setCooperationStatus } from '~/redux/features/cooperationsSlice'
 
 const MyCooperationsDetails = () => {
   const { t } = useTranslation()
   const { id = '' } = useParams()
-  const navigate = useNavigate()
   const { setChatInfo } = useChatContext()
   const userId = useAppSelector((state) => state.appMain.userId)
   const userRole = useAppSelector((state) => state.appMain.userRole)
@@ -48,74 +37,64 @@ const MyCooperationsDetails = () => {
   const { checkConfirmation } = useConfirm()
   const dispatch = useAppDispatch()
 
-  const getDetails: ServiceFunction<
-    MyCooperationDetails<Offer> | null,
-    undefined
-  > = useCallback(() => cooperationService.getCooperationById(id), [id])
+  const getCooperationDetails = useCallback(() => {
+    return cooperationService.getCooperationById(id)
+  }, [id])
 
-  const {
-    response: detailsResponse,
-    loading: detailsLoading,
-    fetchData
-  } = useAxios<MyCooperationDetails<Offer> | null>({
-    service: getDetails,
-    defaultResponse: null
+  const { data: cooperationDetails, isLoading: detailsLoading } = useQuery({
+    queryFn: getCooperationDetails,
+    queryKey: ['cooperation-details', id],
+    options: {
+      staleTime: Infinity
+    }
   })
 
-  const handleCooperationStatusChange = (
-    params: UpdateCooperationStatusParams
-  ): Promise<AxiosResponse> =>
-    cooperationService.updateCooperation({
-      _id: id,
-      ...params
+  const { mutate: updateCooperationDetails } = useMutation({
+    mutationFn: cooperationService.updateCooperation,
+    queryKeys: [['cooperations'], ['cooperation-details', id]]
+  })
+
+  const handleCooperationStatusUpdate = useCallback(async () => {
+    const isConfirmed = await checkConfirmation({
+      title: t('titles.confirmCooperationClosing'),
+      message: t('cooperationsPage.closeCooperationModal.message'),
+      check: true
     })
 
-  const onResponse = () => {
-    void fetchStatusData()
-  }
+    if (isConfirmed) {
+      updateCooperationDetails({ _id: id, status: StatusEnum.RequestToClose })
+      dispatch(setCooperationStatus(StatusEnum.RequestToClose))
+    }
+  }, [checkConfirmation, dispatch, id, t, updateCooperationDetails])
 
-  const { fetchData: fetchStatusData } = useAxios({
-    service: handleCooperationStatusChange,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponse
-  })
+  const handleCloseCooperation = useCallback(() => {
+    void handleCooperationStatusUpdate()
+  }, [handleCooperationStatusUpdate])
 
-  const updateInfo = useCallback(() => {
-    void fetchData
-  }, [fetchData])
-
-  if (detailsLoading || !detailsResponse) {
+  if (detailsLoading || !cooperationDetails) {
     return <Loader pageLoad />
   }
 
   const displayedUser =
-    detailsResponse.initiator._id === userId
-      ? detailsResponse.receiver
-      : detailsResponse.initiator
-  const isTutor = displayedUser.role[0] === UserRoleEnum.Tutor
+    cooperationDetails.initiator._id === userId
+      ? cooperationDetails.receiver
+      : cooperationDetails.initiator
 
-  const { offer, price } = detailsResponse
+  const [displayedUserRole] = displayedUser.role
+
+  const { offer, price } = cooperationDetails
 
   const CategoryIcon = getCategoryIcon(offer.category.appearance.icon)
   const categoryColor = getValidatedHexColor(offer.category.appearance.color)
 
-  const onHandleClick = () => {
-    navigate(
-      createUrlPath(authRoutes.userProfile.path, displayedUser._id, {
-        role: displayedUser.role
-      })
-    )
-  }
-
   const onClickOpenChat = () =>
     setChatInfo({
       author: displayedUser,
-      authorRole: displayedUser.role[0] as
+      authorRole: displayedUserRole as
         | UserRoleEnum.Student
         | UserRoleEnum.Tutor,
       chatId: offer.chatId,
-      updateInfo: updateInfo
+      updateInfo: () => {}
     })
 
   const languages = offer.languages?.map((item: string) => (
@@ -127,23 +106,12 @@ const MyCooperationsDetails = () => {
 
   const avatarSrc =
     displayedUser.photo &&
-    createUrlPath(import.meta.env.VITE_APP_IMG_USER_URL, displayedUser.photo)
-
-  const handleCooperationStatusUpdate = async () => {
-    const confirmed = await checkConfirmation({
-      title: t('titles.confirmCooperationClosing'),
-      message: t('cooperationsPage.closeCooperationModal.message'),
-      check: true
+    getFullUrl({
+      pathname: import.meta.env.VITE_APP_IMG_USER_URL as `${string}/:fileName`,
+      parameters: {
+        fileName: displayedUser.photo
+      }
     })
-    if (confirmed) {
-      await fetchStatusData({ status: StatusEnum.RequestToClose })
-      dispatch(setCooperationStatus(StatusEnum.RequestToClose))
-    }
-  }
-
-  const onCooperationStatusUpdate = () => {
-    void handleCooperationStatusUpdate()
-  }
 
   return (
     <Box>
@@ -157,7 +125,7 @@ const MyCooperationsDetails = () => {
         <Typography sx={style.title}>{offer.title}</Typography>
         <Typography sx={style.titles}>
           {t(
-            isTutor
+            displayedUserRole === UserRoleEnum.Tutor
               ? 'cooperationDetailsPage.tutor'
               : 'cooperationDetailsPage.student'
           )}
@@ -187,10 +155,19 @@ const MyCooperationsDetails = () => {
               {t('common.labels.sendMessage')}
             </Button>
             <Button
-              onClick={onHandleClick}
+              component={Link}
               size='md'
               startIcon={<PersonIcon />}
               sx={style.buttons}
+              to={getFullUrl({
+                pathname: authRoutes.userProfile.route,
+                parameters: {
+                  id: displayedUser._id
+                },
+                searchParameters: {
+                  role: displayedUserRole
+                }
+              })}
               variant={ButtonVariantEnum.Tonal}
             >
               {t('cooperationDetailsPage.profile')}
@@ -232,7 +209,7 @@ const MyCooperationsDetails = () => {
       </Box>
       <CooperationCompletion
         cooperationStatus={cooperationStatus}
-        onCloseCooperation={onCooperationStatusUpdate}
+        onCloseCooperation={handleCloseCooperation}
         userRole={userRole}
       />
     </Box>

--- a/src/containers/offer-details/enroll-offer/EnrollOffer.tsx
+++ b/src/containers/offer-details/enroll-offer/EnrollOffer.tsx
@@ -1,12 +1,10 @@
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AxiosResponse } from 'axios'
 import Box from '@mui/material/Box'
 
-import useAxios from '~/hooks/use-axios'
+import useMutation from '~/hooks/use-mutation'
 import useForm from '~/hooks/use-form'
 import { useModalContext } from '~/context/modal-context'
-import { useAppDispatch } from '~/hooks/use-redux'
+import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 import OfferCardSquare from '~/containers/find-offer/offer-card-square/OfferCardSquare'
 import AppTextArea from '~/components/app-text-area/AppTextArea'
 import AppCard from '~/components/app-card/AppCard'
@@ -23,9 +21,8 @@ import { minMaxPrice } from '~/utils/range-filter'
 
 import {
   ComponentEnum,
-  ErrorResponse,
-  Offer,
-  EnrollOfferForm,
+  type Offer,
+  type EnrollOfferForm,
   ButtonTypeEnum,
   TypographyVariantEnum
 } from '~/types'
@@ -33,21 +30,23 @@ import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
 import { textField } from '~/utils/validations/common'
 import { Typography } from '@mui/material'
+import { type ResponseError } from '~/exceptions'
 
 interface EnrollOfferProps {
   offer: Offer
   enrollOffer: () => Promise<void>
 }
 
-const EnrollOffer: FC<EnrollOfferProps> = ({ offer, enrollOffer }) => {
+const EnrollOffer: React.FC<EnrollOfferProps> = ({ offer, enrollOffer }) => {
   const { isLaptopAndAbove } = useBreakpoints()
   const { closeModal } = useModalContext()
+  const { bookmarkedOffers } = useAppSelector((state) => state.editProfile)
   const dispatch = useAppDispatch()
   const { t } = useTranslation()
 
   const [minPrice, maxPrice] = minMaxPrice(offer.price, 0.25)
 
-  const handleResponseError = (error?: ErrorResponse) => {
+  const handleResponseError = (error: ResponseError) => {
     dispatch(
       openAlert({
         severity: snackbarVariants.error,
@@ -66,21 +65,11 @@ const EnrollOffer: FC<EnrollOfferProps> = ({ offer, enrollOffer }) => {
     void enrollOffer()
   }
 
-  const postOffer = (): Promise<AxiosResponse> => {
-    return cooperationService.createCooperation({
-      ...data,
-      receiver: offer.author._id,
-      receiverRole: offer.authorRole,
-      offer: offer._id
-    })
-  }
-
-  const { loading, fetchData } = useAxios({
-    service: postOffer,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponse: handleResponse,
-    onResponseError: handleResponseError
+  const { isPending, mutate: createCooperation } = useMutation({
+    mutationFn: cooperationService.createCooperation,
+    queryKey: ['cooperations'],
+    onError: handleResponseError,
+    onSuccess: handleResponse
   })
 
   const validateAdditionalInfo = (additionalInfoValue: string) => {
@@ -110,7 +99,17 @@ const EnrollOffer: FC<EnrollOfferProps> = ({ offer, enrollOffer }) => {
       title: offer.title
     },
     validations: validations,
-    onSubmit: fetchData
+    submitWithData: true,
+    onSubmit: (data) => {
+      if (data) {
+        createCooperation({
+          ...data,
+          receiver: offer.author._id,
+          receiverRole: offer.authorRole,
+          offer: offer._id
+        })
+      }
+    }
   })
 
   const levelOptions = offer.proficiencyLevel.map((level) => ({
@@ -124,11 +123,13 @@ const EnrollOffer: FC<EnrollOfferProps> = ({ offer, enrollOffer }) => {
       handleNonInputValueChange(key, value)
     }
 
+  const isBookmarked = bookmarkedOffers.includes(offer._id)
+
   return (
     <Box sx={styles.root}>
       {isLaptopAndAbove && (
         <AppCard sx={styles.offerCard}>
-          <OfferCardSquare offer={offer} />
+          <OfferCardSquare isBookmarked={isBookmarked} offer={offer} />
         </AppCard>
       )}
       <Box
@@ -179,7 +180,7 @@ const EnrollOffer: FC<EnrollOfferProps> = ({ offer, enrollOffer }) => {
           )}
         </Box>
         <Button
-          loading={loading}
+          loading={isPending}
           sx={styles.button}
           type={ButtonTypeEnum.Submit}
         >

--- a/src/pages/my-cooperations/MyCooperations.tsx
+++ b/src/pages/my-cooperations/MyCooperations.tsx
@@ -26,7 +26,7 @@ import {
   sortTranslationKeys,
   tabsInfo
 } from '~/pages/my-cooperations/MyCooperations.constants'
-import { defaultResponses, itemsLoadLimit } from '~/constants'
+import { itemsLoadLimit } from '~/constants'
 import { CardsViewEnum, UserRoleEnum } from '~/types'
 import { styles } from '~/pages/my-cooperations/MyCooperations.styles'
 import TabFilterList from '~/components/tab-filter-list/TabFilterList'
@@ -76,11 +76,11 @@ const MyCooperations = () => {
     [filters, page, itemsPerPage, sort]
   )
 
-  const { isLoading, data, refetch } = useQuery({
+  const { isFetching, data } = useQuery({
     queryKey: ['cooperations', filters, sort, page],
     queryFn: getMyCooperations,
     options: {
-      initialData: defaultResponses.itemsWithCount
+      staleTime: Infinity
     }
   })
 
@@ -125,12 +125,11 @@ const MyCooperations = () => {
         view={itemsView}
         withoutSort={showTable}
       />
-      {isLoading ? (
+      {isFetching || !data ? (
         <Loader pageLoad size={50} />
       ) : (
         <>
           <CooperationContainer
-            getCooperations={refetch}
             items={data.items}
             showTable={showTable}
             sort={sortOptions}

--- a/src/router/constants/authRoutes.ts
+++ b/src/router/constants/authRoutes.ts
@@ -2,7 +2,7 @@ export const authRoutes = {
   categories: { route: 'categories', path: '/categories' },
   subjects: { route: 'categories/subjects', path: '/categories/subjects' },
   chat: { route: 'chat', path: '/chat' },
-  userProfile: { route: 'user/:id', path: '/user' },
+  userProfile: { route: '/user/:id', path: '/user' },
   myProfile: { route: 'my-profile', path: '/my-profile' },
   myCooperations: { route: 'my-cooperations', path: '/my-cooperations' },
   myOffers: { route: 'my-offers', path: '/my-offers' },
@@ -96,4 +96,4 @@ export const authRoutes = {
       path: '/my-courses/new-course'
     }
   }
-}
+} as const

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -2,16 +2,14 @@ import { axiosClient } from '~/plugins/axiosClient'
 import { AxiosResponse } from 'axios'
 
 import { URLs } from '~/constants/request'
-import {
+import type {
   CreateCooperationsParams,
   GetCooperationsParams,
   UpdateCooperationsParams,
   CreateOrUpdateNoteParams,
-  Offer,
-  MyCooperationDetails,
   UpdateCooperationsSections,
-  type Cooperation,
-  type ItemsWithCount
+  Cooperation,
+  ItemsWithCount
 } from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
 import { getFullUrl } from '~/utils/get-full-url'
@@ -35,15 +33,29 @@ export const cooperationService = {
     await axiosClient.post(URLs.cooperations.create, data),
   updateCooperation: async (
     data: UpdateCooperationsParams | UpdateCooperationsSections
-  ): Promise<AxiosResponse> =>
-    await axiosClient.patch(
-      createUrlPath(URLs.cooperations.update, data._id),
-      data
-    ),
-  getCooperationById: async (
-    id?: string
-  ): Promise<AxiosResponse<MyCooperationDetails<Offer>>> =>
-    await axiosClient.get(createUrlPath(URLs.cooperations.get, id))
+  ) => {
+    const url = getFullUrl({
+      pathname: URLs.cooperations.updateById,
+      parameters: {
+        id: data._id
+      }
+    })
+
+    return baseService.request<void>({
+      data,
+      method: 'PATCH',
+      url
+    })
+  },
+  getCooperationById: async (id: string) => {
+    return baseService.request<Cooperation>({
+      method: 'GET',
+      url: getFullUrl({
+        pathname: URLs.cooperations.getById,
+        parameters: { id }
+      })
+    })
+  }
 }
 
 export const CooperationNotesService = {

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -27,10 +27,13 @@ export const cooperationService = {
       url
     })
   },
-  createCooperation: async (
-    data: CreateCooperationsParams
-  ): Promise<AxiosResponse> =>
-    await axiosClient.post(URLs.cooperations.create, data),
+  createCooperation: (data: CreateCooperationsParams) => {
+    return baseService.request<void>({
+      method: 'POST',
+      url: URLs.cooperations.create,
+      data
+    })
+  },
   updateCooperation: async (
     data: UpdateCooperationsParams | UpdateCooperationsSections
   ) => {

--- a/src/types/cooperation/interfaces/cooperation.interface.ts
+++ b/src/types/cooperation/interfaces/cooperation.interface.ts
@@ -1,14 +1,12 @@
 import {
-  CommonEntityFields,
-  ProficiencyLevelEnum,
-  StatusEnum,
-  EnrollOfferForm,
-  Offer,
-  UserResponse,
+  type CommonEntityFields,
+  type ProficiencyLevelEnum,
+  type StatusEnum,
+  type EnrollOfferForm,
+  type Offer,
+  type UserResponse,
   UserRoleEnum,
-  SubjectInterface,
-  CategoryInterface,
-  CourseSection
+  type CourseSection
 } from '~/types'
 
 export enum NeedActionTypeEnum {
@@ -18,58 +16,41 @@ export enum NeedActionTypeEnum {
 }
 
 export interface Cooperation extends CommonEntityFields {
-  offer: Pick<Offer, 'subject' | 'title' | 'category' | 'price' | '_id'>
-  user: Pick<UserResponse, 'firstName' | 'lastName' | 'photo' | '_id'> & {
-    role: UserRoleEnum
-  }
-  initiator: Pick<UserResponse, 'firstName' | 'lastName'>
-  initiatorRole: 'tutor' | 'student'
-  title: Offer['title']
-  price: Offer['price']
-  proficiencyLevel: ProficiencyLevelEnum
-  status: StatusEnum
-  needAction: {
-    role: UserRoleEnum
-    type: NeedActionTypeEnum
-    messages: string[]
-  }
-  receiver: Pick<UserResponse, 'firstName' | 'lastName'>
-  receiverRole: 'tutor' | 'student'
-  sections: CourseSection[]
-}
-
-export interface MyCooperationDetails<TOffer extends Offer> {
   offer: Pick<
-    TOffer,
+    Offer,
     | 'subject'
     | 'title'
     | 'category'
     | 'price'
     | '_id'
+    | 'chatId'
+    | 'languages'
     | 'author'
     | 'proficiencyLevel'
     | 'description'
-    | 'languages'
-    | 'chatId'
   >
-  price: number
-  title: string
-  description: string
-  receiver: UserResponse
-  receiverRole: UserRoleEnum
-  languages: string[]
-  chatId: string
-  author: UserResponse
-  subject: Pick<SubjectInterface, 'name'>
-  category: CategoryInterface
-  proficiencyLevel: ProficiencyLevelEnum
+  user: Pick<UserResponse, 'firstName' | 'lastName' | 'photo' | '_id'> & {
+    role: UserRoleEnum.Tutor | UserRoleEnum.Student
+  }
   initiator: UserResponse
-  initiatorRole: UserRoleEnum
+  initiatorRole: UserRoleEnum.Tutor | UserRoleEnum.Student
+  title: Offer['title']
+  price: Offer['price']
+  proficiencyLevel: ProficiencyLevelEnum
+  chatId: string
   status: StatusEnum
+  needAction: {
+    role: UserRoleEnum.Tutor | UserRoleEnum.Student
+    type: NeedActionTypeEnum
+    messages: string[]
+  }
+  receiver: UserResponse
+  receiverRole: UserRoleEnum.Tutor | UserRoleEnum.Student
+  sections: CourseSection[]
 }
 
 export interface CreateCooperationsParams extends EnrollOfferForm {
   offer: string
   receiver: string
-  receiverRole: UserRoleEnum
+  receiverRole: UserRoleEnum.Tutor | UserRoleEnum.Student
 }

--- a/src/types/cooperation/types/cooperation.types.ts
+++ b/src/types/cooperation/types/cooperation.types.ts
@@ -1,12 +1,14 @@
 import { Cooperation } from '~/types'
 
 export type UpdateCooperationsParams = Partial<
-  Pick<Cooperation, 'status' | 'price' | '_id'>
->
+  Pick<Cooperation, 'status' | 'price'>
+> &
+  Pick<Cooperation, '_id'>
 
 export type UpdateCooperationsSections = Partial<
-  Pick<Cooperation, 'sections' | '_id'>
->
+  Pick<Cooperation, 'sections'>
+> &
+  Pick<Cooperation, '_id'>
 
 export type UpdateCooperationStatusParams = Partial<
   Pick<Cooperation, 'status' | '_id'>

--- a/tests/unit/containers/cooperation-details/cooperation-activities/CooperationActivities.spec.jsx
+++ b/tests/unit/containers/cooperation-details/cooperation-activities/CooperationActivities.spec.jsx
@@ -14,11 +14,10 @@ import openIcon from '~/assets/img/cooperation-details/resource-availability/ope
 
 import CooperationActivities from '~/containers/cooperation-details/cooperation-activities/CooperationActivities'
 
-let mockUpdateCooperation
 const mockSetEditMode = vi.fn()
 const mockDispatch = vi.fn()
 
-const mockedSections = [
+const mockedInvalidSections = [
   {
     resources: [
       {
@@ -48,16 +47,6 @@ vi.mock('~/services/cooperation-service', async () => {
     cooperationService: {
       updateCooperation: mockUpdateCooperation
     }
-  }
-})
-
-vi.mock('~/hooks/use-axios', async () => {
-  const actual = await vi.importActual('~/hooks/use-axios')
-  return {
-    ...actual,
-    useAxios: vi.fn(() => ({
-      fetchData: vi.fn()
-    }))
   }
 })
 
@@ -145,13 +134,7 @@ describe('CooperationActivities', () => {
       '~/services/cooperation-service'
     )
 
-    const mockError = {
-      response: {
-        data: {
-          message: 'An error occurred'
-        }
-      }
-    }
+    const mockError = { message: 'Unknown error' }
 
     cooperationService.updateCooperation.mockRejectedValueOnce(mockError)
 
@@ -201,10 +184,10 @@ describe('CooperationActivities', () => {
   })
 })
 
-describe('CooperationActivities - checkDate function', () => {
+describe('CooperationActivities - checkIfOpenFromDateCorrect function', () => {
   beforeEach(() => {
     useAppSelector.mockReturnValue({
-      sections: mockedSections,
+      sections: mockedInvalidSections,
       resourcesAvailability: ResourcesAvailabilityEnum.OpenAll
     })
 
@@ -217,7 +200,7 @@ describe('CooperationActivities - checkDate function', () => {
     )
   })
 
-  it('should return true and call onResponseError when a resource has OpenFrom status with no date', async () => {
+  it('should return false and call onResponseError when a resource has OpenFrom status with no date', async () => {
     const saveButton = screen.getByText('common.save')
     fireEvent.click(saveButton)
 

--- a/tests/unit/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.spec.jsx
+++ b/tests/unit/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.spec.jsx
@@ -23,8 +23,8 @@ const preloadedState = {
 describe('AcceptCooperationModal component ', () => {
   beforeEach(() => {
     mockAxiosClient
-      .onPatch(`${URLs.cooperations.update}/${mockedCoop._id}`)
-      .reply(200, { data: null })
+      .onPatch(URLs.cooperations.updateById.replace(':id', mockedCoop._id))
+      .reply(200)
 
     mockAxiosClient
       .onPatch(`${URLs.offers.update}/${mockedCoop._id}`)

--- a/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
@@ -76,42 +76,39 @@ vi.mock(
 
 describe('CooperationDetails', () => {
   mockAxiosClient
-    .onGet(`${URLs.cooperations.get}/${cooperationID}`)
+    .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
     .reply(200, cooperationMock)
 
-  beforeEach(async () => {
-    await waitFor(() => {
-      renderWithProviders(<CooperationDetails />, { preloadedState: mockState })
-    })
+  beforeEach(() => {
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockState })
   })
 
   it('should render details page', async () => {
     const notesButton = await screen.findByText(
       'cooperationsPage.details.notes'
     )
+
     expect(notesButton).toBeInTheDocument()
   })
 
-  it('should show cooperation status and title', async () => {
-    const title = await screen.findByText(cooperationMock.title)
-    const statusChip = await screen.findByText(cooperationMock.status)
+  it('should show cooperation status and title', () => {
+    const title = screen.getByText(cooperationMock.title)
+    const statusChip = screen.getByText(cooperationMock.status)
 
     expect(title).toBeInTheDocument()
     expect(statusChip).toBeInTheDocument()
   })
 
-  it('should render the component with tabs', async () => {
-    const tab1 = await screen.findByText('cooperationsPage.tabs.activities')
+  it('should render the component with tabs', () => {
+    const tab1 = screen.getByText('cooperationsPage.tabs.activities')
 
     expect(tab1).toBeInTheDocument()
 
-    const tab2 = await screen.findByText('cooperationsPage.tabs.details')
+    const tab2 = screen.getByText('cooperationsPage.tabs.details')
 
     fireEvent.click(tab2)
 
-    await waitFor(() => {
-      expect(tab2).toBeInTheDocument()
-    })
+    expect(tab2).toBeInTheDocument()
   })
 
   it('should toggle notes block', async () => {
@@ -121,16 +118,14 @@ describe('CooperationDetails', () => {
 
     fireEvent.click(notes)
 
-    let cooperationNotes = await screen.findByText(/cooperation notes/i)
-    await waitFor(() => {
-      expect(cooperationNotes).toBeInTheDocument()
-    })
+    let cooperationNotes = screen.queryByText('Cooperation Notes')
+
+    expect(cooperationNotes).toBeInTheDocument()
 
     fireEvent.click(notes)
 
-    await waitFor(() => {
-      cooperationNotes = screen.queryByText(/cooperation notes/i)
-      expect(cooperationNotes).not.toBeInTheDocument()
-    })
+    cooperationNotes = screen.queryByText('Cooperation Notes')
+
+    expect(cooperationNotes).not.toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.spec.jsx
@@ -82,7 +82,7 @@ describe('MyCooperationsDetails component', () => {
     const profileButton = screen.queryByText('cooperationDetailsPage.profile')
 
     expect(profileButton).toBeInTheDocument()
-    expect(profileButton.href).toContain(
+    expect(profileButton.parentElement.href).toContain(
       `/user/${mockedOffer.initiator._id}?role=${mockedOffer.initiator.role[0]}`
     )
   })

--- a/tests/unit/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.spec.jsx
@@ -39,19 +39,14 @@ vi.mock('~/context/chat-context', () => ({
   useChatContext: () => mockChatContext
 }))
 
-const mockNavigate = vi.fn()
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
-  useNavigate: () => mockNavigate
-}))
 
 describe('MyCooperationsDetails component', () => {
   beforeEach(async () => {
-    await waitFor(() => {
-      mockAxiosClient.onGet(URLs.cooperations.get).reply(200, mockedOffer)
+    mockAxiosClient
+      .onGet(URLs.cooperations.getById.replace(':id', ''))
+      .reply(200, mockedOffer)
 
-      renderWithProviders(<MyCooperationsDetails />)
-    })
+    renderWithProviders(<MyCooperationsDetails />)
   })
 
   it('should render title', async () => {
@@ -77,22 +72,18 @@ describe('MyCooperationsDetails component', () => {
     fireEvent.click(sendMessageButton)
 
     const chatWindow = await screen.findByTestId('MessageIcon')
+
     await waitFor(() => {
       expect(chatWindow).toBeInTheDocument()
     })
   })
 
-  it('should open profile after clicking on profile-button', async () => {
-    const profileButton = await screen.findByRole('button', {
-      name: 'cooperationDetailsPage.profile'
-    })
+  it('should render link to user profile with correct url', async () => {
+    const profileButton = screen.queryByText('cooperationDetailsPage.profile')
 
     expect(profileButton).toBeInTheDocument()
-
-    fireEvent.click(profileButton)
-
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalled()
-    })
+    expect(profileButton.href).toContain(
+      `/user/${mockedOffer.initiator._id}?role=${mockedOffer.initiator.role[0]}`
+    )
   })
 })

--- a/tests/unit/containers/offer-details/enroll-offer/EnrollOffer.spec.jsx
+++ b/tests/unit/containers/offer-details/enroll-offer/EnrollOffer.spec.jsx
@@ -12,18 +12,15 @@ vi.mock('~/services/cooperation-service', () => ({
 }))
 
 describe('EnrollOffer', () => {
-  beforeEach(async () => {
-    await waitFor(() => {
-      renderWithProviders(
-        <EnrollOffer enrollOffer={vi.fn()} offer={mockOffer} />
-      )
-    })
+  beforeEach(() => {
+    renderWithProviders(<EnrollOffer enrollOffer={vi.fn()} offer={mockOffer} />)
   })
 
   it('should display EnrollOffer form', () => {
     const title = screen.getByText('offerDetailsPage.enrollOffer.title')
     expect(title).toBeInTheDocument()
   })
+
   it('should change proficiencyLevel', () => {
     const newLevel = 'Intermediate'
     const levelSelect = screen.getAllByTestId('app-select')[0]
@@ -35,7 +32,7 @@ describe('EnrollOffer', () => {
     expect(levelSelect.value).toBe(newLevel)
   })
 
-  it('should display error message', () => {
+  it('should display error message', async () => {
     const newAdditionalInfo = 'Some text'
     const additionalInfoInput = screen.getByLabelText(
       'offerDetailsPage.enrollOffer.labels.info'
@@ -46,7 +43,7 @@ describe('EnrollOffer', () => {
     expect(additionalInfoInput.value).toBe(newAdditionalInfo)
 
     const button = screen.getByText('button.createCooperation')
-    waitFor(() => fireEvent.click(button))
+    await waitFor(() => fireEvent.click(button))
 
     const errorMessage = screen.getByText(
       'offerDetailsPage.errors.additionalInfo'
@@ -54,10 +51,10 @@ describe('EnrollOffer', () => {
     expect(errorMessage).toBeInTheDocument()
   })
 
-  it('should send form', () => {
+  it('should send form', async () => {
     const button = screen.getByText('button.createCooperation')
 
-    waitFor(() => fireEvent.click(button))
+    await waitFor(() => fireEvent.click(button))
 
     expect(mockFetchData).toBeCalledTimes(1)
   })

--- a/tests/unit/pages/my-cooperations/MyCooperations.spec.jsx
+++ b/tests/unit/pages/my-cooperations/MyCooperations.spec.jsx
@@ -1,10 +1,10 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders, mockAxiosClient } from '~tests/test-utils'
 import { URLs } from '~/constants/request'
 
 import MyCooperations from '~/pages/my-cooperations/MyCooperations'
 
-mockAxiosClient.onGet(URLs.cooperations.get).reply(200, {
+const MOCK_RESPONSE = {
   items: [
     {
       _id: 'id',
@@ -25,21 +25,35 @@ mockAxiosClient.onGet(URLs.cooperations.get).reply(200, {
     }
   ],
   count: 0
-})
+}
 
 describe('MyCooperations', () => {
-  beforeEach(async () => {
-    await waitFor(() => renderWithProviders(<MyCooperations />))
+  beforeAll(() => {
+    mockAxiosClient
+      .onGet(new RegExp(URLs.cooperations.get))
+      .reply(200, MOCK_RESPONSE)
   })
+
+  beforeEach(() => {
+    renderWithProviders(<MyCooperations />)
+  })
+
   it('should render title on page', async () => {
     const title = screen.getByText('cooperationsPage.title')
 
     expect(title).toBeInTheDocument()
   })
+
+  it('should render opposite user name on cooperation card', async () => {
+    const activeTab = screen.queryByText('Kathryn Murphy')
+
+    expect(activeTab).toBeInTheDocument()
+  })
+
   it('should change tab', () => {
     const activeTab = screen.getByText('cooperationsPage.tabs.active')
 
-    waitFor(() => fireEvent.click(activeTab))
+    fireEvent.click(activeTab)
 
     const coopCard = screen.queryAllByText('Beginner')
 


### PR DESCRIPTION
### Query caching example:

https://github.com/user-attachments/assets/a4cbd46c-a6aa-4aa9-8102-811d697d5e8a


### Query invalidation examples: 

- Entrolling in the offer

https://github.com/user-attachments/assets/6b5737cb-ba4f-4547-be6f-a984d4221c24

- Resending the request

https://github.com/user-attachments/assets/175d6cca-23a8-491e-a88a-5bb62b18db9c

- Accepting the offer

https://github.com/user-attachments/assets/0954c23f-cb6e-4938-9384-5a270b319969

- Request to close cooperation

https://github.com/user-attachments/assets/677097c3-409f-4f81-b9d5-16464af5bc45

- Accepting closing cooperation

https://github.com/user-attachments/assets/ee29a45c-a4f8-4a9f-b873-93295d1aa20f








