### PR TITLE
Fixed Categories page not found error

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -52,6 +52,7 @@ export const URLs = {
   },
   subjects: {
     get: '/subjects',
+    getByCategoryId: '/categories/:categoryId/subjects',
     getNames: '/subjects/names'
   },
   cooperations: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -52,7 +52,7 @@ export const URLs = {
   },
   subjects: {
     get: '/subjects',
-    getByCategoryId: '/categories/:categoryId/subjects',
+    getByCategoryId: '/categories/:id/subjects',
     getNames: '/subjects/names'
   },
   cooperations: {

--- a/src/hooks/use-load-more.tsx
+++ b/src/hooks/use-load-more.tsx
@@ -1,12 +1,18 @@
-import { useState, useMemo, useLayoutEffect, useCallback } from 'react'
+import {
+  useState,
+  useMemo,
+  useLayoutEffect,
+  useCallback,
+  useEffect
+} from 'react'
 
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 
 import { defaultResponses } from '~/constants'
-import { ServiceFunction, ItemsWithCount } from '~/types'
+import { ItemsWithCount, ServiceFunctionNew } from '~/types'
 
 interface UseLoadMoreProps<Data, Params> {
-  service: ServiceFunction<ItemsWithCount<Data>, Params>
+  service: ServiceFunctionNew<ItemsWithCount<Data>, Params>
   limit: number
   params?: Params
 }
@@ -36,20 +42,20 @@ const useLoadMore = <Data, Params>({
     setData([])
   }, [])
 
-  const { response, loading, fetchData } = useAxios<
-    ItemsWithCount<Data>,
-    Params
-  >({
-    service,
-    defaultResponse: defaultResponses.itemsWithCount,
-    fetchOnMount: false,
-    onResponse: handleResponse
+  const { data: response, isLoading: loading } = useQuery({
+    queryFn: () => service({ ...params, limit, skip } as Params),
+    queryKey: [`load-more`, params, limit, skip],
+    options: {
+      initialData: defaultResponses.itemsWithCount
+    }
   })
 
+  useEffect(() => {
+    handleResponse(response)
+  }, [response, handleResponse])
+
   useLayoutEffect(() => {
-    if (previousLimit === limit && !isFetched) {
-      void fetchData({ ...params, limit, skip } as Params)
-    } else {
+    if (previousLimit !== limit || isFetched) {
       resetData()
       setPreviousLimit(limit)
     }
@@ -58,7 +64,7 @@ const useLoadMore = <Data, Params>({
       // eslint-disable-next-line react-hooks/exhaustive-deps
       isFetched = true
     }
-  }, [fetchData, limit, previousLimit, resetData, skip, params])
+  }, [limit, previousLimit, resetData, skip, params])
 
   const isExpandable = useMemo(
     () => data.length < response.count && data.length > 0,

--- a/src/hooks/use-load-more.tsx
+++ b/src/hooks/use-load-more.tsx
@@ -44,7 +44,7 @@ const useLoadMore = <Data, Params>({
 
   const { data: response, isFetching: loading } = useQuery({
     queryFn: () => service({ ...params, limit, skip } as Params),
-    queryKey: [`load-more`, params, limit, skip],
+    queryKey: ['load-more', params, limit, skip],
     options: {
       initialData: defaultResponses.itemsWithCount
     }

--- a/src/hooks/use-load-more.tsx
+++ b/src/hooks/use-load-more.tsx
@@ -42,7 +42,7 @@ const useLoadMore = <Data, Params>({
     setData([])
   }, [])
 
-  const { data: response, isLoading: loading } = useQuery({
+  const { data: response, isFetching: loading } = useQuery({
     queryFn: () => service({ ...params, limit, skip } as Params),
     queryKey: [`load-more`, params, limit, skip],
     options: {

--- a/src/pages/subjects/Subjects.tsx
+++ b/src/pages/subjects/Subjects.tsx
@@ -78,9 +78,9 @@ const Subjects = () => {
   }
 
   const getSubjects = useCallback(
-    (data?: Pick<SubjectInterface, 'name'>) =>
-      subjectService.getSubjects(data, categoryId),
-    [categoryId]
+    (data?: Pick<SubjectInterface, 'name' | 'category'>) =>
+      subjectService.getSubjects(data),
+    []
   )
 
   const {
@@ -89,10 +89,16 @@ const Subjects = () => {
     resetData,
     loadMore,
     isExpandable
-  } = useLoadMore<SubjectInterface, Pick<SubjectInterface, 'name'>>({
+  } = useLoadMore<
+    SubjectInterface,
+    Pick<SubjectInterface, 'name' | 'category'>
+  >({
     service: getSubjects,
     limit: cardsLimit,
-    params
+    params: {
+      ...params,
+      category: { _id: categoryId, appearance: { icon: '', color: '' } }
+    }
   })
 
   const oppositeRole = getOpositeRole(userRole)

--- a/src/pages/subjects/Subjects.tsx
+++ b/src/pages/subjects/Subjects.tsx
@@ -78,7 +78,7 @@ const Subjects = () => {
   }
 
   const getSubjects = useCallback(
-    (data: Pick<SubjectInterface, 'name' | 'category'>) =>
+    (data: Pick<SubjectInterface, 'name'> & Record<'categoryId', string>) =>
       subjectService.getSubjects(data),
     []
   )
@@ -91,13 +91,13 @@ const Subjects = () => {
     isExpandable
   } = useLoadMore<
     SubjectInterface,
-    Pick<SubjectInterface, 'name' | 'category'>
+    Pick<SubjectInterface, 'name'> & Record<'categoryId', string>
   >({
     service: getSubjects,
     limit: cardsLimit,
     params: {
       ...params,
-      category: { _id: categoryId, appearance: { icon: '', color: '' } }
+      categoryId
     }
   })
 

--- a/src/pages/subjects/Subjects.tsx
+++ b/src/pages/subjects/Subjects.tsx
@@ -78,7 +78,7 @@ const Subjects = () => {
   }
 
   const getSubjects = useCallback(
-    (data?: Pick<SubjectInterface, 'name' | 'category'>) =>
+    (data: Pick<SubjectInterface, 'name' | 'category'>) =>
       subjectService.getSubjects(data),
     []
   )

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -8,18 +8,20 @@ import { baseService } from '~/services/base-service'
 import { getFullUrl } from '~/utils/get-full-url'
 
 export const subjectService = {
-  getSubjects: (params: Pick<SubjectInterface, 'name' | 'category'>) => {
-    const { category, ...restParams } = params
+  getSubjects: (
+    params: Pick<SubjectInterface, 'name'> & Record<'categoryId', string>
+  ) => {
+    const { categoryId, ...restParams } = params
 
     let resultUrl = getFullUrl({
       pathname: URLs.subjects.get,
       searchParameters: restParams
     })
 
-    if (category?._id) {
+    if (categoryId) {
       resultUrl = getFullUrl({
         pathname: URLs.subjects.getByCategoryId,
-        parameters: { id: category._id },
+        parameters: { id: categoryId },
         searchParameters: restParams
       })
     }

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -4,14 +4,27 @@ import { AxiosResponse } from 'axios'
 import { URLs } from '~/constants/request'
 import { ItemsWithCount, SubjectInterface, SubjectNameInterface } from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
+import { baseService } from '~/services/base-service'
+import { getFullUrl } from '~/utils/get-full-url'
 
 export const subjectService = {
-  getSubjects: (
-    params?: Pick<SubjectInterface, 'name'>,
-    categoryId?: string
-  ): Promise<AxiosResponse<ItemsWithCount<SubjectInterface>>> => {
-    const category = createUrlPath(URLs.categories.get, categoryId)
-    return axiosClient.get(`${category}${URLs.subjects.get}`, { params })
+  getSubjects: (params?: Pick<SubjectInterface, 'name' | 'category'>) => {
+    const { category: { _id: categoryId } = {}, ...restParams } = params ?? {}
+    let resultUrl = getFullUrl({
+      pathname: URLs.subjects.get,
+      searchParameters: restParams
+    })
+    if (categoryId) {
+      resultUrl = getFullUrl({
+        pathname: URLs.subjects.getByCategoryId,
+        parameters: { categoryId },
+        searchParameters: restParams
+      })
+    }
+    return baseService.request<ItemsWithCount<SubjectInterface>>({
+      method: 'GET',
+      url: resultUrl
+    })
   },
   getSubjectsNames: (
     categoryId: string | null

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -8,18 +8,18 @@ import { baseService } from '~/services/base-service'
 import { getFullUrl } from '~/utils/get-full-url'
 
 export const subjectService = {
-  getSubjects: (params?: Pick<SubjectInterface, 'name' | 'category'>) => {
-    const { category: { _id: categoryId } = {}, ...restParams } = params ?? {}
+  getSubjects: (params: Pick<SubjectInterface, 'name' | 'category'>) => {
+    const { category, ...restParams } = params
 
     let resultUrl = getFullUrl({
       pathname: URLs.subjects.get,
       searchParameters: restParams
     })
 
-    if (categoryId) {
+    if (category?._id) {
       resultUrl = getFullUrl({
         pathname: URLs.subjects.getByCategoryId,
-        parameters: { categoryId },
+        parameters: { id: category._id },
         searchParameters: restParams
       })
     }

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -10,10 +10,12 @@ import { getFullUrl } from '~/utils/get-full-url'
 export const subjectService = {
   getSubjects: (params?: Pick<SubjectInterface, 'name' | 'category'>) => {
     const { category: { _id: categoryId } = {}, ...restParams } = params ?? {}
+
     let resultUrl = getFullUrl({
       pathname: URLs.subjects.get,
       searchParameters: restParams
     })
+
     if (categoryId) {
       resultUrl = getFullUrl({
         pathname: URLs.subjects.getByCategoryId,
@@ -21,6 +23,7 @@ export const subjectService = {
         searchParameters: restParams
       })
     }
+
     return baseService.request<ItemsWithCount<SubjectInterface>>({
       method: 'GET',
       url: resultUrl

--- a/tests/unit/hooks/use-load-more.spec.jsx
+++ b/tests/unit/hooks/use-load-more.spec.jsx
@@ -1,34 +1,38 @@
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { mockAxiosClient } from '~tests/test-utils'
 import useLoadMore from '~/hooks/use-load-more'
+import QueryProvider from '~/QueryProvider'
 
 const mockParams = { limit: 1 }
 const mockResponseData = [
   { _id: '1', name: 'test' },
   { _id: '2', name: 'test2' }
 ]
-const getData = (items) => ({ count: mockResponseData.length, items })
 
-const mockResponse = { data: getData(mockResponseData) }
+const mockResponse = { items: mockResponseData, count: mockResponseData.length }
 
 const mockService = vi.fn((params) => {
   const { limit, skip } = params
   const data = mockResponseData.slice(skip, limit + skip)
-  return Promise.resolve({ data: getData(data) })
+  return Promise.resolve({
+    items: data,
+    count: data.length
+  })
 })
 
 const props = {
   service: mockService,
-  limit: mockParams.limit,
-  fetchOnMount: true
+  limit: mockParams.limit
 }
 
 describe('useLoadMore custom hook', () => {
   mockAxiosClient.onAny().reply(200, mockResponse)
 
   it('should return array with length equal to 1', async () => {
-    const { result } = renderHook(() => useLoadMore({ ...props }))
-
+    const { result } = renderHook(() => useLoadMore({ ...props }), {
+      wrapper: QueryProvider
+    })
+    console.log(result.current)
     expect(result.current.loading).toBe(true)
 
     waitFor(() => {
@@ -39,7 +43,9 @@ describe('useLoadMore custom hook', () => {
     })
   })
   it('should call showMore and return array with length equal to 2', async () => {
-    const { result } = renderHook(() => useLoadMore({ ...props }))
+    const { result } = renderHook(() => useLoadMore({ ...props }), {
+      wrapper: QueryProvider
+    })
 
     waitFor(() => {
       expect(result.current.data).toEqual(
@@ -60,7 +66,9 @@ describe('useLoadMore custom hook', () => {
   })
 
   it('should call resetData and return empty data', async () => {
-    const { result } = renderHook(() => useLoadMore({ ...props }))
+    const { result } = renderHook(() => useLoadMore({ ...props }), {
+      wrapper: QueryProvider
+    })
 
     waitFor(() => {
       expect(result.current.data).toEqual(

--- a/tests/unit/hooks/use-load-more.spec.jsx
+++ b/tests/unit/hooks/use-load-more.spec.jsx
@@ -32,7 +32,7 @@ describe('useLoadMore custom hook', () => {
     const { result } = renderHook(() => useLoadMore({ ...props }), {
       wrapper: QueryProvider
     })
-    console.log(result.current)
+
     expect(result.current.loading).toBe(true)
 
     waitFor(() => {

--- a/tests/unit/services/subject-service.spec.jsx
+++ b/tests/unit/services/subject-service.spec.jsx
@@ -44,9 +44,7 @@ describe('subjectService getSubjects function tests', () => {
 
     mockAxiosClient
       .onGet(
-        new RegExp(
-          URLs.subjects.getByCategoryId.replace(':id', mockCategoryId)
-        )
+        new RegExp(URLs.subjects.getByCategoryId.replace(':id', mockCategoryId))
       )
       .reply(200, mockSubjectsByCategoryId)
 
@@ -58,7 +56,7 @@ describe('subjectService getSubjects function tests', () => {
     expect(result).toEqual(mockSubjectsByCategoryId)
     expect(getFullUrlSpy).toHaveBeenCalledWith({
       pathname: URLs.subjects.getByCategoryId,
-      parameters: { categoryId: mockCategoryId },
+      parameters: { id: mockCategoryId },
       searchParameters: mockParams
     })
   })

--- a/tests/unit/services/subject-service.spec.jsx
+++ b/tests/unit/services/subject-service.spec.jsx
@@ -50,7 +50,7 @@ describe('subjectService getSubjects function tests', () => {
 
     const result = await subjectService.getSubjects({
       ...mockParams,
-      category: { _id: mockCategoryId, appearance: { icon: '', color: '' } }
+      categoryId: mockCategoryId
     })
 
     expect(result).toEqual(mockSubjectsByCategoryId)

--- a/tests/unit/services/subject-service.spec.jsx
+++ b/tests/unit/services/subject-service.spec.jsx
@@ -1,0 +1,81 @@
+import { afterEach, vi } from 'vitest'
+import { mockAxiosClient } from '~tests/test-utils'
+import { subjectService } from '~/services/subject-service'
+import { URLs } from '~/constants/request'
+import * as getFullUrl from '~/utils/get-full-url'
+
+const mockCategoryId = '64884fedfdc2d1a130c24ade'
+const mockParams = { limit: 8 }
+
+const mockSubjects = {
+  items: [
+    {
+      _id: '1',
+      name: 'Networking',
+      category: {
+        _id: mockCategoryId
+      }
+    },
+    {
+      _id: '2',
+      name: 'Software Design',
+      category: {
+        _id: '64884fedfdc2d1a130c24adb'
+      }
+    }
+  ],
+  count: 2
+}
+
+const mockSubjectsByCategoryId = {
+  items: mockSubjects.items.filter(
+    (item) => item.category._id === mockCategoryId
+  ),
+  count: 1
+}
+
+describe('subjectService getSubjects function tests', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should find subjects by categoryId', async () => {
+    const getFullUrlSpy = vi.spyOn(getFullUrl, 'getFullUrl')
+
+    mockAxiosClient
+      .onGet(
+        new RegExp(
+          URLs.subjects.getByCategoryId.replace(':categoryId', mockCategoryId)
+        )
+      )
+      .reply(200, mockSubjectsByCategoryId)
+
+    const result = await subjectService.getSubjects({
+      ...mockParams,
+      category: { _id: mockCategoryId, appearance: { icon: '', color: '' } }
+    })
+
+    expect(result).toEqual(mockSubjectsByCategoryId)
+    expect(getFullUrlSpy).toHaveBeenCalledWith({
+      pathname: URLs.subjects.getByCategoryId,
+      parameters: { categoryId: mockCategoryId },
+      searchParameters: mockParams
+    })
+  })
+
+  it('should find all subjects', async () => {
+    const getFullUrlSpy = vi.spyOn(getFullUrl, 'getFullUrl')
+
+    mockAxiosClient
+      .onGet(new RegExp(URLs.subjects.get))
+      .reply(200, mockSubjects)
+
+    const result = await subjectService.getSubjects(mockParams)
+
+    expect(result).toEqual(mockSubjects)
+    expect(getFullUrlSpy).toHaveBeenCalledWith({
+      pathname: URLs.subjects.get,
+      searchParameters: mockParams
+    })
+  })
+})

--- a/tests/unit/services/subject-service.spec.jsx
+++ b/tests/unit/services/subject-service.spec.jsx
@@ -45,7 +45,7 @@ describe('subjectService getSubjects function tests', () => {
     mockAxiosClient
       .onGet(
         new RegExp(
-          URLs.subjects.getByCategoryId.replace(':categoryId', mockCategoryId)
+          URLs.subjects.getByCategoryId.replace(':id', mockCategoryId)
         )
       )
       .reply(200, mockSubjectsByCategoryId)


### PR DESCRIPTION
Fixed Categories page not found error. I refactored code so that it uses useQuery instead of useAxios for data fetching.
### Categories page:
![image](https://github.com/user-attachments/assets/a17c457c-9a7f-4d3b-a1bb-2fbfc8a59b9d)
### Subjects page:
![image](https://github.com/user-attachments/assets/3bb2eec5-2d5e-4a4e-93e1-a18b49264227)
### Subjects page filtered by category:
![image](https://github.com/user-attachments/assets/1320f81b-44ec-49b6-859d-9a5b5b8d7c3e)
