### PR TITLE
Fixed usage of Button color prop

### DIFF
--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
@@ -33,7 +33,7 @@ const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
     <CooperationActionBanner
       actionButtons={
         <>
-          <Button color='tonal-error' onClick={onAccept} size='xs'>
+          <Button onClick={onAccept} size='xs' variant='tonal-error'>
             {t('cooperationDetailsPage.acceptBtn')}
           </Button>
           <Button

--- a/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
+++ b/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
@@ -82,7 +82,7 @@ const CooperationActionInput: React.FC<CooperationActionInputProps> = ({
             value={data.declineReason}
             variant={InputFieldVariantEnum.Outlined}
           ></InputField>
-          <Button color='tonal-error' onClick={handleReasonSubmit} size='sm'>
+          <Button onClick={handleReasonSubmit} size='sm' variant='tonal-error'>
             {t('cooperationDetailsPage.submitBtn')}
           </Button>
         </Box>

--- a/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
@@ -29,7 +29,7 @@ const CooperationClosureDeclinedBanner: React.FC<
   return (
     <CooperationActionBanner
       actionButtons={
-        <Button color='tonal-error' onClick={handleResendRequest} size='xs'>
+        <Button onClick={handleResendRequest} size='xs' variant='tonal-error'>
           {t('cooperationDetailsPage.resendRequestBtn')}
         </Button>
       }

--- a/src/design-system/stories/Button.stories.tsx
+++ b/src/design-system/stories/Button.stories.tsx
@@ -91,19 +91,19 @@ export const All: Story = {
       <Button {...args} color='primary'>
         Primary
       </Button>
-      <Button {...args} color='tonal'>
+      <Button {...args} variant='tonal'>
         Tonal
       </Button>
-      <Button {...args} color='text-primary'>
+      <Button {...args} variant='text-primary'>
         Text Primary
       </Button>
-      <Button {...args} color='text-secondary'>
+      <Button {...args} variant='text-secondary'>
         Text Secondary
       </Button>
-      <Button {...args} color='tonal-success'>
+      <Button {...args} variant='tonal-success'>
         Tonal Success
       </Button>
-      <Button {...args} color='tonal-error'>
+      <Button {...args} variant='tonal-error'>
         Tonal Error
       </Button>
     </div>
@@ -136,7 +136,7 @@ export const Primary: Story = {
 export const Tonal: Story = {
   args: {
     children: 'Tonal',
-    color: 'tonal'
+    variant: 'tonal'
   },
   parameters: {
     docs: {
@@ -151,7 +151,7 @@ export const Tonal: Story = {
 export const TextPrimary: Story = {
   args: {
     children: 'Text Primary',
-    color: 'text-primary'
+    variant: 'text-primary'
   },
   parameters: {
     docs: {
@@ -166,7 +166,7 @@ export const TextPrimary: Story = {
 export const TextSecondary: Story = {
   args: {
     children: 'Text Secondary',
-    color: 'text-secondary'
+    variant: 'text-secondary'
   },
   parameters: {
     docs: {
@@ -181,7 +181,7 @@ export const TextSecondary: Story = {
 export const TonalError: Story = {
   args: {
     children: 'Tonal Error',
-    color: 'tonal-error'
+    variant: 'tonal-error'
   },
   parameters: {
     docs: {
@@ -196,7 +196,7 @@ export const TonalError: Story = {
 export const TonalSuccess: Story = {
   args: {
     children: 'Tonal Success',
-    color: 'tonal-success'
+    variant: 'tonal-success'
   },
   parameters: {
     docs: {


### PR DESCRIPTION
1. Made changes to components that used `Button` **color** to use the correct option `variant` for better consistency across the application.
2. Modified Storybook stories: Adjusted all instances where the `color` prop was used in the `Button` component to use the `variant` prop instead.

Before:
![image](https://github.com/user-attachments/assets/c240cf5f-13bd-46ee-a17c-8785a999b723)


After:
![image](https://github.com/user-attachments/assets/078302b8-b5d4-4690-a53f-eaa08f3b4488)

**Issue: #3145** 