### PR TITLE
Enhance Cooperation Closure: Modal Logic & needAction.messages Updates

### DIFF
--- a/src/components/status-chip/StatusChip.styles.ts
+++ b/src/components/status-chip/StatusChip.styles.ts
@@ -4,7 +4,7 @@ import { type ChipColor } from '~scss-components/chip/Chip'
 export const statusColors: Record<StatusEnum, ChipColor> = {
   [StatusEnum.Pending]: 'blue',
   [StatusEnum.Active]: 'green',
-  [StatusEnum.Closed]: 'red',
+  [StatusEnum.Closed]: 'blue-gray',
   [StatusEnum.Draft]: 'blue',
   [StatusEnum.NeedAction]: 'red',
   [StatusEnum.RequestToClose]: 'yellow'

--- a/src/constants/translations/en/cooperation-details.json
+++ b/src/constants/translations/en/cooperation-details.json
@@ -42,6 +42,7 @@
   "responseInputFieldLabel": "Please provide a reason for resending the request.",
   "inputError": "This field is required.",
   "submitMessage": "Your reason has been successfully submitted to the opposite party.",
+  "submittedReason": "Submitted reason: ",
   "cooperationCloseDeclinedMessage": "<userWrapper>{{user}}</userWrapper> declined to close the cooperation due to the following reason:",
   "resendRequestBtn": "Resend request",
   "answer": "Response from "

--- a/src/constants/translations/en/cooperation-details.json
+++ b/src/constants/translations/en/cooperation-details.json
@@ -42,6 +42,7 @@
   "responseInputFieldLabel": "Please provide a reason for resending the request.",
   "inputError": "This field is required.",
   "submitMessage": "Your reason has been successfully submitted to the opposite party.",
-  "cooperationCloseDeclinedMessage": "<userWrapper>{{user}}</userWrapper> declined the cooperation closing process due to the following reason:",
-  "resendRequestBtn": "Resend request"
+  "cooperationCloseDeclinedMessage": "<userWrapper>{{user}}</userWrapper> declined to close the cooperation due to the following reason:",
+  "resendRequestBtn": "Resend request",
+  "answer": "Response from "
 }

--- a/src/constants/translations/uk/cooperation-details.json
+++ b/src/constants/translations/uk/cooperation-details.json
@@ -42,6 +42,7 @@
   "responseInputFieldLabel": "Будь ласка, вкажіть причину повторного надсилання запиту.",
   "inputError": "Це поле є обов'язковим для заповнення.",
   "submitMessage": "Вашу причину було успішно надіслано протилежній стороні.",
+  "submittedReason": "Надіслана причина: ",
   "cooperationCloseDeclinedMessage": "<userWrapper>{{user}}</userWrapper> відмовив(-ла) у закритті співпраці з наступної причини:",
   "resendRequestBtn": "Надіслати повторно",
   "answer": "Відповідь від "

--- a/src/constants/translations/uk/cooperation-details.json
+++ b/src/constants/translations/uk/cooperation-details.json
@@ -43,5 +43,6 @@
   "inputError": "Це поле є обов'язковим для заповнення.",
   "submitMessage": "Вашу причину було успішно надіслано протилежній стороні.",
   "cooperationCloseDeclinedMessage": "<userWrapper>{{user}}</userWrapper> відмовив(-ла) у закритті співпраці з наступної причини:",
-  "resendRequestBtn": "Надіслати повторно"
+  "resendRequestBtn": "Надіслати повторно",
+  "answer": "Відповідь від "
 }

--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.styles.ts
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.styles.ts
@@ -1,5 +1,15 @@
+import { TypographyVariantEnum } from '~/types'
+import palette from '~/styles/app-theme/app.pallete'
+
 export const styles = {
   boldText: {
     fontWeight: 500
+  },
+  response: {
+    paddingTop: '10px'
+  },
+  secondaryText: {
+    typography: TypographyVariantEnum.Body2,
+    color: palette.basic.bismark
   }
 }

--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
@@ -15,6 +15,7 @@ interface AcceptCooperationClosureProps {
   onAccept: () => void
   onReasonSubmit: (reason: string) => void
   message?: string
+  submittedReason?: string
 }
 
 const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
@@ -22,7 +23,8 @@ const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
   isReasonSubmitted,
   onAccept,
   onReasonSubmit,
-  message
+  message,
+  submittedReason
 }) => {
   const { t } = useTranslation()
   const [isInputShown, setIsInputShown] = useState<boolean>(false)
@@ -81,6 +83,7 @@ const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
         isReasonSubmitted={isReasonSubmitted}
         onReasonSubmit={onReasonSubmit}
         setIsInputShown={setIsInputShown}
+        submittedReason={submittedReason}
       />
     </CooperationActionBanner>
   )

--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { ErrorOutlineRounded } from '@mui/icons-material'
-import { Typography } from '@mui/material'
+import { Box, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 import CooperationActionBanner from '~/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner'
@@ -14,13 +14,15 @@ interface AcceptCooperationClosureProps {
   isReasonSubmitted: boolean
   onAccept: () => void
   onReasonSubmit: (reason: string) => void
+  message?: string
 }
 
 const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
   user,
   isReasonSubmitted,
   onAccept,
-  onReasonSubmit
+  onReasonSubmit,
+  message
 }) => {
   const { t } = useTranslation()
   const [isInputShown, setIsInputShown] = useState<boolean>(false)
@@ -55,6 +57,16 @@ const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
             {t('cooperationDetailsPage.accessDuration')}
           </Typography>
           {t('cooperationDetailsPage.closingMessage2')}
+          {message && (
+            <Box sx={styles.response}>
+              <Typography component='span' sx={styles.boldText}>
+                {t('cooperationDetailsPage.answer')}
+                {user}:
+              </Typography>
+              <br />
+              <Typography sx={styles.secondaryText}>{message}</Typography>
+            </Box>
+          )}
         </>
       }
       icon={<ErrorOutlineRounded />}

--- a/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.tsx
@@ -30,7 +30,7 @@ const CooperationActionBanner: React.FC<Properties> = ({
         </Box>
         {actionButtons && <Box sx={styles.buttonsWrapper}>{actionButtons}</Box>}
       </Box>
-      {children && <Box>{children}</Box>}
+      {children}
     </Box>
   )
 }

