### PR TITLE
Fixed profile editing

### DIFF
--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -161,11 +161,16 @@ const EditProfile = () => {
     if (typeof photo === 'object' || photo === '') {
       dataToUpdate.photo = photo
     }
-
+    const dataWithoutEmptyStrings = Object.fromEntries(
+      Object.entries(dataToUpdate).map(([key, value]) => [
+        key,
+        value === '' ? null : value
+      ])
+    )
     await dispatch(
       updateUser({
         userId,
-        params: dataToUpdate
+        params: dataWithoutEmptyStrings
       })
     )
 

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -36,6 +36,7 @@ import { authRoutes } from '~/router/constants/authRoutes'
 
 import { styles } from '~/pages/edit-profile/EditProfile.styles'
 import { getChangedFields } from '~/utils/get-changed-fields'
+import { replaceEmptyStringsWithNull } from '~/utils/replace-empty-strings-with-null'
 
 const EditProfile = () => {
   const [initialEditProfileState, setInitialEditProfileState] = useState<
@@ -95,10 +96,8 @@ const EditProfile = () => {
   }, [loading, profileState, initialEditProfileState])
 
   const changedFields = useMemo<Partial<EditProfileState>>(() => {
-    return getChangedFields(
-      initialEditProfileState,
-      profileState
-    ) as Partial<EditProfileState>
+    if (!profileState || !initialEditProfileState) return {}
+    return getChangedFields(initialEditProfileState, profileState)
   }, [profileState, initialEditProfileState])
   const isChanged = useMemo<boolean>(
     () => Object.keys(changedFields).length > 0,
@@ -161,12 +160,7 @@ const EditProfile = () => {
     if (typeof photo === 'object' || photo === '') {
       dataToUpdate.photo = photo
     }
-    const dataWithoutEmptyStrings = Object.fromEntries(
-      Object.entries(dataToUpdate).map(([key, value]) => [
-        key,
-        value === '' ? null : value
-      ])
-    )
+    const dataWithoutEmptyStrings = replaceEmptyStringsWithNull(dataToUpdate)
     await dispatch(
       updateUser({
         userId,

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -96,7 +96,10 @@ const EditProfile = () => {
   }, [loading, profileState, initialEditProfileState])
 
   const changedFields = useMemo<Partial<EditProfileState>>(() => {
-    if (!profileState || !initialEditProfileState) return {}
+    if (!profileState || !initialEditProfileState) {
+      return {}
+    }
+
     return getChangedFields(initialEditProfileState, profileState)
   }, [profileState, initialEditProfileState])
   const isChanged = useMemo<boolean>(
@@ -160,7 +163,9 @@ const EditProfile = () => {
     if (typeof photo === 'object' || photo === '') {
       dataToUpdate.photo = photo
     }
+
     const dataWithoutEmptyStrings = replaceEmptyStringsWithNull(dataToUpdate)
+
     await dispatch(
       updateUser({
         userId,

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -106,24 +106,21 @@ const EditProfile = () => {
     }
 
     const changes: Partial<NullableFields> = {}
-
     ;(Object.keys(profileState) as Array<keyof EditableFields>).forEach(
       <K extends keyof EditableFields>(key: K) => {
         const initialValue = initialEditProfileState[key]
         const currentValue = profileState[key]
 
-        if (JSON.stringify(initialValue) !== JSON.stringify(currentValue)) {
-          if (!currentValue) {
-            changes[key] = changes[key] || null
-          } else {
-            changes[key] = currentValue
-          }
+        if (
+          (currentValue || initialValue) &&
+          JSON.stringify(initialValue) !== JSON.stringify(currentValue)
+        ) {
+          changes[key] = currentValue || null
         }
       }
     )
-
     return changes as Partial<EditProfileState>
-  }, [profileState])
+  }, [profileState, initialEditProfileState])
 
   const isChanged = useMemo<boolean>(
     () => Object.keys(changedFields).length > 0,

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -35,7 +35,6 @@ import { snackbarVariants } from '~/constants'
 import { authRoutes } from '~/router/constants/authRoutes'
 
 import { styles } from '~/pages/edit-profile/EditProfile.styles'
-import { hasPhotoChanges } from '~/utils/has-photo-changes'
 
 const EditProfile = () => {
   const [initialEditProfileState, setInitialEditProfileState] = useState<
@@ -72,13 +71,6 @@ const EditProfile = () => {
   const isPasswordSecurityTab =
     activeTab === UserProfileTabsEnum.PasswordAndSecurity
 
-  const hasChanges = (
-    initialData: Partial<EditProfileState> | DataByRole<string>,
-    currentData: Partial<EditProfileState> | DataByRole<string>
-  ): boolean => {
-    return JSON.stringify(initialData) !== JSON.stringify(currentData)
-  }
-
   useEffect(() => {
     const fetchData = async () => {
       await dispatch(
@@ -103,35 +95,31 @@ const EditProfile = () => {
 
   const changedFields = useMemo<Partial<EditProfileState>>(() => {
     if (!initialEditProfileState || !profileState) return {}
-    const { videoLink: initialVideoLink } = initialEditProfileState
-    const { videoLink: currentVideoLink } = profileState
 
-    const { photo: initialPhoto, ...initialData } = initialEditProfileState
-    const { photo: currentPhoto, ...currentData } = profileState
+    type EditableFields = Omit<
+      EditProfileState,
+      'loading' | 'error' | 'tabValidityStatus'
+    >
 
-    const hasPhotoChanged = hasPhotoChanges(initialPhoto, currentPhoto)
+    const changes: Partial<EditableFields> = {}
 
-    const hasChanged = hasChanges(initialData, currentData) || hasPhotoChanged
+    ;(Object.keys(profileState) as Array<keyof EditableFields>).forEach(
+      <K extends keyof EditableFields>(key: K) => {
+        const initialValue = initialEditProfileState[key]
+        const currentValue = profileState[key]
 
-    if (hasChanged) {
-      const changes: Partial<EditProfileState> = {
-        ...currentData
+        if (
+          JSON.stringify(initialValue) !== JSON.stringify(currentValue) &&
+          currentValue !== '' &&
+          currentValue !== null
+        ) {
+          changes[key] = currentValue
+        }
       }
+    )
 
-      if (!hasChanges(initialVideoLink, currentVideoLink)) {
-        delete changes.videoLink
-      }
-
-      if (hasPhotoChanged) {
-        changes.photo = currentPhoto
-      }
-
-      return changes
-    } else {
-      return {}
-    }
+    return changes as Partial<EditProfileState>
   }, [profileState, initialEditProfileState])
-
   const isChanged = useMemo<boolean>(
     () => Object.keys(changedFields).length > 0,
     [changedFields]
@@ -167,7 +155,9 @@ const EditProfile = () => {
     } = changedFields
 
     const dataToUpdate: UpdateUserParams = rest
-
+    //console.log('data to update', dataToUpdate)
+    //console.log('about student', aboutStudent)'
+    console.log('changed fields', changedFields)
     if (city && country) dataToUpdate.address = { city, country }
 
     if (videoLink) {
@@ -194,22 +184,33 @@ const EditProfile = () => {
       dataToUpdate.photo = photo
     }
 
-    await dispatch(
-      updateUser({
-        userId,
-        params: dataToUpdate
-      })
-    )
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.success,
-        message: 'editProfilePage.profile.successMessage'
-      })
-    )
-    setInitialEditProfileState(structuredClone(profileState))
+    try {
+      await dispatch(
+        updateUser({
+          userId,
+          params: dataToUpdate
+        })
+      ).unwrap()
 
-    if (hash) {
-      navigate(`${authRoutes.myProfile.path}#complete`)
+      dispatch(
+        openAlert({
+          severity: snackbarVariants.success,
+          message: 'editProfilePage.profile.successMessage'
+        })
+      )
+
+      setInitialEditProfileState(structuredClone(profileState))
+
+      if (hash) {
+        navigate(`${authRoutes.myProfile.path}#complete`)
+      }
+    } catch (error) {
+      dispatch(
+        openAlert({
+          severity: snackbarVariants.error,
+          message: 'editProfilePage.profile.errorMessage'
+        })
+      )
     }
   }
 

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -35,6 +35,7 @@ import { snackbarVariants } from '~/constants'
 import { authRoutes } from '~/router/constants/authRoutes'
 
 import { styles } from '~/pages/edit-profile/EditProfile.styles'
+import { getChangedFields } from '~/utils/get-changed-fields'
 
 const EditProfile = () => {
   const [initialEditProfileState, setInitialEditProfileState] = useState<
@@ -94,34 +95,11 @@ const EditProfile = () => {
   }, [loading, profileState, initialEditProfileState])
 
   const changedFields = useMemo<Partial<EditProfileState>>(() => {
-    if (!initialEditProfileState || !profileState) return {}
-
-    type EditableFields = Omit<
-      EditProfileState,
-      'loading' | 'error' | 'tabValidityStatus'
-    >
-
-    type NullableFields = {
-      [K in keyof EditableFields]: EditableFields[K] | null
-    }
-
-    const changes: Partial<NullableFields> = {}
-    ;(Object.keys(profileState) as Array<keyof EditableFields>).forEach(
-      <K extends keyof EditableFields>(key: K) => {
-        const initialValue = initialEditProfileState[key]
-        const currentValue = profileState[key]
-
-        if (
-          (currentValue || initialValue) &&
-          JSON.stringify(initialValue) !== JSON.stringify(currentValue)
-        ) {
-          changes[key] = currentValue || null
-        }
-      }
-    )
-    return changes as Partial<EditProfileState>
+    return getChangedFields(
+      initialEditProfileState,
+      profileState
+    ) as Partial<EditProfileState>
   }, [profileState, initialEditProfileState])
-
   const isChanged = useMemo<boolean>(
     () => Object.keys(changedFields).length > 0,
     [changedFields]

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -101,25 +101,30 @@ const EditProfile = () => {
       'loading' | 'error' | 'tabValidityStatus'
     >
 
-    const changes: Partial<EditableFields> = {}
+    type NullableFields = {
+      [K in keyof EditableFields]: EditableFields[K] | null
+    }
+
+    const changes: Partial<NullableFields> = {}
 
     ;(Object.keys(profileState) as Array<keyof EditableFields>).forEach(
       <K extends keyof EditableFields>(key: K) => {
         const initialValue = initialEditProfileState[key]
         const currentValue = profileState[key]
 
-        if (
-          JSON.stringify(initialValue) !== JSON.stringify(currentValue) &&
-          currentValue !== '' &&
-          currentValue !== null
-        ) {
-          changes[key] = currentValue
+        if (JSON.stringify(initialValue) !== JSON.stringify(currentValue)) {
+          if (!currentValue) {
+            changes[key] = changes[key] || null
+          } else {
+            changes[key] = currentValue
+          }
         }
       }
     )
 
     return changes as Partial<EditProfileState>
-  }, [profileState, initialEditProfileState])
+  }, [profileState])
+
   const isChanged = useMemo<boolean>(
     () => Object.keys(changedFields).length > 0,
     [changedFields]
@@ -155,9 +160,7 @@ const EditProfile = () => {
     } = changedFields
 
     const dataToUpdate: UpdateUserParams = rest
-    //console.log('data to update', dataToUpdate)
-    //console.log('about student', aboutStudent)'
-    console.log('changed fields', changedFields)
+
     if (city && country) dataToUpdate.address = { city, country }
 
     if (videoLink) {
@@ -184,33 +187,23 @@ const EditProfile = () => {
       dataToUpdate.photo = photo
     }
 
-    try {
-      await dispatch(
-        updateUser({
-          userId,
-          params: dataToUpdate
-        })
-      ).unwrap()
+    await dispatch(
+      updateUser({
+        userId,
+        params: dataToUpdate
+      })
+    )
 
-      dispatch(
-        openAlert({
-          severity: snackbarVariants.success,
-          message: 'editProfilePage.profile.successMessage'
-        })
-      )
+    dispatch(
+      openAlert({
+        severity: snackbarVariants.success,
+        message: 'editProfilePage.profile.successMessage'
+      })
+    )
+    setInitialEditProfileState(structuredClone(profileState))
 
-      setInitialEditProfileState(structuredClone(profileState))
-
-      if (hash) {
-        navigate(`${authRoutes.myProfile.path}#complete`)
-      }
-    } catch (error) {
-      dispatch(
-        openAlert({
-          severity: snackbarVariants.error,
-          message: 'editProfilePage.profile.errorMessage'
-        })
-      )
+    if (hash) {
+      navigate(`${authRoutes.myProfile.path}#complete`)
     }
   }
 

--- a/src/types/user/user-interfaces/user.interfaces.ts
+++ b/src/types/user/user-interfaces/user.interfaces.ts
@@ -76,8 +76,7 @@ export interface UserGeneralInfo
   city: UserResponse['address']['city'] | null
 }
 
-export interface UpdateUserParams
-  extends Partial<Pick<UserResponse, UpdateFields>> {
+export type UpdateUserParams = Partial<Pick<UserResponse, UpdateFields>> & {
   mainSubjects?: DataByRole<UserMainSubject[]>
   videoLink?: string
   photo?: EditProfilePhoto

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -3,8 +3,8 @@ type Nullable<T> = {
 }
 
 export function getChangedFields<T>(
-  initialState: Partial<T> | null,
-  currentState: Partial<T> | null
+  initialState: T | null,
+  currentState: T | null
 ): Partial<Nullable<T>> {
   if (!initialState || !currentState) return {}
 
@@ -19,9 +19,8 @@ export function getChangedFields<T>(
       (currentValue !== undefined || initialValue !== undefined) &&
       JSON.stringify(initialValue) !== JSON.stringify(currentValue)
     ) {
-      changes[typedKey] = currentValue || null
+      changes[typedKey] = currentValue
     }
   })
-
   return changes
 }

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -1,0 +1,27 @@
+type Nullable<T> = {
+  [K in keyof T]: T[K] | null
+}
+
+export function getChangedFields<T>(
+  initialState: Readonly<Partial<T>> | null,
+  currentState: Readonly<Partial<T>> | null
+): Partial<Nullable<T>> {
+  if (!initialState || !currentState) return {}
+
+  const changes: Partial<Nullable<T>> = {}
+
+  Object.keys(currentState).forEach((key) => {
+    const typedKey = key as keyof T
+    const initialValue = initialState[typedKey]
+    const currentValue = currentState[typedKey]
+
+    if (
+      (currentValue !== undefined || initialValue !== undefined) &&
+      JSON.stringify(initialValue) !== JSON.stringify(currentValue)
+    ) {
+      changes[typedKey] = currentValue ?? null
+    }
+  })
+
+  return changes
+}

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -1,1 +1,18 @@
-export function getChangedFields<T extends Record<string, unknown>>(  initialState: T,  currentState: T): Partial<T> {  const changes: Partial<T> = {}  Object.keys(currentState).forEach((key) => {    const typedKey = key as keyof T    const initialValue = initialState[typedKey]    const currentValue = currentState[typedKey]    if (JSON.stringify(initialValue) !== JSON.stringify(currentValue)) {      changes[typedKey] = currentValue    }  })  return changes}
+export function getChangedFields<T extends Record<string, unknown>>(
+  initialState: T,
+  currentState: T
+): Partial<T> {
+  const changes: Partial<T> = {}
+
+  Object.keys(currentState).forEach((key) => {
+    const typedKey = key as keyof T
+    const initialValue = initialState[typedKey]
+    const currentValue = currentState[typedKey]
+
+    if (JSON.stringify(initialValue) !== JSON.stringify(currentValue)) {
+      changes[typedKey] = currentValue
+    }
+  })
+
+  return changes
+}

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -1,24 +1,17 @@
-type Nullable<T> = {
-  [K in keyof T]: T[K] | null
-}
-
-export function getChangedFields<T>(
-  initialState: T | null,
-  currentState: T | null
-): Partial<Nullable<T>> {
+export function getChangedFields<T extends Record<string, unknown>>(
+  initialState: T,
+  currentState: T
+): Partial<T> {
   if (!initialState || !currentState) return {}
 
-  const changes: Partial<Nullable<T>> = {}
+  const changes: Partial<T> = {}
 
   Object.keys(currentState).forEach((key) => {
     const typedKey = key as keyof T
     const initialValue = initialState[typedKey]
     const currentValue = currentState[typedKey]
 
-    if (
-      (currentValue !== undefined || initialValue !== undefined) &&
-      JSON.stringify(initialValue) !== JSON.stringify(currentValue)
-    ) {
+    if (JSON.stringify(initialValue) !== JSON.stringify(currentValue)) {
       changes[typedKey] = currentValue
     }
   })

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -1,17 +1,1 @@
-export function getChangedFields<T extends Record<string, unknown>>(
-  initialState: T,
-  currentState: T
-): Partial<T> {
-  const changes: Partial<T> = {}
-
-  Object.keys(currentState).forEach((key) => {
-    const typedKey = key as keyof T
-    const initialValue = initialState[typedKey]
-    const currentValue = currentState[typedKey]
-
-    if (JSON.stringify(initialValue) !== JSON.stringify(currentValue)) {
-      changes[typedKey] = currentValue
-    }
-  })
-  return changes
-}
+export function getChangedFields<T extends Record<string, unknown>>(  initialState: T,  currentState: T): Partial<T> {  const changes: Partial<T> = {}  Object.keys(currentState).forEach((key) => {    const typedKey = key as keyof T    const initialValue = initialState[typedKey]    const currentValue = currentState[typedKey]    if (JSON.stringify(initialValue) !== JSON.stringify(currentValue)) {      changes[typedKey] = currentValue    }  })  return changes}

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -3,8 +3,8 @@ type Nullable<T> = {
 }
 
 export function getChangedFields<T>(
-  initialState: Readonly<Partial<T>> | null,
-  currentState: Readonly<Partial<T>> | null
+  initialState: Partial<T> | null,
+  currentState: Partial<T> | null
 ): Partial<Nullable<T>> {
   if (!initialState || !currentState) return {}
 

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -2,8 +2,6 @@ export function getChangedFields<T extends Record<string, unknown>>(
   initialState: T,
   currentState: T
 ): Partial<T> {
-  if (!initialState || !currentState) return {}
-
   const changes: Partial<T> = {}
 
   Object.keys(currentState).forEach((key) => {

--- a/src/utils/get-changed-fields.ts
+++ b/src/utils/get-changed-fields.ts
@@ -19,7 +19,7 @@ export function getChangedFields<T>(
       (currentValue !== undefined || initialValue !== undefined) &&
       JSON.stringify(initialValue) !== JSON.stringify(currentValue)
     ) {
-      changes[typedKey] = currentValue ?? null
+      changes[typedKey] = currentValue || null
     }
   })
 

--- a/src/utils/replace-empty-strings-with-null.ts
+++ b/src/utils/replace-empty-strings-with-null.ts
@@ -1,0 +1,10 @@
+export function replaceEmptyStringsWithNull(
+  obj: Record<string, unknown>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [
+      key,
+      value === '' ? null : value
+    ])
+  )
+}

--- a/src/utils/replace-empty-strings-with-null.ts
+++ b/src/utils/replace-empty-strings-with-null.ts
@@ -1,10 +1,15 @@
-export function replaceEmptyStringsWithNull(
-  obj: Record<string, unknown>
-): Record<string, unknown> {
+type ConvertStringsToNullable<T> = {
+  [K in keyof T]: T[K] extends string ? string | null : T[K]
+}
+
+export const replaceEmptyStringsWithNull = <T extends Record<string, unknown>>(
+  obj: T
+) => {
   return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [
-      key,
-      value === '' ? null : value
-    ])
-  )
+    Object.entries(obj).map((entries) => {
+      const [key, value] = entries as [keyof T, T[keyof T]]
+
+      return [key, value === '' ? null : value]
+    })
+  ) as ConvertStringsToNullable<T>
 }


### PR DESCRIPTION
This PR depends on [Backend PR #1180](https://github.com/ita-social-projects/SpaceToStudy-BackEnd/pull/1180).
Merge the backend PR first to avoid breaking changes.

When sending a request to the server, the entire `profileState` object was sent, even those fields that were not edited, so a validation error occurred on the server because some fields (for example, `professionalSummary`, `nativeLanguage`) were empty strings. I also found another bug, when a user wanted to clear `professionalSummary` or `nativeLanguage`, he could not do it, because a request was also sent with an empty string and an error was thrown on the server. I implemented the request in such a way that only those fields that have changed are sent, and if the field is an **empty string** (“”), then **null** is sent

- Before:

https://github.com/user-attachments/assets/e15c7bd9-4621-4490-b481-2c7078f81398


- After

https://github.com/user-attachments/assets/f010fb7c-0836-4c23-9d63-c7dc212b2914

