### PR TITLE
Replace useAxios with useQuery in the AttachmentsContainer

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -87,7 +87,8 @@ export const URLs = {
     attachments: {
       get: '/attachments',
       patch: '/attachments/:id',
-      delete: '/attachments'
+      delete: '/attachments',
+      post: '/attachments'
     },
     questions: {
       get: '/questions',

--- a/src/containers/add-documents/AddDocuments.tsx
+++ b/src/containers/add-documents/AddDocuments.tsx
@@ -13,7 +13,7 @@ import { spliceSx } from '~/utils/helper-functions'
 import { openAlert } from '~/redux/features/snackbarSlice'
 
 interface AddDocumentsProps {
-  fetchData: (formData: FormData) => void
+  onCreateDocument: (formData: FormData) => void
   formData: FormData
   buttonText: string
   sx?: {
@@ -25,7 +25,7 @@ interface AddDocumentsProps {
 }
 
 const AddDocuments: FC<AddDocumentsProps> = ({
-  fetchData,
+  onCreateDocument,
   formData,
   buttonText,
   sx = {},
@@ -56,7 +56,7 @@ const AddDocuments: FC<AddDocumentsProps> = ({
       formData.append('files', file)
     }
 
-    !error && void fetchData(formData)
+    !error && onCreateDocument(formData)
     removePreviousFiles && setDocuments([])
   }
 

--- a/src/containers/add-documents/AddDocuments.tsx
+++ b/src/containers/add-documents/AddDocuments.tsx
@@ -8,15 +8,14 @@ import { useAppDispatch } from '~/hooks/use-redux'
 import { validationData } from '~/containers/add-documents/AddDocuments.constants'
 import { styles } from '~/containers/add-documents/AddDocuments.styles'
 import { snackbarVariants } from '~/constants'
-import { ButtonVariantEnum, UploadFileEmitter } from '~/types'
+import type { UploadFileEmitter } from '~/types'
 import { spliceSx } from '~/utils/helper-functions'
 import { openAlert } from '~/redux/features/snackbarSlice'
 
 interface AddDocumentsProps {
-  fetchData: (formData: FormData) => Promise<void>
+  fetchData: (formData: FormData) => void
   formData: FormData
   buttonText: string
-  variant?: ButtonVariantEnum
   sx?: {
     root?: SxProps
     button?: SxProps
@@ -29,7 +28,6 @@ const AddDocuments: FC<AddDocumentsProps> = ({
   fetchData,
   formData,
   buttonText,
-  variant,
   sx = {},
   icon,
   removePreviousFiles = false
@@ -75,7 +73,6 @@ const AddDocuments: FC<AddDocumentsProps> = ({
           button: spliceSx(styles.fileUpload.button, sx?.button)
         }}
         validationData={validationData}
-        variant={variant}
       />
     </Box>
   )

--- a/src/containers/add-documents/AddDocuments.tsx
+++ b/src/containers/add-documents/AddDocuments.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement, useEffect, useState } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import Box from '@mui/material/Box'
 import { SxProps } from '@mui/material'
 
@@ -24,7 +24,7 @@ interface AddDocumentsProps {
   removePreviousFiles?: boolean
 }
 
-const AddDocuments: FC<AddDocumentsProps> = ({
+const AddDocuments: React.FC<AddDocumentsProps> = ({
   onCreateDocument,
   formData,
   buttonText,

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -162,7 +162,7 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
   }
 
   const { mutate: mutateAttachment } = useMutation({
-    mutationFn: ResourceService.updateAttachmentQuery,
+    mutationFn: ResourceService.updateAttachment,
     onSuccess: (data) => {
       resourceEventHandler?.({
         type: CourseResourceEventType.ResourceUpdated,
@@ -325,7 +325,7 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
           columns={attachmentColumns}
           onAddResources={onAddResourcesWrapper}
           removeColumnRules={removeAttachmentColumnRules}
-          requestService={ResourceService.getAttachmentsQuery}
+          requestService={ResourceService.getAttachments}
           resourceTab={resourcesData.attachments.resourceTab}
           resources={attachments}
           showCheckboxWithTooltip

--- a/src/containers/my-resources/add-attachment-category-modal/AddAttachmentCategoryModal.tsx
+++ b/src/containers/my-resources/add-attachment-category-modal/AddAttachmentCategoryModal.tsx
@@ -22,13 +22,13 @@ import {
 interface AddAttachmentCategoryModalProps {
   closeModal: () => void
   attachment: Attachment
-  updateAttachmentCategory: (params: UpdateAttachmentParams) => void
+  onAttachmentUpdate: (params: UpdateAttachmentParams) => void
 }
 
 const AddAttachmentCategoryModal: FC<AddAttachmentCategoryModalProps> = ({
   closeModal,
   attachment,
-  updateAttachmentCategory
+  onAttachmentUpdate
 }) => {
   const { t } = useTranslation()
 
@@ -39,7 +39,10 @@ const AddAttachmentCategoryModal: FC<AddAttachmentCategoryModalProps> = ({
       initialValues: getInitialValues(attachment),
       onSubmit: () => {
         setLoading(true)
-        updateAttachmentCategory(data)
+        onAttachmentUpdate({
+          id: attachment._id,
+          category: data.category
+        })
         setLoading(false)
         closeModal()
       }
@@ -84,7 +87,7 @@ const AddAttachmentCategoryModal: FC<AddAttachmentCategoryModalProps> = ({
           {t('common.cancel')}
         </Button>
         <Button
-          disabled={!!errors.fileName}
+          disabled={Boolean(errors.fileName) || !data.category}
           loading={loading}
           sx={styles.saveBtn}
           type={ButtonTypeEnum.Submit}

--- a/src/containers/my-resources/add-attachment-category-modal/AddAttachmentCategoryModal.tsx
+++ b/src/containers/my-resources/add-attachment-category-modal/AddAttachmentCategoryModal.tsx
@@ -1,4 +1,3 @@
-import { FC, SyntheticEvent, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
@@ -25,31 +24,27 @@ interface AddAttachmentCategoryModalProps {
   onAttachmentUpdate: (params: UpdateAttachmentParams) => void
 }
 
-const AddAttachmentCategoryModal: FC<AddAttachmentCategoryModalProps> = ({
+const AddAttachmentCategoryModal: React.FC<AddAttachmentCategoryModalProps> = ({
   closeModal,
   attachment,
   onAttachmentUpdate
 }) => {
   const { t } = useTranslation()
 
-  const [loading, setLoading] = useState<boolean>(false)
-
   const { data, errors, handleNonInputValueChange, handleBlur, handleSubmit } =
     useForm<UpdateAttachmentParams>({
       initialValues: getInitialValues(attachment),
       onSubmit: () => {
-        setLoading(true)
         onAttachmentUpdate({
           id: attachment._id,
           category: data.category
         })
-        setLoading(false)
         closeModal()
       }
     })
 
   const onCategoryChange = (
-    _: SyntheticEvent,
+    _: React.SyntheticEvent,
     value: CategoryNameInterface | null
   ) => {
     handleNonInputValueChange('category', value?._id ?? null)
@@ -88,7 +83,6 @@ const AddAttachmentCategoryModal: FC<AddAttachmentCategoryModalProps> = ({
         </Button>
         <Button
           disabled={Boolean(errors.fileName) || !data.category}
-          loading={loading}
           sx={styles.saveBtn}
           type={ButtonTypeEnum.Submit}
         >

--- a/src/containers/my-resources/add-attachment-category-modal/AddAttachmentCategoryModal.tsx
+++ b/src/containers/my-resources/add-attachment-category-modal/AddAttachmentCategoryModal.tsx
@@ -22,9 +22,7 @@ import {
 interface AddAttachmentCategoryModalProps {
   closeModal: () => void
   attachment: Attachment
-  updateAttachmentCategory: (
-    params?: UpdateAttachmentParams | undefined
-  ) => Promise<void>
+  updateAttachmentCategory: (params: UpdateAttachmentParams) => void
 }
 
 const AddAttachmentCategoryModal: FC<AddAttachmentCategoryModalProps> = ({
@@ -39,9 +37,9 @@ const AddAttachmentCategoryModal: FC<AddAttachmentCategoryModalProps> = ({
   const { data, errors, handleNonInputValueChange, handleBlur, handleSubmit } =
     useForm<UpdateAttachmentParams>({
       initialValues: getInitialValues(attachment),
-      onSubmit: async () => {
+      onSubmit: () => {
         setLoading(true)
-        await updateAttachmentCategory(data)
+        updateAttachmentCategory(data)
         setLoading(false)
         closeModal()
       }

--- a/src/containers/my-resources/add-resource-modal/AddResourceModal.tsx
+++ b/src/containers/my-resources/add-resource-modal/AddResourceModal.tsx
@@ -136,8 +136,10 @@ const AddResourceModal = <T extends TableItem>({
       {uploadItem && (
         <AddDocuments
           buttonText={t('common.uploadNewFile')}
-          fetchData={uploadItem}
           formData={formData}
+          onCreateDocument={(data: FormData) => {
+            void uploadItem(data)
+          }}
         />
       )}
     </Box>

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -60,7 +60,6 @@ const AttachmentsContainer = () => {
     [itemsPerPage, page, sort, searchFileName, selectedItems]
   )
 
-  // useMutation hook
   const deleteAttachment = useCallback(
     (id?: string) => ResourceService.deleteAttachment(id ?? ''),
     []
@@ -149,7 +148,7 @@ const AttachmentsContainer = () => {
   const props = {
     columns: columnsToShow,
     data: {
-      response: loadedAttachments ?? defaultResponses.itemsWithCount,
+      response: loadedAttachments,
       getData: handleRefetchAttachments
     },
     services: { deleteService: deleteAttachment },

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -98,11 +98,7 @@ const AttachmentsContainer = () => {
   })
 
   const onEdit = (id: string) => {
-    if (!loadedAttachments) {
-      return
-    }
-
-    const attachment = loadedAttachments.items.find((item) => item._id === id)
+    const attachment = loadedAttachments!.items.find((item) => item._id === id)
 
     const handleConfirm = () =>
       openModal({
@@ -127,11 +123,7 @@ const AttachmentsContainer = () => {
   }
 
   const onAddCategory = (id: string) => {
-    if (!loadedAttachments) {
-      return
-    }
-
-    const attachment = loadedAttachments.items.find((item) => item._id === id)
+    const attachment = loadedAttachments!.items.find((item) => item._id === id)
 
     openModal({
       component: (

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -11,7 +11,6 @@ import MyResourcesTable from '~/containers/my-resources/my-resources-table/MyRes
 import Loader from '~/components/loader/Loader'
 import useSort from '~/hooks/table/use-sort'
 import useBreakpoints from '~/hooks/use-breakpoints'
-import useAxios from '~/hooks/use-axios'
 import usePagination from '~/hooks/table/use-pagination'
 import AddDocuments from '~/containers/add-documents/AddDocuments'
 
@@ -23,12 +22,11 @@ import {
   removeColumnRules
 } from '~/containers/my-resources/attachments-container/AttachmentsContainer.constants'
 import {
-  ItemsWithCount,
-  Attachment,
-  ErrorResponse,
-  ResourcesTabsEnum,
-  ButtonVariantEnum,
-  CooperationSliceAttachment
+  type ItemsWithCount,
+  type Attachment,
+  type ErrorResponse,
+  type CooperationSliceAttachment,
+  ResourcesTabsEnum
 } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 import { styles } from '~/containers/my-resources/attachments-container/AttachmentsContainer.styles'
@@ -105,11 +103,6 @@ const AttachmentsContainer = () => {
     queryKey: ['attachments']
   })
 
-  const createAttachments = useCallback(
-    (data?: FormData) => ResourceService.createAttachments(data),
-    []
-  )
-
   const onCreateAttachmentsError = (error?: ErrorResponse) => {
     dispatch(
       openAlert({
@@ -119,18 +112,11 @@ const AttachmentsContainer = () => {
     )
   }
 
-  // TODO: useMutation
-  const { fetchData: fetchCreateAttachment } = useAxios({
-    service: createAttachments,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponseError: onCreateAttachmentsError
+  const { mutate: mutateCreateAttachment } = useMutation({
+    mutationFn: ResourceService.createAttachments,
+    onError: onCreateAttachmentsError,
+    queryKey: ['attachments']
   })
-
-  const uploadFile = async (data: FormData) => {
-    await fetchCreateAttachment(data)
-    await fetchAttachments()
-  }
 
   const onEdit = (id: string) => {
     const attachment = response.items.find((item) => item._id === id)
@@ -197,12 +183,11 @@ const AttachmentsContainer = () => {
       button={
         <AddDocuments
           buttonText={t('myResourcesPage.attachments.addBtn')}
-          fetchData={uploadFile}
+          fetchData={mutateCreateAttachment}
           formData={formData}
           icon={<AddIcon sx={styles.addAttachmentIcon} />}
           removePreviousFiles
           sx={styles.addAttachmentBtn}
-          variant={ButtonVariantEnum.Contained}
         />
       }
       fetchData={fetchAttachments}

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -75,7 +75,13 @@ const AttachmentsContainer = () => {
     refetch: refetchAttachments,
     error: fetchAttachmentsError
   } = useQuery<ItemsWithCount<Attachment>>({
-    queryKey: ['attachments'],
+    queryKey: [
+      'attachments',
+      page,
+      sort,
+      searchFileName.current,
+      selectedItems
+    ],
     queryFn: getAttachments,
     options: {
       initialData: defaultResponses.itemsWithCount

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -65,7 +65,7 @@ const AttachmentsContainer = () => {
 
   const getAttachments = useCallback(
     () =>
-      ResourceService.getAttachmentsQuery({
+      ResourceService.getAttachments({
         limit: itemsPerPage,
         skip: (page - 1) * itemsPerPage,
         sort,
@@ -97,8 +97,8 @@ const AttachmentsContainer = () => {
     await refetchAttachments()
   }
 
-  const { mutate: mutateAttachment } = useMutation({
-    mutationFn: ResourceService.updateAttachmentQuery,
+  const { mutate: updateAttachment } = useMutation({
+    mutationFn: ResourceService.updateAttachment,
     onError: onResponseError,
     queryKey: ['attachments']
   })
@@ -112,8 +112,8 @@ const AttachmentsContainer = () => {
     )
   }
 
-  const { mutate: mutateCreateAttachment } = useMutation({
-    mutationFn: ResourceService.createAttachments,
+  const { mutate: createAttachment } = useMutation({
+    mutationFn: ResourceService.createAttachment,
     onError: onCreateAttachmentsError,
     queryKey: ['attachments']
   })
@@ -127,7 +127,7 @@ const AttachmentsContainer = () => {
           <EditAttachmentModal
             attachment={attachment as CooperationSliceAttachment}
             closeModal={closeModal}
-            onAttachmentUpdate={mutateAttachment}
+            onAttachmentUpdate={updateAttachment}
           />
         )
       })
@@ -151,7 +151,7 @@ const AttachmentsContainer = () => {
         <AddAttachmentCategoryModal
           attachment={attachment as Attachment}
           closeModal={closeModal}
-          updateAttachmentCategory={mutateAttachment}
+          updateAttachmentCategory={updateAttachment}
         />
       )
     })
@@ -183,7 +183,7 @@ const AttachmentsContainer = () => {
       button={
         <AddDocuments
           buttonText={t('myResourcesPage.attachments.addBtn')}
-          fetchData={mutateCreateAttachment}
+          fetchData={createAttachment}
           formData={formData}
           icon={<AddIcon sx={styles.addAttachmentIcon} />}
           removePreviousFiles

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -183,9 +183,9 @@ const AttachmentsContainer = () => {
       button={
         <AddDocuments
           buttonText={t('myResourcesPage.attachments.addBtn')}
-          fetchData={createAttachment}
           formData={formData}
           icon={<AddIcon sx={styles.addAttachmentIcon} />}
+          onCreateDocument={createAttachment}
           removePreviousFiles
           sx={styles.addAttachmentBtn}
         />

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -21,18 +21,14 @@ import {
   itemsLoadLimit,
   removeColumnRules
 } from '~/containers/my-resources/attachments-container/AttachmentsContainer.constants'
-import {
-  type ItemsWithCount,
-  type Attachment,
-  type ErrorResponse,
-  ResourcesTabsEnum
-} from '~/types'
+import { type Attachment, ResourcesTabsEnum } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 import { styles } from '~/containers/my-resources/attachments-container/AttachmentsContainer.styles'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 import useMutation from '~/hooks/use-mutation'
 import useQuery from '~/hooks/use-query'
 import useSnackbarAlert from '~/hooks/use-snackbar-alert'
+import { queryClient } from '~/plugins/queryClient'
 
 const AttachmentsContainer = () => {
   const { t } = useTranslation()
@@ -68,9 +64,8 @@ const AttachmentsContainer = () => {
   const {
     data: loadedAttachments,
     isLoading: isLoadingAttachments,
-    refetch: refetchAttachments,
     error: attachmentsLoadError
-  } = useQuery<ItemsWithCount<Attachment>>({
+  } = useQuery({
     queryKey: [
       'attachments',
       page,
@@ -80,12 +75,14 @@ const AttachmentsContainer = () => {
     ],
     queryFn: getAttachments,
     options: {
-      initialData: defaultResponses.itemsWithCount
+      staleTime: Infinity
     }
   })
 
-  const handleRefetchAttachments = async (): Promise<void> => {
-    await refetchAttachments()
+  const invalidateAttachments = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ['attachments']
+    })
   }
 
   const { mutate: handleUpdateAttachment } = useMutation({
@@ -101,6 +98,10 @@ const AttachmentsContainer = () => {
   })
 
   const onEdit = (id: string) => {
+    if (!loadedAttachments) {
+      return
+    }
+
     const attachment = loadedAttachments.items.find((item) => item._id === id)
 
     const handleConfirm = () =>
@@ -126,6 +127,10 @@ const AttachmentsContainer = () => {
   }
 
   const onAddCategory = (id: string) => {
+    if (!loadedAttachments) {
+      return
+    }
+
     const attachment = loadedAttachments.items.find((item) => item._id === id)
 
     openModal({
@@ -148,8 +153,8 @@ const AttachmentsContainer = () => {
   const props = {
     columns: columnsToShow,
     data: {
-      response: loadedAttachments,
-      getData: handleRefetchAttachments
+      response: loadedAttachments ?? defaultResponses.itemsWithCount,
+      getData: invalidateAttachments
     },
     services: { deleteService: deleteAttachment },
     itemsPerPage,
@@ -172,7 +177,7 @@ const AttachmentsContainer = () => {
           sx={styles.addAttachmentBtn}
         />
       }
-      fetchData={handleRefetchAttachments}
+      fetchData={invalidateAttachments}
       placeholder={'myResourcesPage.attachments.searchInput'}
       searchRef={searchFileName}
       selectedItems={selectedItems}
@@ -183,7 +188,7 @@ const AttachmentsContainer = () => {
 
   useEffect(() => {
     if (attachmentsLoadError) {
-      handleErrorAlert(attachmentsLoadError as ErrorResponse)
+      handleErrorAlert(attachmentsLoadError)
     }
   }, [attachmentsLoadError, handleErrorAlert])
 

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -70,10 +70,10 @@ const AttachmentsContainer = () => {
   )
 
   const {
-    data: response,
-    isLoading: loading,
+    data: loadedAttachments,
+    isLoading: isLoadingAttachments,
     refetch: refetchAttachments,
-    error: fetchAttachmentsError
+    error: attachmentsLoadError
   } = useQuery<ItemsWithCount<Attachment>>({
     queryKey: [
       'attachments',
@@ -114,7 +114,7 @@ const AttachmentsContainer = () => {
   })
 
   const onEdit = (id: string) => {
-    const attachment = response.items.find((item) => item._id === id)
+    const attachment = loadedAttachments.items.find((item) => item._id === id)
 
     const handleConfirm = () =>
       openModal({
@@ -139,7 +139,7 @@ const AttachmentsContainer = () => {
   }
 
   const onAddCategory = (id: string) => {
-    const attachment = response.items.find((item) => item._id === id)
+    const attachment = loadedAttachments.items.find((item) => item._id === id)
 
     openModal({
       component: (
@@ -161,7 +161,7 @@ const AttachmentsContainer = () => {
   const props = {
     columns: columnsToShow,
     data: {
-      response: response ?? defaultResponses.itemsWithCount,
+      response: loadedAttachments ?? defaultResponses.itemsWithCount,
       getData: fetchAttachments
     },
     services: { deleteService: deleteAttachment },
@@ -195,15 +195,15 @@ const AttachmentsContainer = () => {
   )
 
   useEffect(() => {
-    if (fetchAttachmentsError) {
-      handleErrorAlert(fetchAttachmentsError as ErrorResponse)
+    if (attachmentsLoadError) {
+      handleErrorAlert(attachmentsLoadError as ErrorResponse)
     }
-  }, [fetchAttachmentsError, handleErrorAlert])
+  }, [attachmentsLoadError, handleErrorAlert])
 
   return (
     <Box>
       {addAttachmentBlock}
-      {loading ? (
+      {isLoadingAttachments ? (
         <Loader pageLoad size={50} />
       ) : (
         <MyResourcesTable<Attachment> {...props} />

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -66,13 +66,7 @@ const AttachmentsContainer: React.FC = () => {
     isLoading: isLoadingAttachments,
     error: attachmentsLoadError
   } = useQuery({
-    queryKey: [
-      'attachments',
-      page,
-      sort,
-      searchFileName.current,
-      selectedItems
-    ],
+    queryKey: ['attachments', page, sort, selectedItems],
     queryFn: getAttachments,
     options: {
       staleTime: Infinity
@@ -170,7 +164,7 @@ const AttachmentsContainer: React.FC = () => {
         />
       }
       fetchData={invalidateAttachments}
-      placeholder={'myResourcesPage.attachments.searchInput'}
+      placeholder='myResourcesPage.attachments.searchInput'
       searchRef={searchFileName}
       selectedItems={selectedItems}
       setItems={setSelectedItems}

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -30,7 +30,7 @@ import useQuery from '~/hooks/use-query'
 import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 import { queryClient } from '~/plugins/queryClient'
 
-const AttachmentsContainer = () => {
+const AttachmentsContainer: React.FC = () => {
   const { t } = useTranslation()
   const { openModal, closeModal } = useModalContext()
   const breakpoints = useBreakpoints()

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -14,7 +14,7 @@ import useBreakpoints from '~/hooks/use-breakpoints'
 import usePagination from '~/hooks/table/use-pagination'
 import AddDocuments from '~/containers/add-documents/AddDocuments'
 
-import { defaultResponses, snackbarVariants } from '~/constants'
+import { defaultResponses } from '~/constants'
 import {
   columns,
   initialSort,
@@ -29,9 +29,6 @@ import {
 } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 import { styles } from '~/containers/my-resources/attachments-container/AttachmentsContainer.styles'
-import { useAppDispatch } from '~/hooks/use-redux'
-import { openAlert } from '~/redux/features/snackbarSlice'
-import { getErrorKey } from '~/utils/get-error-key'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 import useMutation from '~/hooks/use-mutation'
 import useQuery from '~/hooks/use-query'
@@ -39,7 +36,6 @@ import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 const AttachmentsContainer = () => {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const { openModal, closeModal } = useModalContext()
   const breakpoints = useBreakpoints()
   const { page, handleChangePage } = usePagination()
@@ -64,6 +60,7 @@ const AttachmentsContainer = () => {
     [itemsPerPage, page, sort, searchFileName, selectedItems]
   )
 
+  // useMutation hook
   const deleteAttachment = useCallback(
     (id?: string) => ResourceService.deleteAttachment(id ?? ''),
     []
@@ -88,28 +85,19 @@ const AttachmentsContainer = () => {
     }
   })
 
-  const fetchAttachments = async (): Promise<void> => {
+  const handleRefetchAttachments = async (): Promise<void> => {
     await refetchAttachments()
   }
 
-  const { mutate: updateAttachment } = useMutation({
+  const { mutate: handleUpdateAttachment } = useMutation({
     mutationFn: ResourceService.updateAttachment,
     onError: handleErrorAlert,
     queryKey: ['attachments']
   })
 
-  const onCreateAttachmentsError = (error?: ErrorResponse) => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.error,
-        message: getErrorKey(error)
-      })
-    )
-  }
-
-  const { mutate: createAttachment } = useMutation({
+  const { mutate: handleCreateAttachment } = useMutation({
     mutationFn: ResourceService.createAttachment,
-    onError: onCreateAttachmentsError,
+    onError: handleErrorAlert,
     queryKey: ['attachments']
   })
 
@@ -122,7 +110,7 @@ const AttachmentsContainer = () => {
           <EditAttachmentModal
             attachment={attachment as Attachment}
             closeModal={closeModal}
-            onAttachmentUpdate={updateAttachment}
+            onAttachmentUpdate={handleUpdateAttachment}
           />
         )
       })
@@ -146,7 +134,7 @@ const AttachmentsContainer = () => {
         <AddAttachmentCategoryModal
           attachment={attachment as Attachment}
           closeModal={closeModal}
-          onAttachmentUpdate={updateAttachment}
+          onAttachmentUpdate={handleUpdateAttachment}
         />
       )
     })
@@ -162,7 +150,7 @@ const AttachmentsContainer = () => {
     columns: columnsToShow,
     data: {
       response: loadedAttachments ?? defaultResponses.itemsWithCount,
-      getData: fetchAttachments
+      getData: handleRefetchAttachments
     },
     services: { deleteService: deleteAttachment },
     itemsPerPage,
@@ -180,12 +168,12 @@ const AttachmentsContainer = () => {
           buttonText={t('myResourcesPage.attachments.addBtn')}
           formData={formData}
           icon={<AddIcon sx={styles.addAttachmentIcon} />}
-          onCreateDocument={createAttachment}
+          onCreateDocument={handleCreateAttachment}
           removePreviousFiles
           sx={styles.addAttachmentBtn}
         />
       }
-      fetchData={fetchAttachments}
+      fetchData={handleRefetchAttachments}
       placeholder={'myResourcesPage.attachments.searchInput'}
       searchRef={searchFileName}
       selectedItems={selectedItems}

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -25,7 +25,6 @@ import {
   type ItemsWithCount,
   type Attachment,
   type ErrorResponse,
-  type CooperationSliceAttachment,
   ResourcesTabsEnum
 } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
@@ -36,6 +35,7 @@ import { getErrorKey } from '~/utils/get-error-key'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
 import useMutation from '~/hooks/use-mutation'
 import useQuery from '~/hooks/use-query'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 const AttachmentsContainer = () => {
   const { t } = useTranslation()
@@ -47,21 +47,10 @@ const AttachmentsContainer = () => {
   const searchFileName = useRef<string>('')
   const [selectedItems, setSelectedItems] = useState<string[]>([])
   const formData = new FormData()
+  const { handleErrorAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
-
-  const onResponseError = useCallback(
-    (error?: ErrorResponse) => {
-      dispatch(
-        openAlert({
-          severity: snackbarVariants.error,
-          message: getErrorKey(error)
-        })
-      )
-    },
-    [dispatch]
-  )
 
   const getAttachments = useCallback(
     () =>
@@ -99,7 +88,7 @@ const AttachmentsContainer = () => {
 
   const { mutate: updateAttachment } = useMutation({
     mutationFn: ResourceService.updateAttachment,
-    onError: onResponseError,
+    onError: handleErrorAlert,
     queryKey: ['attachments']
   })
 
@@ -125,7 +114,7 @@ const AttachmentsContainer = () => {
       openModal({
         component: (
           <EditAttachmentModal
-            attachment={attachment as CooperationSliceAttachment}
+            attachment={attachment as Attachment}
             closeModal={closeModal}
             onAttachmentUpdate={updateAttachment}
           />
@@ -151,7 +140,7 @@ const AttachmentsContainer = () => {
         <AddAttachmentCategoryModal
           attachment={attachment as Attachment}
           closeModal={closeModal}
-          updateAttachmentCategory={updateAttachment}
+          onAttachmentUpdate={updateAttachment}
         />
       )
     })
@@ -201,9 +190,9 @@ const AttachmentsContainer = () => {
 
   useEffect(() => {
     if (fetchAttachmentsError) {
-      onResponseError(fetchAttachmentsError as ErrorResponse)
+      handleErrorAlert(fetchAttachmentsError as ErrorResponse)
     }
-  }, [fetchAttachmentsError, onResponseError])
+  }, [fetchAttachmentsError, handleErrorAlert])
 
   return (
     <Box>

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Box from '@mui/material/Box'
 import AddIcon from '@mui/icons-material/Add'
 import { useTranslation } from 'react-i18next'
@@ -24,10 +24,8 @@ import {
 } from '~/containers/my-resources/attachments-container/AttachmentsContainer.constants'
 import {
   ItemsWithCount,
-  GetResourcesParams,
   Attachment,
   ErrorResponse,
-  UpdateAttachmentParams,
   ResourcesTabsEnum,
   ButtonVariantEnum,
   CooperationSliceAttachment
@@ -38,6 +36,8 @@ import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
+import useMutation from '~/hooks/use-mutation'
+import useQuery from '~/hooks/use-query'
 
 const AttachmentsContainer = () => {
   const { t } = useTranslation()
@@ -67,7 +67,7 @@ const AttachmentsContainer = () => {
 
   const getAttachments = useCallback(
     () =>
-      ResourceService.getAttachments({
+      ResourceService.getAttachmentsQuery({
         limit: itemsPerPage,
         skip: (page - 1) * itemsPerPage,
         sort,
@@ -82,33 +82,27 @@ const AttachmentsContainer = () => {
     []
   )
 
-  const updateAttachment = useCallback(
-    (params?: UpdateAttachmentParams) =>
-      ResourceService.updateAttachment(params),
-    []
-  )
-
   const {
-    response,
-    loading,
-    fetchData: fetchAttachments
-  } = useAxios<ItemsWithCount<Attachment>, GetResourcesParams>({
-    service: getAttachments,
-    defaultResponse: defaultResponses.itemsWithCount,
-    onResponseError
+    data: response,
+    isLoading: loading,
+    refetch: refetchAttachments,
+    error: fetchAttachmentsError
+  } = useQuery<ItemsWithCount<Attachment>>({
+    queryKey: ['attachments'],
+    queryFn: getAttachments,
+    options: {
+      initialData: defaultResponses.itemsWithCount
+    }
   })
 
-  const onAttachmentUpdate = useCallback(
-    () => void fetchAttachments(),
-    [fetchAttachments]
-  )
+  const fetchAttachments = async (): Promise<void> => {
+    await refetchAttachments()
+  }
 
-  const { fetchData: updateData } = useAxios({
-    service: updateAttachment,
-    defaultResponse: null,
-    onResponseError,
-    onResponse: onAttachmentUpdate,
-    fetchOnMount: false
+  const { mutate: mutateAttachment } = useMutation({
+    mutationFn: ResourceService.updateAttachmentQuery,
+    onError: onResponseError,
+    queryKey: ['attachments']
   })
 
   const createAttachments = useCallback(
@@ -124,6 +118,8 @@ const AttachmentsContainer = () => {
       })
     )
   }
+
+  // TODO: useMutation
   const { fetchData: fetchCreateAttachment } = useAxios({
     service: createAttachments,
     fetchOnMount: false,
@@ -145,9 +141,7 @@ const AttachmentsContainer = () => {
           <EditAttachmentModal
             attachment={attachment as CooperationSliceAttachment}
             closeModal={closeModal}
-            onAttachmentUpdate={() => {
-              void updateData()
-            }}
+            onAttachmentUpdate={mutateAttachment}
           />
         )
       })
@@ -171,7 +165,7 @@ const AttachmentsContainer = () => {
         <AddAttachmentCategoryModal
           attachment={attachment as Attachment}
           closeModal={closeModal}
-          updateAttachmentCategory={updateData}
+          updateAttachmentCategory={mutateAttachment}
         />
       )
     })
@@ -185,7 +179,10 @@ const AttachmentsContainer = () => {
 
   const props = {
     columns: columnsToShow,
-    data: { response, getData: fetchAttachments },
+    data: {
+      response: response ?? defaultResponses.itemsWithCount,
+      getData: fetchAttachments
+    },
     services: { deleteService: deleteAttachment },
     itemsPerPage,
     actions: { onEdit },
@@ -216,6 +213,12 @@ const AttachmentsContainer = () => {
       sortOptions={sortOptions}
     />
   )
+
+  useEffect(() => {
+    if (fetchAttachmentsError) {
+      onResponseError(fetchAttachmentsError as ErrorResponse)
+    }
+  }, [fetchAttachmentsError, onResponseError])
 
   return (
     <Box>

--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
@@ -78,7 +78,7 @@ const CreateOrEditLesson = () => {
           columns={columns}
           onAddResources={handleAddAttachments}
           removeColumnRules={removeColumnRules}
-          requestService={ResourceService.getAttachmentsQuery}
+          requestService={ResourceService.getAttachments}
           resourceTab={ResourcesTabsEnum.Attachments}
           resources={data.attachments}
         />

--- a/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
+++ b/src/pages/create-or-edit-lesson/CreateOrEditLesson.tsx
@@ -44,7 +44,7 @@ import {
 } from '~/types'
 import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
-const CreateOrEditLesson = () => {
+const CreateOrEditLesson: React.FC = () => {
   const { t } = useTranslation()
 
   const { openModal } = useModalContext()

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -155,12 +155,6 @@ export const ResourceService = {
       })
     })
   },
-  updateAttachment: async (params?: UpdateAttachmentParams) => {
-    return await axiosClient.patch(
-      createUrlPath(URLs.resources.attachments.patch, params?.id),
-      params
-    )
-  },
   updateAttachmentQuery: (data: UpdateAttachmentParams) => {
     const { id, ...attachmentData } = data
 

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -172,9 +172,11 @@ export const ResourceService = {
       createUrlPath(URLs.resources.attachments.delete, id)
     )
   },
-  createAttachments: (data?: FormData): Promise<AxiosResponse> => {
-    return axiosClient.post(URLs.attachments.post, data, {
-      headers: { 'Content-Type': 'multipart/form-data' }
+  createAttachments: (data: FormData) => {
+    return baseService.request<Attachment>({
+      method: 'POST',
+      url: URLs.resources.attachments.post,
+      data: data
     })
   },
   getQuestions: (

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -142,11 +142,7 @@ export const ResourceService = {
       })
     })
   },
-  getAttachments: async (
-    params?: GetResourcesParams
-  ): Promise<AxiosResponse<ItemsWithCount<Attachment>>> =>
-    await axiosClient.get(URLs.resources.attachments.get, { params }),
-  getAttachmentsQuery: (params?: GetResourcesParams) => {
+  getAttachments: (params?: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Attachment>>({
       method: 'GET',
       url: getFullUrl({
@@ -155,7 +151,7 @@ export const ResourceService = {
       })
     })
   },
-  updateAttachmentQuery: (data: UpdateAttachmentParams) => {
+  updateAttachment: (data: UpdateAttachmentParams) => {
     const { id, ...attachmentData } = data
 
     return baseService.request<Attachment>({
@@ -172,7 +168,7 @@ export const ResourceService = {
       createUrlPath(URLs.resources.attachments.delete, id)
     )
   },
-  createAttachments: (data: FormData) => {
+  createAttachment: (data: FormData) => {
     return baseService.request<Attachment>({
       method: 'POST',
       url: URLs.resources.attachments.post,

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -142,7 +142,7 @@ export const ResourceService = {
       })
     })
   },
-  getAttachments: (params?: GetResourcesParams) => {
+  getAttachments: (params: GetResourcesParams) => {
     return baseService.request<ItemsWithCount<Attachment>>({
       method: 'GET',
       url: getFullUrl({
@@ -172,7 +172,7 @@ export const ResourceService = {
     return baseService.request<Attachment>({
       method: 'POST',
       url: URLs.resources.attachments.post,
-      data: data
+      data
     })
   },
   getQuestions: (

--- a/src/types/my-resources/interfaces/myResources.interface.ts
+++ b/src/types/my-resources/interfaces/myResources.interface.ts
@@ -28,7 +28,7 @@ export interface Categories extends CommonEntityFields {
 
 export type GetResourcesParams = Partial<RequestParams> & {
   title?: string
-  fileName?: string
+  fileName: string
 }
 
 export interface UpdateResourceCategory {

--- a/tests/unit/containers/AttachmentsContainer/AttachmentsContainer.spec.jsx
+++ b/tests/unit/containers/AttachmentsContainer/AttachmentsContainer.spec.jsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react'
+import { vi } from 'vitest'
 import AttachmentsContainer from '~/containers/my-resources/attachments-container/AttachmentsContainer'
 import { mockAxiosClient, renderWithProviders } from '~tests/test-utils'
-import { URLs } from '~/constants/request'
 
 vi.mock(
   '~/containers/my-resources/my-resources-table/MyResourcesTable',
@@ -54,6 +54,12 @@ const attachmentMockData = {
   items: responseItemsMock
 }
 
+vi.mock('~/services/resource-service', () => ({
+  ResourceService: {
+    getAttachments: vi.fn(() => Promise.resolve(attachmentMockData))
+  }
+}))
+
 describe('AttachmentContainer renders correct data', () => {
   beforeEach(() => {
     mockAxiosClient
@@ -65,7 +71,6 @@ describe('AttachmentContainer renders correct data', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
-    mockAxiosClient.reset()
   })
 
   it('should render "New attachment" button', () => {

--- a/tests/unit/containers/AttachmentsContainer/AttachmentsContainer.spec.jsx
+++ b/tests/unit/containers/AttachmentsContainer/AttachmentsContainer.spec.jsx
@@ -1,7 +1,8 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import AttachmentsContainer from '~/containers/my-resources/attachments-container/AttachmentsContainer'
-import { renderWithProviders } from '~tests/test-utils'
+import { renderWithProviders, mockAxiosClient } from '~tests/test-utils'
+import { URLs } from '~/constants/request'
 
 vi.mock(
   '~/containers/my-resources/my-resources-table/MyResourcesTable',
@@ -54,16 +55,10 @@ const attachmentMockData = {
   items: responseItemsMock
 }
 
-vi.mock('~/services/resource-service', () => ({
-  ResourceService: {
-    getAttachments: vi.fn(() => Promise.resolve(attachmentMockData))
-  }
-}))
-
 describe('AttachmentContainer renders correct data', () => {
   beforeEach(() => {
     mockAxiosClient
-      .onGet(URLs.resources.attachments.get)
+      .onGet(new RegExp(URLs.resources.attachments.get))
       .reply(200, attachmentMockData)
 
     renderWithProviders(<AttachmentsContainer />)
@@ -71,6 +66,7 @@ describe('AttachmentContainer renders correct data', () => {
 
   afterEach(() => {
     vi.clearAllMocks()
+    mockAxiosClient.reset()
   })
 
   it('should render "New attachment" button', () => {

--- a/tests/unit/containers/AttachmentsContainer/AttachmentsContainer.spec.jsx
+++ b/tests/unit/containers/AttachmentsContainer/AttachmentsContainer.spec.jsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import AttachmentsContainer from '~/containers/my-resources/attachments-container/AttachmentsContainer'
-import { mockAxiosClient, renderWithProviders } from '~tests/test-utils'
+import { renderWithProviders } from '~tests/test-utils'
 
 vi.mock(
   '~/containers/my-resources/my-resources-table/MyResourcesTable',

--- a/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
+++ b/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
@@ -55,8 +55,7 @@ describe('AddAttachmentCategoryModal component', () => {
   })
 
   it('should render save button and click on it if category was changed', async () => {
-    const saveBtn = screen.getByText('common.save')
-
+    const saveBtn = screen.getByRole('button', { name: 'common.save' })
     expect(saveBtn).toBeInTheDocument()
 
     await selectOption(
@@ -70,19 +69,13 @@ describe('AddAttachmentCategoryModal component', () => {
   })
 
   it('should render disabled save button by default', () => {
-    const saveBtn = screen.getByText('common.save')
+    const saveBtn = screen.getByRole('button', { name: 'common.save' })
 
     expect(saveBtn).toBeInTheDocument()
-
+    
     fireEvent.click(saveBtn)
-
+    
+    expect(saveBtn).toBeDisabled()
     expect(updateAttachmentCategory).not.toHaveBeenCalled()
-  })
-
-  it('should change category', async () => {
-    const categoryDropbox = screen.getByRole('combobox')
-
-    await selectOption(categoryDropbox, categoriesNamesMock[1].name)
-    expect(categoryDropbox.value).toBe(categoriesNamesMock[1].name)
   })
 })

--- a/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
+++ b/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
@@ -25,6 +25,15 @@ const attachmentMock = {
   category: null
 }
 
+const changeCategory = (autocomplete, categoryName) => {
+  fireEvent.click(autocomplete)
+  fireEvent.change(autocomplete, {
+    target: { value: categoryName }
+  })
+  fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
+  fireEvent.keyDown(autocomplete, { key: 'Enter' })
+}
+
 describe('AddAttachmentCategoryModal component', () => {
   mockAxiosClient
     .onGet(URLs.resources.resourcesCategories.getNames)
@@ -50,7 +59,7 @@ describe('AddAttachmentCategoryModal component', () => {
     expect(title).toBeInTheDocument()
   })
 
-  it('should render save button and click on it', () => {
+  it('should render save button and click on it if category was changed', async () => {
     const saveBtn = screen.getByText('common.save')
 
     expect(saveBtn).toBeInTheDocument()
@@ -60,16 +69,20 @@ describe('AddAttachmentCategoryModal component', () => {
     expect(updateAttachmentCategory).toHaveBeenCalled()
   })
 
+  it('should render disabled save button by default', () => {
+    const saveBtn = screen.getByText('common.save')
+
+    expect(saveBtn).toBeInTheDocument()
+
+    fireEvent.click(saveBtn)
+
+    expect(updateAttachmentCategory).not.toHaveBeenCalled()
+  })
+
   it('should change category', () => {
     const categoryDropbox = screen.getByRole('combobox')
 
-    fireEvent.click(categoryDropbox)
-    fireEvent.change(categoryDropbox, {
-      target: { value: categoriesNamesMock[1].name }
-    })
-    fireEvent.keyDown(categoryDropbox, { key: 'ArrowDown' })
-    fireEvent.keyDown(categoryDropbox, { key: 'Enter' })
-
+    changeCategory(categoryDropbox, categoriesNamesMock[1].name)
     expect(categoryDropbox.value).toBe(categoriesNamesMock[1].name)
   })
 })

--- a/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
+++ b/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
@@ -1,5 +1,9 @@
 import { screen, fireEvent } from '@testing-library/react'
-import { renderWithProviders, mockAxiosClient } from '~tests/test-utils'
+import {
+  renderWithProviders,
+  mockAxiosClient,
+  selectOption
+} from '~tests/test-utils'
 import { afterEach, beforeEach, describe, expect } from 'vitest'
 
 import AddAttachmentCategoryModal from '~/containers/my-resources/add-attachment-category-modal/AddAttachmentCategoryModal'
@@ -23,15 +27,6 @@ const attachmentMock = {
   updatedAt: '2023-11-05T16:22:35.063Z',
   description: 'Description',
   category: null
-}
-
-const changeCategory = (autocomplete, categoryName) => {
-  fireEvent.click(autocomplete)
-  fireEvent.change(autocomplete, {
-    target: { value: categoryName }
-  })
-  fireEvent.keyDown(autocomplete, { key: 'ArrowDown' })
-  fireEvent.keyDown(autocomplete, { key: 'Enter' })
 }
 
 describe('AddAttachmentCategoryModal component', () => {
@@ -64,6 +59,11 @@ describe('AddAttachmentCategoryModal component', () => {
 
     expect(saveBtn).toBeInTheDocument()
 
+    await selectOption(
+      screen.getByRole('combobox'),
+      categoriesNamesMock[0].name
+    )
+
     fireEvent.click(saveBtn)
 
     expect(updateAttachmentCategory).toHaveBeenCalled()
@@ -79,10 +79,10 @@ describe('AddAttachmentCategoryModal component', () => {
     expect(updateAttachmentCategory).not.toHaveBeenCalled()
   })
 
-  it('should change category', () => {
+  it('should change category', async () => {
     const categoryDropbox = screen.getByRole('combobox')
 
-    changeCategory(categoryDropbox, categoriesNamesMock[1].name)
+    await selectOption(categoryDropbox, categoriesNamesMock[1].name)
     expect(categoryDropbox.value).toBe(categoriesNamesMock[1].name)
   })
 })

--- a/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
+++ b/tests/unit/containers/my-resources/AddAttachmentCategoryModal.spec.jsx
@@ -39,7 +39,7 @@ describe('AddAttachmentCategoryModal component', () => {
       <AddAttachmentCategoryModal
         attachment={attachmentMock}
         closeModal={closeModalMock}
-        updateAttachmentCategory={updateAttachmentCategory}
+        onAttachmentUpdate={updateAttachmentCategory}
       />
     )
   })

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -19,7 +19,7 @@ describe('resourseService tests', () => {
     }
     mockAxiosClient
       .onPatch(
-        new RegExp(URLs.resources.lessons.patch.replace(':id', lessonId))
+        URLs.resources.lessons.patch.replace(':id', lessonId)
       )
       .reply(200)
 
@@ -79,7 +79,7 @@ describe('resourseService tests', () => {
     }
   
     mockAxiosClient
-      .onPatch(new RegExp(URLs.quizzes.patch.replace(':id', quizId)))
+      .onPatch(URLs.quizzes.patch.replace(':id', quizId))
       .reply(200)
   
     await ResourceService.editQuiz({ id: quizId, ...quizData })
@@ -171,7 +171,7 @@ describe('resourseService tests', () => {
     }
 
     mockAxiosClient
-      .onPatch(RegExp(URLs.resources.attachments.patch.replace(':id', attachmentId)))
+      .onPatch(URLs.resources.attachments.patch.replace(':id', attachmentId))
       .reply(200, mockAttachmentResponse)  
 
     const updatedAttachmentResponse = await ResourceService.updateAttachment({

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -156,32 +156,32 @@ describe('resourseService tests', () => {
     expect(response).toEqual(mockResponse)
   })
 
-   it('should edit an attachment', async () => {
-     const attachmentId = '6255bc080a75adf9223df444'
-     const attachment = {
-       description: 'Modified description',
-       category: '8655bc080a75adf9223df444'
-     }
-     const mockAttachmentResponse = {
-       ...attachment,
-       _id: attachmentId,
-       link: '1722535882408-test.pdf',
-       size: 15069,
-       resourceType: 'Attachment'
-     }
+  it('should edit an attachment', async () => {
+    const attachmentId = '6255bc080a75adf9223df444'
+    const attachment = {
+      description: 'Modified description',
+      category: '8655bc080a75adf9223df444'
+    }
+    const mockAttachmentResponse = {
+      ...attachment,
+      _id: attachmentId,
+      link: '1722535882408-test.pdf',
+      size: 15069,
+      resourceType: 'Attachment'
+    }
 
-     mockAxiosClient.onPatch().reply((config) => {
-       expect(config.url).toBe(`/attachments/${attachmentId}`)
+    mockAxiosClient.onPatch().reply((config) => {
+      expect(config.url).toBe(`/attachments/${attachmentId}`)
 
-       return [200, mockAttachmentResponse]
-     })
+      return [200, mockAttachmentResponse]
+    })
 
-     const updatedAttachmentResponse = await ResourceService.updateAttachment({
-       ...attachment,
-       id: attachmentId
-     })
-
-     expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
+    const updatedAttachmentResponse = await ResourceService.updateAttachment({
+      ...attachment,
+      id: attachmentId
+    })
+    
+    expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
    })
 
   it('should create a new question', async () => {
@@ -221,5 +221,52 @@ describe('resourseService tests', () => {
     )
 
     expect(createdQuestion).toEqual(mockResponse)
+    expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
+  })
+
+  it('should get attachements' , async () => {
+
+    const mockResponse = [
+      {
+        _id: '6255bc080a75adf9223df444',
+        link: '1722535882408-test.jpg',
+        resourceType: 'Attachment',
+        description: 'Attachment description',
+        category: '8655bc080a75adf9223df444'
+      }
+    ]
+
+    mockAxiosClient.onGet().reply((config) => {
+      expect(config.url).toBe('/attachments')
+
+      return [200, mockResponse]
+    })
+
+    const response = await ResourceService.getAttachments()
+
+    expect(response).toEqual(mockResponse)
+  })
+
+  it('should create an attachment', async () => {
+    const attachment = {
+      link: '1722535882408-test.jpg',
+      description: 'Attachment description',
+      category: '8655bc080a75adf9223df444'
+    }
+    const mockAttachmentResponse = {
+      ...attachment,
+      _id: '6255bc080a75adf9223df444',
+      resourceType: 'Attachment'
+    }
+
+    mockAxiosClient.onPost().reply((config) => {
+      expect(config.url).toBe('/attachments')
+
+      return [200, mockAttachmentResponse]
+    })
+
+    const response = await ResourceService.createAttachment(attachment)
+
+    expect(response).toEqual(mockAttachmentResponse)
   })
 })

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -223,7 +223,6 @@ describe('resourseService tests', () => {
   })
 
   it('should get attachements' , async () => {
-
     const mockResponse = [
       {
         _id: '6255bc080a75adf9223df444',

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -176,11 +176,10 @@ describe('resourseService tests', () => {
        return [200, mockAttachmentResponse]
      })
 
-     const updatedAttachmentResponse =
-       await ResourceService.updateAttachmentQuery({
-         ...attachment,
-         id: attachmentId
-       })
+     const updatedAttachmentResponse = await ResourceService.updateAttachment({
+       ...attachment,
+       id: attachmentId
+     })
 
      expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
    })

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -170,11 +170,9 @@ describe('resourseService tests', () => {
       resourceType: 'Attachment'
     }
 
-    mockAxiosClient.onPatch().reply((config) => {
-      expect(config.url).toBe(`/attachments/${attachmentId}`)
-
-      return [200, mockAttachmentResponse]
-    })
+    mockAxiosClient
+      .onPatch(RegExp(URLs.resources.attachments.patch.replace(':id', attachmentId)))
+      .reply(200, mockAttachmentResponse)  
 
     const updatedAttachmentResponse = await ResourceService.updateAttachment({
       ...attachment,
@@ -236,11 +234,7 @@ describe('resourseService tests', () => {
       }
     ]
 
-    mockAxiosClient.onGet().reply((config) => {
-      expect(config.url).toBe('/attachments')
-
-      return [200, mockResponse]
-    })
+    mockAxiosClient.onGet(URLs.resources.attachments.get).reply(200, mockResponse)  
 
     const response = await ResourceService.getAttachments()
 
@@ -259,11 +253,9 @@ describe('resourseService tests', () => {
       resourceType: 'Attachment'
     }
 
-    mockAxiosClient.onPost().reply((config) => {
-      expect(config.url).toBe('/attachments')
-
-      return [200, mockAttachmentResponse]
-    })
+    mockAxiosClient
+      .onPost(URLs.resources.attachments.post)
+      .reply(200, mockAttachmentResponse)
 
     const response = await ResourceService.createAttachment(attachment)
 

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -219,7 +219,6 @@ describe('resourseService tests', () => {
     )
 
     expect(createdQuestion).toEqual(mockResponse)
-    expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
   })
 
   it('should get attachements' , async () => {


### PR DESCRIPTION
### Replace useAxios with useQuery in the AttachmentsContainer

- Replace useAxios with useQuery for loading attachements
- Replace useAxios with useMutation for updating attachements

https://github.com/user-attachments/assets/c1199cbf-331a-4f54-8aac-a556664b3087


- Replace useAxios with useMutation for creating attachements

https://github.com/user-attachments/assets/a33ae3a3-4353-4b87-8e09-b9e86d37c4f2

- Renamed methods in ResourceService for attachments as there are only methods using baseQuery used around app
- Replaced onCreateAttachmentsError, onResponseError with usage of handleErrorAlert (custom useSnackbarAlert hook) 

- Add tests for resource-service
- Update tests for AddAttachmentCategoryModal