--- a/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
+++ b/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
@@ -17,6 +17,7 @@ type CooperationActionInputProps = {
   isReasonSubmitted: boolean
   onReasonSubmit: (reason: string) => void
   setIsInputShown: (value: boolean) => void
+  submittedReason?: string
 }
 
 const CooperationActionInput: React.FC<CooperationActionInputProps> = ({
@@ -25,7 +26,8 @@ const CooperationActionInput: React.FC<CooperationActionInputProps> = ({
   isReasonSubmitted,
   isInputShown,
   onReasonSubmit,
-  setIsInputShown
+  setIsInputShown,
+  submittedReason
 }) => {
   const { t } = useTranslation()
   const inputRef = useRef<HTMLInputElement | null>(null)
@@ -99,7 +101,7 @@ const CooperationActionInput: React.FC<CooperationActionInputProps> = ({
         </Typography>
         <Typography sx={styles.textGray}>
           {t('cooperationDetailsPage.submittedReason')}
-          {data.declineReason}
+          {submittedReason}
         </Typography>
       </Box>
     )

--- a/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
+++ b/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
@@ -93,9 +93,15 @@ const CooperationActionInput: React.FC<CooperationActionInputProps> = ({
   return (
     isReasonSubmitted &&
     !hasErrors && (
-      <Typography sx={styles.textGray}>
-        {t('cooperationDetailsPage.submitMessage')}
-      </Typography>
+      <Box>
+        <Typography sx={styles.textGray}>
+          {t('cooperationDetailsPage.submitMessage')}
+        </Typography>
+        <Typography sx={styles.textGray}>
+          {t('cooperationDetailsPage.submittedReason')}
+          {data.declineReason}
+        </Typography>
+      </Box>
     )
   )
 }

--- a/src/containers/my-cooperations/cooperation-card/CooperationCard.tsx
+++ b/src/containers/my-cooperations/cooperation-card/CooperationCard.tsx
@@ -32,14 +32,16 @@ const CooperationCard: FC<CooperationCardProps> = ({
 
   const { userRole } = useAppSelector((state) => state.appMain)
 
+  const roleBasedStatus =
+    cooperation.needAction.role === userRole
+      ? StatusEnum.NeedAction
+      : StatusEnum.RequestToClose
+
   const cooperationStatus =
     cooperation.status === StatusEnum.RequestToClose
-      ? cooperation.needAction.role === userRole
-        ? StatusEnum.NeedAction
-        : StatusEnum.RequestToClose
+      ? roleBasedStatus
       : cooperation.status
 
-  console.log(cooperationStatus)
   return (
     <AppCard onClick={onClick} sx={spliceSx(styles.root, sx)}>
       <Box sx={styles.userInfo}>

--- a/src/containers/my-cooperations/cooperation-card/CooperationCard.tsx
+++ b/src/containers/my-cooperations/cooperation-card/CooperationCard.tsx
@@ -14,6 +14,7 @@ import { spliceSx } from '~/utils/helper-functions'
 
 import { Cooperation, StatusEnum } from '~/types'
 import { styles } from '~/containers/my-cooperations/cooperation-card/CooperationCard.styles'
+import { useAppSelector } from '~/hooks/use-redux'
 
 interface CooperationCardProps {
   cooperation: Cooperation
@@ -27,21 +28,18 @@ const CooperationCard: FC<CooperationCardProps> = ({
   sx
 }) => {
   const { t } = useTranslation()
-  const {
-    user,
-    offer,
-    updatedAt,
-    proficiencyLevel,
-    price,
-    status,
-    needAction
-  } = cooperation
+  const { user, offer, updatedAt, proficiencyLevel, price } = cooperation
+
+  const { userRole } = useAppSelector((state) => state.appMain)
 
   const cooperationStatus =
-    user.role !== needAction.role && status === StatusEnum.Pending
-      ? StatusEnum.NeedAction
-      : status
+    cooperation.status === StatusEnum.RequestToClose
+      ? cooperation.needAction.role === userRole
+        ? StatusEnum.NeedAction
+        : StatusEnum.RequestToClose
+      : cooperation.status
 
+  console.log(cooperationStatus)
   return (
     <AppCard onClick={onClick} sx={spliceSx(styles.root, sx)}>
       <Box sx={styles.userInfo}>

--- a/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
@@ -30,7 +30,12 @@ const CooperationClosureDeclinedBanner: React.FC<
   return (
     <CooperationActionBanner
       actionButtons={
-        <Button onClick={handleResendRequest} size='xs' variant='tonal-error'>
+        <Button
+          disabled={isAnswerSubmitted}
+          onClick={handleResendRequest}
+          size='xs'
+          variant='tonal-error'
+        >
           {t('cooperationDetailsPage.resendRequestBtn')}
         </Button>
       }

--- a/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
@@ -14,11 +14,12 @@ export interface CooperationClosureDeclinedBannerProps {
   message?: string
   onSend: (answer: string) => void
   user: string
+  submittedReason?: string
 }
 
 const CooperationClosureDeclinedBanner: React.FC<
   CooperationClosureDeclinedBannerProps
-> = ({ isAnswerSubmitted, message, onSend, user }) => {
+> = ({ isAnswerSubmitted, message, onSend, user, submittedReason }) => {
   const { t } = useTranslation()
   const [isInputShown, setIsInputShown] = useState<boolean>(false)
 
@@ -57,6 +58,7 @@ const CooperationClosureDeclinedBanner: React.FC<
         isReasonSubmitted={isAnswerSubmitted}
         onReasonSubmit={onSend}
         setIsInputShown={setIsInputShown}
+        submittedReason={submittedReason}
       />
     </CooperationActionBanner>
   )

--- a/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
@@ -11,7 +11,7 @@ import CooperationActionInput from '../cooperation-action-input/CooperationActio
 
 export interface CooperationClosureDeclinedBannerProps {
   isAnswerSubmitted: boolean
-  message: string
+  message?: string
   onSend: (answer: string) => void
   user: string
 }

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -190,12 +190,15 @@ const CooperationDetails = () => {
       ? StatusEnum.NeedAction
       : StatusEnum.RequestToClose
 
-  const cooperationStatusChip =
+  const cooperationStatus =
     cooperation.status === StatusEnum.RequestToClose
       ? roleBasedStatus
       : cooperation.status
 
   const getCooperationClosingModal = () => {
+    const lastMessage = cooperation.needAction.messages.at(-1)
+    const secondLastMessage = cooperation.needAction.messages.at(-2)
+
     if (cooperation.status !== StatusEnum.RequestToClose) {
       return null
     }
@@ -204,7 +207,7 @@ const CooperationDetails = () => {
       return cooperation.needAction.role === userRole ? (
         <AcceptCooperationClosing
           isReasonSubmitted={false}
-          message={cooperation.needAction.messages.at(-1)}
+          message={lastMessage}
           onAccept={handleCooperationClosingAccept}
           onReasonSubmit={handleReasonSubmit}
           user={closeCooperationInitiator.firstName}
@@ -213,9 +216,9 @@ const CooperationDetails = () => {
         cooperation.needAction.messages.length !== 0 && (
           <CooperationClosureDeclinedBanner
             isAnswerSubmitted
-            message={cooperation.needAction.messages.at(-2)}
+            message={secondLastMessage}
             onSend={handleAnswerSubmit}
-            submittedReason={cooperation.needAction.messages.at(-1)}
+            submittedReason={lastMessage}
             user={closeCooperationReceiver.firstName}
           />
         )
@@ -226,21 +229,17 @@ const CooperationDetails = () => {
       return cooperation.needAction.role === userRole ? (
         <CooperationClosureDeclinedBanner
           isAnswerSubmitted={false}
-          message={
-            cooperation.needAction.messages[
-              cooperation.needAction.messages.length - 1
-            ]
-          }
+          message={lastMessage}
           onSend={handleAnswerSubmit}
           user={closeCooperationInitiator.firstName}
         />
       ) : (
         <AcceptCooperationClosing
           isReasonSubmitted
-          message={cooperation.needAction.messages.at(-2)}
+          message={secondLastMessage}
           onAccept={handleCooperationClosingAccept}
           onReasonSubmit={handleReasonSubmit}
-          submittedReason={cooperation.needAction.messages.at(-1)}
+          submittedReason={lastMessage}
           user={closeCooperationReceiver.firstName}
         />
       )
@@ -258,7 +257,7 @@ const CooperationDetails = () => {
   return (
     <PageWrapper>
       <Box sx={styles.header}>
-        <StatusChip status={cooperationStatusChip} />
+        <StatusChip status={cooperationStatus} />
         <TitleWithDescription
           key={crypto.randomUUID()}
           style={styles.cooperationTitle}

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -215,6 +215,7 @@ const CooperationDetails = () => {
             isAnswerSubmitted
             message={cooperation.needAction.messages.at(-2)}
             onSend={handleAnswerSubmit}
+            submittedReason={cooperation.needAction.messages.at(-1)}
             user={closeCooperationReceiver.firstName}
           />
         )
@@ -239,6 +240,7 @@ const CooperationDetails = () => {
           message={cooperation.needAction.messages.at(-2)}
           onAccept={handleCooperationClosingAccept}
           onReasonSubmit={handleReasonSubmit}
+          submittedReason={cooperation.needAction.messages.at(-1)}
           user={closeCooperationReceiver.firstName}
         />
       )

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -196,12 +196,12 @@ const CooperationDetails = () => {
       : cooperation.status
 
   const getCooperationClosingModal = () => {
-    const lastMessage = cooperation.needAction.messages.at(-1)
-    const secondLastMessage = cooperation.needAction.messages.at(-2)
-
     if (cooperation.status !== StatusEnum.RequestToClose) {
       return null
     }
+
+    const lastMessage = cooperation.needAction.messages.at(-1)
+    const secondLastMessage = cooperation.needAction.messages.at(-2)
 
     if (cooperation.needAction.type === NeedActionTypeEnum.WaitingForApproval) {
       return cooperation.needAction.role === userRole ? (

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -43,7 +43,7 @@ import {
   setIsActivityCreated
 } from '~/redux/features/cooperationsSlice'
 import AcceptCooperationClosing from '~/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing'
-import CooperationClosureDeclinedBanner from '../cooperation-closure-declined-banner/CooperationClosureDeclinedBanner'
+import CooperationClosureDeclinedBanner from '~/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner'
 
 const CooperationDetails = () => {
   const dispatch = useAppDispatch()
@@ -185,17 +185,21 @@ const CooperationDetails = () => {
       ? cooperation.initiator
       : cooperation.receiver
 
+  const roleBasedStatus =
+    cooperation.needAction.role === userRole
+      ? StatusEnum.NeedAction
+      : StatusEnum.RequestToClose
+
   const cooperationStatusChip =
     cooperation.status === StatusEnum.RequestToClose
-      ? cooperation.needAction.role === userRole
-        ? StatusEnum.NeedAction
-        : StatusEnum.RequestToClose
+      ? roleBasedStatus
       : cooperation.status
 
   const getCooperationClosingModal = () => {
     if (cooperation.status !== StatusEnum.RequestToClose) {
       return null
     }
+
     if (cooperation.needAction.type === NeedActionTypeEnum.WaitingForApproval) {
       return cooperation.needAction.role === userRole ? (
         <AcceptCooperationClosing
@@ -216,6 +220,7 @@ const CooperationDetails = () => {
         )
       )
     }
+
     if (cooperation.needAction.type === NeedActionTypeEnum.WaitingForAnswer) {
       return cooperation.needAction.role === userRole ? (
         <CooperationClosureDeclinedBanner

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -31,14 +31,19 @@ import { styles } from '~/containers/my-cooperations/cooperation-details/Coopera
 import { errorRoutes } from '~/router/constants/errorRoutes'
 import { cooperationService } from '~/services/cooperation-service'
 
-import { CooperationTabsEnum, PositionEnum, StatusEnum } from '~/types'
+import {
+  CooperationTabsEnum,
+  NeedActionTypeEnum,
+  PositionEnum,
+  StatusEnum
+} from '~/types'
 import {
   cooperationsSelector,
   setCooperationSections,
-  setCooperationStatus,
   setIsActivityCreated
 } from '~/redux/features/cooperationsSlice'
 import AcceptCooperationClosing from '~/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing'
+import CooperationClosureDeclinedBanner from '../cooperation-closure-declined-banner/CooperationClosureDeclinedBanner'
 
 const CooperationDetails = () => {
   const dispatch = useAppDispatch()
@@ -49,9 +54,7 @@ const CooperationDetails = () => {
   const { isActivityCreated } = useAppSelector(cooperationsSelector)
   const [isNotesOpen, setIsNotesOpen] = useState<boolean>(false)
   const [editMode, setEditMode] = useState<boolean>(false)
-  const [isClosed, setIsClosed] = useState<boolean>(false)
   const { userRole } = useAppSelector((state) => state.appMain)
-  const cooperationStatus = useAppSelector((state) => state.cooperations.status)
 
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -91,7 +94,6 @@ const CooperationDetails = () => {
   useEffect(() => {
     if (cooperation) {
       dispatch(setCooperationSections(cooperation.sections))
-      dispatch(setCooperationStatus(cooperation.status))
       setEditMode(Boolean(cooperation.sections?.length))
     }
   }, [cooperation, dispatch])
@@ -108,14 +110,32 @@ const CooperationDetails = () => {
     })
   }, [id])
 
-  const handleCooperationStatusUpdateSuccess = useCallback(() => {
-    setIsClosed(true)
-    dispatch(setCooperationStatus(StatusEnum.Closed))
-  }, [dispatch])
-
   const { mutate: handleCooperationClosingAccept } = useMutation({
     mutationFn: handleCooperationStatusUpdate,
-    onSuccess: handleCooperationStatusUpdateSuccess,
+    queryKeys: [['cooperations'], ['cooperation', id]]
+  })
+
+  const handleCooperationClosingDecline = async (declineReason: string) => {
+    await cooperationService.updateCooperation({
+      _id: id,
+      newMessage: declineReason
+    })
+  }
+
+  const { mutate: handleReasonSubmit } = useMutation({
+    mutationFn: handleCooperationClosingDecline,
+    queryKeys: [['cooperations'], ['cooperation', id]]
+  })
+
+  const handleAnswerForDecliningSend = async (answer: string) => {
+    await cooperationService.updateCooperation({
+      _id: id,
+      newMessage: answer
+    })
+  }
+
+  const { mutate: handleAnswerSubmit } = useMutation({
+    mutationFn: handleAnswerForDecliningSend,
     queryKeys: [['cooperations'], ['cooperation', id]]
   })
 
@@ -160,18 +180,67 @@ const CooperationDetails = () => {
       ? cooperation.initiator
       : cooperation.receiver
 
-  const acceptClosingProcess = !isClosed && (
-    <AcceptCooperationClosing
-      isReasonSubmitted={false}
-      onAccept={handleCooperationClosingAccept}
-      onReasonSubmit={() => {}}
-      user={closeCooperationInitiator.firstName}
-    />
-  )
+  const closeCooperationReceiver =
+    cooperation.needAction.role === cooperation.initiatorRole
+      ? cooperation.initiator
+      : cooperation.receiver
 
-  const isCooperationClosingRequestSend =
-    cooperation.needAction.role === userRole &&
+  const cooperationStatusChip =
     cooperation.status === StatusEnum.RequestToClose
+      ? cooperation.needAction.role === userRole
+        ? StatusEnum.NeedAction
+        : StatusEnum.RequestToClose
+      : cooperation.status
+
+  const getCooperationClosingModal = () => {
+    if (cooperation.status !== StatusEnum.RequestToClose) {
+      return null
+    }
+    if (cooperation.needAction.type === NeedActionTypeEnum.WaitingForApproval) {
+      return cooperation.needAction.role === userRole ? (
+        <AcceptCooperationClosing
+          isReasonSubmitted={false}
+          message={cooperation.needAction.messages.at(-1)}
+          onAccept={handleCooperationClosingAccept}
+          onReasonSubmit={handleReasonSubmit}
+          user={closeCooperationInitiator.firstName}
+        />
+      ) : (
+        cooperation.needAction.messages.length !== 0 && (
+          <CooperationClosureDeclinedBanner
+            isAnswerSubmitted
+            message={cooperation.needAction.messages.at(-2)}
+            onSend={handleAnswerSubmit}
+            user={closeCooperationReceiver.firstName}
+          />
+        )
+      )
+    }
+    if (cooperation.needAction.type === NeedActionTypeEnum.WaitingForAnswer) {
+      return cooperation.needAction.role === userRole ? (
+        <CooperationClosureDeclinedBanner
+          isAnswerSubmitted={false}
+          message={
+            cooperation.needAction.messages[
+              cooperation.needAction.messages.length - 1
+            ]
+          }
+          onSend={handleAnswerSubmit}
+          user={closeCooperationInitiator.firstName}
+        />
+      ) : (
+        <AcceptCooperationClosing
+          isReasonSubmitted
+          message={cooperation.needAction.messages.at(-2)}
+          onAccept={handleCooperationClosingAccept}
+          onReasonSubmit={handleReasonSubmit}
+          user={closeCooperationReceiver.firstName}
+        />
+      )
+    }
+  }
+
+  const cooperationClosingModal = getCooperationClosingModal()
 
   const iconConditionals = isNotesOpen ? (
     <KeyboardDoubleArrowRightIcon />
@@ -182,7 +251,7 @@ const CooperationDetails = () => {
   return (
     <PageWrapper>
       <Box sx={styles.header}>
-        <StatusChip status={cooperationStatus} />
+        <StatusChip status={cooperationStatusChip} />
         <TitleWithDescription
           key={crypto.randomUUID()}
           style={styles.cooperationTitle}
@@ -208,9 +277,7 @@ const CooperationDetails = () => {
           </Button>
         </Box>
       </Box>
-      {activeTab === CooperationTabsEnum.Activities &&
-        isCooperationClosingRequestSend &&
-        acceptClosingProcess}
+      {activeTab === CooperationTabsEnum.Activities && cooperationClosingModal}
       <Box sx={styles.notesBlock}>
         <Box sx={styles.pageContent}>{pageContent()}</Box>
         {!isDesktop && isNotesOpen && (

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -71,6 +71,7 @@ const CooperationContainer: React.FC<CooperationContainerProps> = ({
             item.needAction.role === userRole
               ? StatusEnum.NeedAction
               : StatusEnum.RequestToClose
+
           return {
             ...item,
             status:

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -15,6 +15,7 @@ import {
 import { styles } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
 import { type Cooperation, SizeEnum, StatusEnum } from '~/types'
 import { useNavigate } from 'react-router-dom'
+import { useAppSelector } from '~/hooks/use-redux'
 
 interface CooperationContainerProps {
   items: Cooperation[]
@@ -30,6 +31,7 @@ const CooperationContainer: React.FC<CooperationContainerProps> = ({
   const breakpoints = useBreakpoints()
   const { openModal } = useModalContext()
   const navigate = useNavigate()
+  const { userRole } = useAppSelector((state) => state.appMain)
 
   const columnsToShow = adjustColumns<Cooperation>(
     breakpoints,
@@ -43,7 +45,8 @@ const CooperationContainer: React.FC<CooperationContainerProps> = ({
           component: <AcceptCooperationModal cooperation={item} />
         })
       : (item.status === StatusEnum.Active ||
-          item.status === StatusEnum.RequestToClose) &&
+          item.status === StatusEnum.RequestToClose ||
+          item.status === StatusEnum.NeedAction) &&
         navigate(`./${item._id}`)
   }
 
@@ -62,7 +65,19 @@ const CooperationContainer: React.FC<CooperationContainerProps> = ({
   const cooperationTable = (
     <EnhancedTable
       columns={columnsToShow}
-      data={{ items }}
+      data={{
+        items: items.map((item) => {
+          return {
+            ...item,
+            status:
+              item.status === StatusEnum.RequestToClose
+                ? item.needAction.role === userRole
+                  ? StatusEnum.NeedAction
+                  : StatusEnum.RequestToClose
+                : item.status
+          }
+        })
+      }}
       onRowClick={handleCardClick}
       size={SizeEnum.Small}
       sort={sort}

--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -67,13 +67,15 @@ const CooperationContainer: React.FC<CooperationContainerProps> = ({
       columns={columnsToShow}
       data={{
         items: items.map((item) => {
+          const roleBasedStatus =
+            item.needAction.role === userRole
+              ? StatusEnum.NeedAction
+              : StatusEnum.RequestToClose
           return {
             ...item,
             status:
               item.status === StatusEnum.RequestToClose
-                ? item.needAction.role === userRole
-                  ? StatusEnum.NeedAction
-                  : StatusEnum.RequestToClose
+                ? roleBasedStatus
                 : item.status
           }
         })

--- a/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.tsx
+++ b/src/containers/my-cooperations/my-cooperations-details/MyCooperationsDetails.tsx
@@ -24,8 +24,7 @@ import { useChatContext } from '~/context/chat-context'
 import CooperationCompletion from '../cooperation-completion/CooperationCompletion'
 import { getCategoryIcon } from '~/services/category-icon-service'
 import { getValidatedHexColor } from '~/utils/get-validated-hex-color'
-import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
-import { setCooperationStatus } from '~/redux/features/cooperationsSlice'
+import { useAppSelector } from '~/hooks/use-redux'
 
 const MyCooperationsDetails = () => {
   const { t } = useTranslation()
@@ -33,9 +32,7 @@ const MyCooperationsDetails = () => {
   const { setChatInfo } = useChatContext()
   const userId = useAppSelector((state) => state.appMain.userId)
   const userRole = useAppSelector((state) => state.appMain.userRole)
-  const cooperationStatus = useAppSelector((state) => state.cooperations.status)
   const { checkConfirmation } = useConfirm()
-  const dispatch = useAppDispatch()
 
   const getCooperationDetails = useCallback(() => {
     return cooperationService.getCooperationById(id)
@@ -51,7 +48,11 @@ const MyCooperationsDetails = () => {
 
   const { mutate: updateCooperationDetails } = useMutation({
     mutationFn: cooperationService.updateCooperation,
-    queryKeys: [['cooperations'], ['cooperation-details', id]]
+    queryKeys: [
+      ['cooperations'],
+      ['cooperation', id],
+      ['cooperation-details', id]
+    ]
   })
 
   const handleCooperationStatusUpdate = useCallback(async () => {
@@ -63,9 +64,8 @@ const MyCooperationsDetails = () => {
 
     if (isConfirmed) {
       updateCooperationDetails({ _id: id, status: StatusEnum.RequestToClose })
-      dispatch(setCooperationStatus(StatusEnum.RequestToClose))
     }
-  }, [checkConfirmation, dispatch, id, t, updateCooperationDetails])
+  }, [checkConfirmation, id, t, updateCooperationDetails])
 
   const handleCloseCooperation = useCallback(() => {
     void handleCooperationStatusUpdate()
@@ -208,7 +208,7 @@ const MyCooperationsDetails = () => {
         <Typography>{`${price} UAH/hour`}</Typography>
       </Box>
       <CooperationCompletion
-        cooperationStatus={cooperationStatus}
+        cooperationStatus={cooperationDetails.status}
         onCloseCooperation={handleCloseCooperation}
         userRole={userRole}
       />

--- a/src/redux/features/cooperationsSlice.ts
+++ b/src/redux/features/cooperationsSlice.ts
@@ -7,22 +7,19 @@ import {
   CourseSection,
   ResourceAvailabilityStatusEnum,
   ResourceAvailability,
-  ResourcesAvailabilityEnum,
-  StatusEnum
+  ResourcesAvailabilityEnum
 } from '~/types'
 
 interface CooperationsState {
   isActivityCreated: boolean
   sections: CourseSection[]
   resourcesAvailability: ResourcesAvailabilityEnum
-  status: StatusEnum
 }
 
 const initialState: CooperationsState = {
   isActivityCreated: false,
   sections: [],
-  resourcesAvailability: ResourcesAvailabilityEnum.OpenAll,
-  status: StatusEnum.Active
+  resourcesAvailability: ResourcesAvailabilityEnum.OpenAll
 }
 
 export const initialCooperationSectionData: CourseSection = {
@@ -240,9 +237,6 @@ const cooperationsSlice = createSlice({
           }
         }
       }
-    },
-    setCooperationStatus(state, action: PayloadAction<StatusEnum>) {
-      state.status = action.payload
     }
   }
 })
@@ -260,8 +254,7 @@ export const {
   updateResource,
   deleteResource,
   setResourcesAvailability,
-  updateResourceAvailability,
-  setCooperationStatus
+  updateResourceAvailability
 } = actions
 
 export const cooperationsSelector = (state: RootState) => state.cooperations

--- a/src/services/cooperation-service.ts
+++ b/src/services/cooperation-service.ts
@@ -8,6 +8,7 @@ import type {
   UpdateCooperationsParams,
   CreateOrUpdateNoteParams,
   UpdateCooperationsSections,
+  UpdateCooperationsNeedActionMessages,
   Cooperation,
   ItemsWithCount
 } from '~/types'
@@ -35,7 +36,10 @@ export const cooperationService = {
     })
   },
   updateCooperation: async (
-    data: UpdateCooperationsParams | UpdateCooperationsSections
+    data:
+      | UpdateCooperationsParams
+      | UpdateCooperationsSections
+      | UpdateCooperationsNeedActionMessages
   ) => {
     const url = getFullUrl({
       pathname: URLs.cooperations.updateById,

--- a/src/types/common/enums/common.enums.ts
+++ b/src/types/common/enums/common.enums.ts
@@ -101,6 +101,7 @@ export enum StatusEnum {
   NeedAction = 'need action',
   RequestToClose = 'request to close'
 }
+
 export enum PositionEnum {
   Left = 'left',
   Right = 'right',

--- a/src/types/common/enums/common.enums.ts
+++ b/src/types/common/enums/common.enums.ts
@@ -101,7 +101,6 @@ export enum StatusEnum {
   NeedAction = 'need action',
   RequestToClose = 'request to close'
 }
-
 export enum PositionEnum {
   Left = 'left',
   Right = 'right',

--- a/src/types/cooperation/types/cooperation.types.ts
+++ b/src/types/cooperation/types/cooperation.types.ts
@@ -13,3 +13,6 @@ export type UpdateCooperationsSections = Partial<
 export type UpdateCooperationStatusParams = Partial<
   Pick<Cooperation, 'status' | '_id'>
 >
+export type UpdateCooperationsNeedActionMessages = {
+  newMessage: string
+} & Pick<Cooperation, '_id'>

--- a/tests/unit/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.spec.jsx
+++ b/tests/unit/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.spec.jsx
@@ -7,6 +7,7 @@ vi.mock('react-i18next', () => ({
     t: (key) => key
   })
 }))
+
 describe('AcceptCooperationClosing', () => {
   const mockOnAccept = vi.fn()
   const mockOnDecline = vi.fn()
@@ -17,6 +18,7 @@ describe('AcceptCooperationClosing', () => {
         user='John Doe'
         onAccept={mockOnAccept}
         onDecline={mockOnDecline}
+        message={'You forgot to add a quiz'}
       />
     )
   })
@@ -47,5 +49,10 @@ describe('AcceptCooperationClosing', () => {
 
     const errorMessage = screen.getByText('cooperationDetailsPage.inputError')
     expect(errorMessage).toBeInTheDocument()
+  })
+
+  it('should render answer when message is provided', () => {
+    const message = screen.getByText('You forgot to add a quiz')
+    expect(message).toBeInTheDocument()
   })
 })

--- a/tests/unit/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.spec.jsx
+++ b/tests/unit/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.spec.jsx
@@ -18,7 +18,7 @@ describe('AcceptCooperationClosing', () => {
         user='John Doe'
         onAccept={mockOnAccept}
         onDecline={mockOnDecline}
-        message={'You forgot to add a quiz'}
+        message='You forgot to add a quiz'
       />
     )
   })

--- a/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
@@ -25,19 +25,12 @@ const mockState1 = {
   appMain: { userId: userId, userRole: 'student' }
 }
 
-const cooperationMock = {
+const cooperationData = {
   _id: '123456789',
   price: 100,
   proficiencyLevel: 'Beginner',
   status: 'request to close',
-  needAction: {
-    role: 'tutor',
-    type: 'waiting for approval',
-    messages: []
-  },
   title: 'Cooperation title',
-  initiator: { _id: userId, role: ['tutor'] },
-  receiver: { _id: '123123', role: ['student'] },
   offer: {
     title: 'Title',
     description: 'Description',
@@ -70,47 +63,47 @@ const cooperationMock = {
 }
 
 const cooperationMock1 = {
-  _id: '123456789',
-  price: 100,
-  proficiencyLevel: 'Beginner',
-  status: 'request to close',
+  ...cooperationData,
+  needAction: {
+    role: 'tutor',
+    type: 'waiting for approval',
+    messages: []
+  },
+  initiator: { _id: userId, role: ['tutor'] },
+  receiver: { _id: '123123', role: ['student'] }
+}
+
+const cooperationMock2 = {
+  ...cooperationData,
   needAction: {
     role: 'student',
     type: 'waiting for answer',
     messages: ['reason1']
   },
-  title: 'Cooperation title',
   initiator: { _id: userId, role: ['student'] },
-  receiver: { _id: '123123', role: ['tutor'] },
-  offer: {
-    title: 'Title',
-    description: 'Description',
-    languages: ['Ukrainian', 'English'],
-    author: {
-      firstName: 'Michael',
-      lastName: 'Scarn',
-      photo: '1701182621626.jpg',
-      professionalSummary: 'Agent'
-    },
-    subject: {
-      name: 'Algebra'
-    },
-    category: {
-      name: 'Mathematics',
-      appearance: {
-        color: '#1234'
-      }
-    },
-    proficiencyLevel: ['INTERMEDIATE']
+  receiver: { _id: '123123', role: ['tutor'] }
+}
+
+const cooperationMock3 = {
+  ...cooperationData,
+  needAction: {
+    role: 'student',
+    type: 'waiting for approval',
+    messages: ['message1']
   },
-  user: {
-    _id: '123456',
-    firstName: 'Name',
-    lastName: 'Surname',
-    role: 'tutor'
+  initiator: { _id: userId, role: ['tutor'] },
+  receiver: { _id: '123123', role: ['student'] }
+}
+
+const cooperationMock4 = {
+  ...cooperationData,
+  needAction: {
+    role: 'tutor',
+    type: 'waiting for answer',
+    messages: ['reason1']
   },
-  createdAt: '2024-01-12T11:28:34.397Z',
-  updatedAt: '2024-01-12T11:28:34.397Z'
+  initiator: { _id: userId, role: ['student'] },
+  receiver: { _id: '123123', role: ['tutor'] }
 }
 
 vi.mock(
@@ -126,7 +119,7 @@ describe('CooperationDetails', () => {
   beforeAll(() => {
     mockAxiosClient
       .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
-      .reply(200, cooperationMock)
+      .reply(200, cooperationMock1)
   })
 
   beforeEach(() => {
@@ -134,7 +127,7 @@ describe('CooperationDetails', () => {
   })
 
   afterAll(() => {
-    mockAxiosClient.reset();
+    mockAxiosClient.reset()
   })
 
   it('should render details page', async () => {
@@ -146,7 +139,7 @@ describe('CooperationDetails', () => {
   })
 
   it('should show cooperation status and title', () => {
-    const title = screen.getByText(cooperationMock.title)
+    const title = screen.getByText(cooperationMock1.title)
     const statusChip = screen.getByText('need action')
 
     expect(title).toBeInTheDocument()
@@ -183,10 +176,7 @@ describe('CooperationDetails', () => {
     expect(cooperationNotes).not.toBeInTheDocument()
   })
 
-  it('should render cooperation closing modal', () => {
-    const tab1 = screen.getByText('cooperationsPage.tabs.activities')
-    fireEvent.click(tab1)
-
+  it('should render AcceptCooperationClosing modal when needAction type is "waiting for approval" and role equals users role', () => {
     const cooperationClosingModal = screen.getByText(
       'titles.acceptCooperationClosing'
     )
@@ -194,22 +184,66 @@ describe('CooperationDetails', () => {
   })
 })
 
-describe('cooperation closing process modals', () => {
+describe('CooperationClosureDeclinedBanner without answer being submitted', () => {
   beforeAll(() => {
-    mockAxiosClient.reset();
+    mockAxiosClient.reset()
     mockAxiosClient
       .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
-      .reply(200, cooperationMock1)
+      .reply(200, cooperationMock2)
   })
 
   beforeEach(() => {
     renderWithProviders(<CooperationDetails />, { preloadedState: mockState1 })
   })
 
-  it('should render cooperation closing modal with message', async () => {
+  it('should render CooperationClosureDeclinedBanner when needAction type is "waiting for answer" and role equals users role', async () => {
     await waitFor(() => {
       const cooperationClosingModal = screen.getByText(
         'titles.cooperationClosureDeclined'
+      )
+      expect(cooperationClosingModal).toBeInTheDocument()
+    })
+  })
+})
+
+describe('CooperationClosureDeclinedBanner with submitted answer', () => {
+  beforeAll(() => {
+    mockAxiosClient.reset()
+    mockAxiosClient
+      .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
+      .reply(200, cooperationMock3)
+  })
+
+  beforeEach(() => {
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockState })
+  })
+
+  it('should render CooperationClosureDeclinedBanner when needAction type is "waiting for approval" and role is not the same as users role', async () => {
+    await waitFor(() => {
+      const cooperationClosingModal = screen.getByText(
+        'titles.cooperationClosureDeclined'
+      )
+      expect(cooperationClosingModal).toBeInTheDocument()
+    })
+  })
+})
+
+describe('AcceptCooperationClosing modal with submitted answer', () => {
+  beforeAll(() => {
+    mockAxiosClient.reset()
+    mockAxiosClient
+      .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
+      .reply(200, cooperationMock4)
+  })
+
+  beforeEach(() => {
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockState1 })
+  })
+
+  it('should render AcceptCooperationClosing modal when needAction type is "waiting for answer" and role is not the same as users role', async () => {
+    await waitFor(() => {
+      const cooperationClosingModal = screen.getByText(
+        'titles.acceptCooperationClosing'
       )
       expect(cooperationClosingModal).toBeInTheDocument()
     })

--- a/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
@@ -21,19 +21,67 @@ const mockState = {
   appMain: { userId: userId, userRole: 'tutor' }
 }
 
+const mockState1 = {
+  appMain: { userId: userId, userRole: 'student' }
+}
+
 const cooperationMock = {
   _id: '123456789',
   price: 100,
   proficiencyLevel: 'Beginner',
-  status: 'active',
+  status: 'request to close',
   needAction: {
     role: 'tutor',
-    type: 'price',
+    type: 'waiting for approval',
     messages: []
   },
   title: 'Cooperation title',
   initiator: { _id: userId, role: ['tutor'] },
   receiver: { _id: '123123', role: ['student'] },
+  offer: {
+    title: 'Title',
+    description: 'Description',
+    languages: ['Ukrainian', 'English'],
+    author: {
+      firstName: 'Michael',
+      lastName: 'Scarn',
+      photo: '1701182621626.jpg',
+      professionalSummary: 'Agent'
+    },
+    subject: {
+      name: 'Algebra'
+    },
+    category: {
+      name: 'Mathematics',
+      appearance: {
+        color: '#1234'
+      }
+    },
+    proficiencyLevel: ['INTERMEDIATE']
+  },
+  user: {
+    _id: '123456',
+    firstName: 'Name',
+    lastName: 'Surname',
+    role: 'tutor'
+  },
+  createdAt: '2024-01-12T11:28:34.397Z',
+  updatedAt: '2024-01-12T11:28:34.397Z'
+}
+
+const cooperationMock1 = {
+  _id: '123456789',
+  price: 100,
+  proficiencyLevel: 'Beginner',
+  status: 'request to close',
+  needAction: {
+    role: 'student',
+    type: 'waiting for answer',
+    messages: ['reason1']
+  },
+  title: 'Cooperation title',
+  initiator: { _id: userId, role: ['student'] },
+  receiver: { _id: '123123', role: ['tutor'] },
   offer: {
     title: 'Title',
     description: 'Description',
@@ -75,12 +123,18 @@ vi.mock(
 )
 
 describe('CooperationDetails', () => {
-  mockAxiosClient
-    .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
-    .reply(200, cooperationMock)
+  beforeAll(() => {
+    mockAxiosClient
+      .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
+      .reply(200, cooperationMock)
+  })
 
   beforeEach(() => {
     renderWithProviders(<CooperationDetails />, { preloadedState: mockState })
+  })
+
+  afterAll(() => {
+    mockAxiosClient.reset();
   })
 
   it('should render details page', async () => {
@@ -93,7 +147,7 @@ describe('CooperationDetails', () => {
 
   it('should show cooperation status and title', () => {
     const title = screen.getByText(cooperationMock.title)
-    const statusChip = screen.getByText(cooperationMock.status)
+    const statusChip = screen.getByText('need action')
 
     expect(title).toBeInTheDocument()
     expect(statusChip).toBeInTheDocument()
@@ -127,5 +181,37 @@ describe('CooperationDetails', () => {
     cooperationNotes = screen.queryByText('Cooperation Notes')
 
     expect(cooperationNotes).not.toBeInTheDocument()
+  })
+
+  it('should render cooperation closing modal', () => {
+    const tab1 = screen.getByText('cooperationsPage.tabs.activities')
+    fireEvent.click(tab1)
+
+    const cooperationClosingModal = screen.getByText(
+      'titles.acceptCooperationClosing'
+    )
+    expect(cooperationClosingModal).toBeInTheDocument()
+  })
+})
+
+describe('cooperation closing process modals', () => {
+  beforeAll(() => {
+    mockAxiosClient.reset();
+    mockAxiosClient
+      .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
+      .reply(200, cooperationMock1)
+  })
+
+  beforeEach(() => {
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockState1 })
+  })
+
+  it('should render cooperation closing modal with message', async () => {
+    await waitFor(() => {
+      const cooperationClosingModal = screen.getByText(
+        'titles.cooperationClosureDeclined'
+      )
+      expect(cooperationClosingModal).toBeInTheDocument()
+    })
   })
 })

--- a/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
+++ b/tests/unit/containers/my-cooperations/cooperation-details/CooperationDetails.spec.jsx
@@ -17,11 +17,11 @@ vi.mock('react-router-dom', async () => {
   }
 })
 
-const mockState = {
+const mockStateTutor = {
   appMain: { userId: userId, userRole: 'tutor' }
 }
 
-const mockState1 = {
+const mockStateStudent = {
   appMain: { userId: userId, userRole: 'student' }
 }
 
@@ -62,7 +62,7 @@ const cooperationData = {
   updatedAt: '2024-01-12T11:28:34.397Z'
 }
 
-const cooperationMock1 = {
+const OPPOSITE_USER_DECIDED_TO_CLOSE_COOPERATION = {
   ...cooperationData,
   needAction: {
     role: 'tutor',
@@ -73,7 +73,7 @@ const cooperationMock1 = {
   receiver: { _id: '123123', role: ['student'] }
 }
 
-const cooperationMock2 = {
+const OPPOSITE_USER_DECLINED_TO_CLOSE_COOPERATION = {
   ...cooperationData,
   needAction: {
     role: 'student',
@@ -84,7 +84,7 @@ const cooperationMock2 = {
   receiver: { _id: '123123', role: ['tutor'] }
 }
 
-const cooperationMock3 = {
+const USER_SUBMITTED_AN_ANSWER = {
   ...cooperationData,
   needAction: {
     role: 'student',
@@ -95,7 +95,7 @@ const cooperationMock3 = {
   receiver: { _id: '123123', role: ['student'] }
 }
 
-const cooperationMock4 = {
+const USER_SUBMITTED_A_REASON_FOR_DECLINING = {
   ...cooperationData,
   needAction: {
     role: 'tutor',
@@ -119,11 +119,11 @@ describe('CooperationDetails', () => {
   beforeAll(() => {
     mockAxiosClient
       .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
-      .reply(200, cooperationMock1)
+      .reply(200, OPPOSITE_USER_DECIDED_TO_CLOSE_COOPERATION)
   })
 
   beforeEach(() => {
-    renderWithProviders(<CooperationDetails />, { preloadedState: mockState })
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockStateTutor })
   })
 
   afterAll(() => {
@@ -139,7 +139,9 @@ describe('CooperationDetails', () => {
   })
 
   it('should show cooperation status and title', () => {
-    const title = screen.getByText(cooperationMock1.title)
+    const title = screen.getByText(
+      OPPOSITE_USER_DECIDED_TO_CLOSE_COOPERATION.title
+    )
     const statusChip = screen.getByText('need action')
 
     expect(title).toBeInTheDocument()
@@ -189,11 +191,11 @@ describe('CooperationClosureDeclinedBanner without answer being submitted', () =
     mockAxiosClient.reset()
     mockAxiosClient
       .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
-      .reply(200, cooperationMock2)
+      .reply(200, OPPOSITE_USER_DECLINED_TO_CLOSE_COOPERATION)
   })
 
   beforeEach(() => {
-    renderWithProviders(<CooperationDetails />, { preloadedState: mockState1 })
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockStateStudent })
   })
 
   it('should render CooperationClosureDeclinedBanner when needAction type is "waiting for answer" and role equals users role', async () => {
@@ -211,11 +213,11 @@ describe('CooperationClosureDeclinedBanner with submitted answer', () => {
     mockAxiosClient.reset()
     mockAxiosClient
       .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
-      .reply(200, cooperationMock3)
+      .reply(200, USER_SUBMITTED_AN_ANSWER)
   })
 
   beforeEach(() => {
-    renderWithProviders(<CooperationDetails />, { preloadedState: mockState })
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockStateTutor })
   })
 
   it('should render CooperationClosureDeclinedBanner when needAction type is "waiting for approval" and role is not the same as users role', async () => {
@@ -233,11 +235,11 @@ describe('AcceptCooperationClosing modal with submitted answer', () => {
     mockAxiosClient.reset()
     mockAxiosClient
       .onGet(URLs.cooperations.getById.replace(':id', cooperationID))
-      .reply(200, cooperationMock4)
+      .reply(200, USER_SUBMITTED_A_REASON_FOR_DECLINING)
   })
 
   beforeEach(() => {
-    renderWithProviders(<CooperationDetails />, { preloadedState: mockState1 })
+    renderWithProviders(<CooperationDetails />, { preloadedState: mockStateStudent })
   })
 
   it('should render AcceptCooperationClosing modal when needAction type is "waiting for answer" and role is not the same as users role', async () => {

--- a/tests/unit/pages/my-cooperations/MyCooperations.spec.jsx
+++ b/tests/unit/pages/my-cooperations/MyCooperations.spec.jsx
@@ -21,7 +21,12 @@ const MOCK_RESPONSE = {
       },
       price: 1800,
       proficiencyLevel: 'Beginner',
-      status: 'pending'
+      status: 'pending',
+      needAction: {
+        role: 'student',
+        type: 'price',
+        messages: []
+      }
     }
   ],
   count: 0


### PR DESCRIPTION
1. Added needAction Modals Logic in GET Cooperation by id: Implemented getCooperationClosingModal Function for Correct Modal Display:
- Determines the correct modal based on cooperation.needAction.type and cooperation.needAction.role.
- Returns null if the cooperation status is not RequestToClose.
- Retrieves the last message and second last message from needAction.messages.
- Displays the appropriate modal
2. Updated updateCooperation service to include UpdateCooperationsNeedActionMessages
- Extended updateCooperation to handle needAction.messages updates when cooperation data changes.
- Ensures correct message flow for cooperation closure requests.


Flow Overview:

https://github.com/user-attachments/assets/2bf12a7a-1e59-4cad-8753-e5b021a6e904

----------------------------------

- [x] Implemented getCooperationClosingModal function.
- [x] Integrated correct modals based on needAction.type and needAction.role.
- [x] Updated updateCooperation service to handle needAction.messages.
- [x] Added tests for modal selection logic.
- [x] Removed redundant setCooperationStatus logic from cooperationSlice