### PR TITLE
Fix validation error in GeneralInfoSteps

### DIFF
--- a/src/hooks/use-steps.tsx
+++ b/src/hooks/use-steps.tsx
@@ -95,6 +95,7 @@ const useSteps = ({ steps }: UseSteps) => {
       professionalSummary: professionalSummary
         ? professionalSummary
         : undefined,
+      mainSubjects: stepData.subjects,
       nativeLanguage: stepData.language ?? undefined
     }
 

--- a/src/hooks/use-steps.tsx
+++ b/src/hooks/use-steps.tsx
@@ -92,9 +92,10 @@ const useSteps = ({ steps }: UseSteps) => {
         country: country ?? '',
         city: city ?? ''
       },
-      professionalSummary: professionalSummary,
-      mainSubjects: stepData.subjects,
-      nativeLanguage: stepData.language ?? null
+      professionalSummary: professionalSummary
+        ? professionalSummary
+        : undefined,
+      nativeLanguage: stepData.language ?? undefined
     }
 
     if (!hasErrors) {

--- a/src/hooks/use-steps.tsx
+++ b/src/hooks/use-steps.tsx
@@ -92,7 +92,7 @@ const useSteps = ({ steps }: UseSteps) => {
         country: country ?? '',
         city: city ?? ''
       },
-      professionalSummary: professionalSummary
+      professionalSummary: professionalSummary?.length
         ? professionalSummary
         : undefined,
       mainSubjects: stepData.subjects,


### PR DESCRIPTION
Fixed `FIELD_IS_NOT_OF_PROPER_LENGTH` and `FIELD_IS_NOT_OF_PROPER_ENUM_VALUE` validation errors.

1. `FIELD_IS_NOT_OF_PROPER_LENGTH` was caused by sending an `empty string` to the backend instead of `undefined` (which will be ignored inside `JSON.stringify`)
2. `FIELD_IS_NOT_OF_PROPER_ENUM_VALUE` was caused by sending a `null` value of language instead of `undefined` (which will be ignored inside `JSON.stringify`)

Succesful information update:

https://github.com/user-attachments/assets/2ef828e6-3f9a-4ce8-8205-2ad3c8df09ba

