### PR TITLE
[Blocked] Replace useAxios with useQuery in the MyResourcesTable and props from all related components

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -81,7 +81,8 @@ export const URLs = {
       add: '/lessons',
       get: '/lessons',
       getById: '/lessons/:id',
-      delete: '/lessons',
+      deleteOld: '/lessons',
+      delete: '/lessons/:id',
       patch: '/lessons/:id'
     },
     attachments: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -87,7 +87,9 @@ export const URLs = {
     attachments: {
       get: '/attachments',
       patch: '/attachments/:id',
-      delete: '/attachments'
+      delete: '/attachments/:id',
+      deleteOld: '/attachments',
+      post: '/attachments'
     },
     questions: {
       get: '/questions',

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -103,7 +103,8 @@ export const URLs = {
       getNames: '/resources-categories/names',
       patch: '/resources-categories',
       post: '/resources-categories',
-      delete: 'resources-categories'
+      deleteOld: 'resources-categories',
+      delete: 'resources-categories/:id'
     }
   },
   messages: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -81,7 +81,6 @@ export const URLs = {
       add: '/lessons',
       get: '/lessons',
       getById: '/lessons/:id',
-      deleteOld: '/lessons',
       delete: '/lessons/:id',
       patch: '/lessons/:id'
     },
@@ -89,7 +88,6 @@ export const URLs = {
       get: '/attachments',
       patch: '/attachments/:id',
       delete: '/attachments/:id',
-      deleteOld: '/attachments',
       post: '/attachments'
     },
     questions: {
@@ -103,7 +101,6 @@ export const URLs = {
       getNames: '/resources-categories/names',
       patch: '/resources-categories',
       post: '/resources-categories',
-      deleteOld: 'resources-categories',
       delete: 'resources-categories/:id'
     }
   },
@@ -118,7 +115,6 @@ export const URLs = {
     getById: '/quizzes/:id',
     add: '/quizzes',
     patch: '/quizzes/:id',
-    deleteOld: '/quizzes',
     delete: '/quizzes/:id'
   },
   finishedQuizzes: {

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -117,7 +117,8 @@ export const URLs = {
     getById: '/quizzes/:id',
     add: '/quizzes',
     patch: '/quizzes/:id',
-    delete: '/quizzes'
+    deleteOld: '/quizzes',
+    delete: '/quizzes/:id'
   },
   finishedQuizzes: {
     add: '/finished-quizzes',

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -94,7 +94,7 @@ export const URLs = {
     },
     questions: {
       get: '/questions',
-      delete: '/questions',
+      delete: '/questions/:id',
       post: '/questions',
       patch: '/questions'
     },

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -140,25 +140,41 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
     [sectionData, resourceEventHandler]
   )
 
-  const deleteResource = (resource: CourseResource) => {
-    if (resource.isDuplicate) {
-      if (resource.resourceType === ResourcesTypesEnum.Lesson) {
-        void ResourceService.deleteLesson(resource._id)
-      }
+  const { mutate: handleDeleteResource } = useMutation<
+    void,
+    Error,
+    { resourceId: string; resource: CourseResource }
+  >({
+    mutationFn: async ({ resourceId, resource }) => {
+      switch (resource.resourceType) {
+        case ResourcesTypesEnum.Lesson: {
+          return ResourceService.deleteLesson(resourceId)
+        }
 
-      if (resource.resourceType === ResourcesTypesEnum.Quiz) {
-        void ResourceService.deleteQuiz(resource._id)
-      }
+        case ResourcesTypesEnum.Quiz: {
+          return ResourceService.deleteQuiz(resourceId)
+        }
 
-      if (resource.resourceType === ResourcesTypesEnum.Attachment) {
-        void ResourceService.deleteAttachment(resource._id)
+        case ResourcesTypesEnum.Attachment: {
+          return ResourceService.deleteAttachment(resourceId)
+        }
       }
+    },
+    onSuccess: (_data, variables) => {
+      const { resource } = variables
+
+      resourceEventHandler?.({
+        type: CourseResourceEventType.ResourceRemoved,
+        sectionId: sectionData.id,
+        resourceId: resource.id!
+      })
     }
-    resourceEventHandler?.({
-      type: CourseResourceEventType.ResourceRemoved,
-      sectionId: sectionData.id,
-      resourceId: resource.id!
-    })
+  })
+
+  const deleteResource = (resource: CourseResource) => {
+    if (resource.isDuplicate && resource._id) {
+      handleDeleteResource({ resourceId: resource._id, resource })
+    }
   }
 
   const { mutate: mutateAttachment } = useMutation({

--- a/src/containers/course-section/CourseSectionContainer.tsx
+++ b/src/containers/course-section/CourseSectionContainer.tsx
@@ -159,22 +159,19 @@ const CourseSectionContainer: React.FC<SectionProps> = ({
           return ResourceService.deleteAttachment(resourceId)
         }
       }
-    },
-    onSuccess: (_data, variables) => {
-      const { resource } = variables
-
-      resourceEventHandler?.({
-        type: CourseResourceEventType.ResourceRemoved,
-        sectionId: sectionData.id,
-        resourceId: resource.id!
-      })
     }
   })
 
   const deleteResource = (resource: CourseResource) => {
-    if (resource.isDuplicate && resource._id) {
+    if (resource.isDuplicate) {
       handleDeleteResource({ resourceId: resource._id, resource })
     }
+
+    resourceEventHandler?.({
+      type: CourseResourceEventType.ResourceRemoved,
+      sectionId: sectionData.id,
+      resourceId: resource.id!
+    })
   }
 
   const { mutate: mutateAttachment } = useMutation({

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -62,7 +62,7 @@ const QuizzesContainer = () => {
   }, [itemsPerPage, sort, searchTitle, page, selectedItems])
 
   const { mutate: handleDeleteQuiz } = useMutation({
-    mutationFn: ResourceService.deleteQuizQuery,
+    mutationFn: ResourceService.deleteQuiz,
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -28,6 +28,8 @@ import { type Quiz, ResourcesTabsEnum } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 import { getFullUrl } from '~/utils/get-full-url'
 import ChangeResourceConfirmModal from '../change-resource-confirm-modal/ChangeResourceConfirmModal'
+import useMutation from '~/hooks/use-mutation'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 const QuizzesContainer = () => {
   const navigate = useNavigate()
@@ -39,6 +41,7 @@ const QuizzesContainer = () => {
   const breakpoints = useBreakpoints()
   const [selectedItems, setSelectedItems] = useState<string[]>([])
   const { openModal } = useModalContext()
+  const { handleSuccessAlert, handleErrorAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -58,14 +61,15 @@ const QuizzesContainer = () => {
     })
   }, [itemsPerPage, sort, searchTitle, page, selectedItems])
 
-  const deleteQuiz = useCallback(
-    async (id?: string): Promise<AxiosResponse<unknown>> => {
-      const response = await ResourceService.deleteQuiz(id ?? '')
-      await queryClient.invalidateQueries({ queryKey: ['quizzes'] })
-      return response
-    },
-    [queryClient]
-  )
+  const { mutate: handleDeleteQuiz } = useMutation({
+    mutationFn: ResourceService.deleteQuizQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)
+      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when <N> issue will be merged
+    }
+    // queryKey: ['quizzes']
+  })
 
   const {
     data: quizzes,
@@ -112,14 +116,10 @@ const QuizzesContainer = () => {
 
   const props = {
     columns: columnsToShow,
-    data: {
-      response: quizzes ?? defaultResponses.itemsWithCount,
-      getData: getQuizzes
-    },
-    services: { deleteService: deleteQuiz },
+    resourceItems: quizzes ?? defaultResponses.itemsWithCount,
     itemsPerPage,
-    actions: { onEdit },
-    resource: ResourcesTabsEnum.Quizzes,
+    actions: { onEdit, onDelete: handleDeleteQuiz },
+    resourceType: ResourcesTabsEnum.Quizzes,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage }
   }

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useQueryClient } from '@tanstack/react-query'
 import Box from '@mui/material/Box'
-import { AxiosResponse } from 'axios'
 
 import { ResourceService } from '~/services/resource-service'
 import AddResourceWithInput from '~/containers/my-resources/add-resource-with-input/AddResourceWithInput'
@@ -11,7 +9,6 @@ import Loader from '~/components/loader/Loader'
 import useSort from '~/hooks/table/use-sort'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import useQuery from '~/hooks/use-query'
-import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 import usePagination from '~/hooks/table/use-pagination'
 import { authRoutes } from '~/router/constants/authRoutes'
 import { useModalContext } from '~/context/modal-context'
@@ -34,8 +31,6 @@ import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 const QuizzesContainer = () => {
   const navigate = useNavigate()
   const { page, handleChangePage } = usePagination()
-  const { handleErrorAlert } = useSnackbarAlert()
-  const queryClient = useQueryClient()
   const sortOptions = useSort({ initialSort })
   const searchTitle = useRef('')
   const breakpoints = useBreakpoints()
@@ -66,9 +61,8 @@ const QuizzesContainer = () => {
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)
-      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when 3183 issue will be merged
-    }
-    // queryKey: ['quizzes']
+    },
+    queryKey: ['quizzes']
   })
 
   const {

--- a/src/containers/my-quizzes/QuizzesContainer.tsx
+++ b/src/containers/my-quizzes/QuizzesContainer.tsx
@@ -66,7 +66,7 @@ const QuizzesContainer = () => {
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.quizzes.successDeletion`)
-      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when <N> issue will be merged
+      void queryClient.invalidateQueries({ queryKey: ['quizzes'] }) // TODO: remove and replace with queryKey, when 3183 issue will be merged
     }
     // queryKey: ['quizzes']
   })

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -193,12 +193,10 @@ const AttachmentsContainer = () => {
 
   const props = {
     columns: columnsToShow,
-    data: {
-      response
-    },
+    resourceItems: response,
     itemsPerPage,
     actions: { onEdit, onDelete: handleDeleteAttachment },
-    resource: ResourcesTabsEnum.Attachments,
+    resourceType: ResourcesTabsEnum.Attachments,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage },
     sx: styles.table

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -38,6 +38,8 @@ import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
+import useMutation from '~/hooks/use-mutation'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 const AttachmentsContainer = () => {
   const { t } = useTranslation()
@@ -49,6 +51,7 @@ const AttachmentsContainer = () => {
   const searchFileName = useRef<string>('')
   const [selectedItems, setSelectedItems] = useState<string[]>([])
   const formData = new FormData()
+  const { handleSuccessAlert, handleErrorAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -77,10 +80,15 @@ const AttachmentsContainer = () => {
     [itemsPerPage, page, sort, searchFileName, selectedItems]
   )
 
-  const deleteAttachment = useCallback(
-    (id?: string) => ResourceService.deleteAttachment(id ?? ''),
-    []
-  )
+  const { mutate: handleDeleteAttachment } = useMutation({
+    mutationFn: ResourceService.deleteAttachmentQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.attachments.successDeletion`)
+      void fetchAttachments() // TODO: remove and replace with queryKey, when 3110 issue will be merged
+    }
+    // queryKey: ['attachments']
+  })
 
   const updateAttachment = useCallback(
     (params?: UpdateAttachmentParams) =>
@@ -185,10 +193,11 @@ const AttachmentsContainer = () => {
 
   const props = {
     columns: columnsToShow,
-    data: { response, getData: fetchAttachments },
-    services: { deleteService: deleteAttachment },
+    data: {
+      response
+    },
     itemsPerPage,
-    actions: { onEdit },
+    actions: { onEdit, onDelete: handleDeleteAttachment },
     resource: ResourcesTabsEnum.Attachments,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage },

--- a/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
+++ b/src/containers/my-resources/attachments-container/AttachmentsContainer.tsx
@@ -81,7 +81,7 @@ const AttachmentsContainer = () => {
   )
 
   const { mutate: handleDeleteAttachment } = useMutation({
-    mutationFn: ResourceService.deleteAttachmentQuery,
+    mutationFn: ResourceService.deleteAttachment,
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.attachments.successDeletion`)

--- a/src/containers/my-resources/categories-container/CategoriesContainer.tsx
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.tsx
@@ -101,7 +101,7 @@ const CategoriesContainer = () => {
   )
 
   const { mutate: handleDeleteCategory } = useMutation({
-    mutationFn: ResourceService.deleteResourceCategoryQuery,
+    mutationFn: ResourceService.deleteResourceCategory,
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.categories.successDeletion`)

--- a/src/containers/my-resources/categories-container/CategoriesContainer.tsx
+++ b/src/containers/my-resources/categories-container/CategoriesContainer.tsx
@@ -41,6 +41,7 @@ import { styles } from '~/containers/my-resources/categories-container/Categorie
 import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 const CategoriesContainer = () => {
   const { t } = useTranslation()
@@ -52,6 +53,7 @@ const CategoriesContainer = () => {
   const dispatch = useAppDispatch()
   const [selectedItemId, setSelectedItemId] = useState<string>('')
   const [updateResourceCategory] = useUpdateResourceCategoryMutation()
+  const { handleSuccessAlert, handleErrorAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -98,10 +100,15 @@ const CategoriesContainer = () => {
     [page, itemsPerPage, sort, searchTitle]
   )
 
-  const deleteCategory = useCallback(
-    (id?: string) => ResourceService.deleteResourceCategory(id ?? ''),
-    []
-  )
+  const { mutate: handleDeleteCategory } = useMutation({
+    mutationFn: ResourceService.deleteResourceCategoryQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.categories.successDeletion`)
+      void fetchData() // TODO: remove and replace with queryKey, when 3185 issue will be merged
+    }
+    // queryKey: ['resource-categories']
+  })
 
   const { response, loading, fetchData } = useAxios<
     ItemsWithCount<Categories>,
@@ -170,14 +177,13 @@ const CategoriesContainer = () => {
   )
 
   const props = {
-    actions: { onEdit },
+    actions: { onEdit, onDelete: handleDeleteCategory },
     columns: columnsToShow,
-    data: { response, getData: onCategoryUpdate },
-    services: { deleteService: deleteCategory },
+    resourceItems: response,
     pagination: { page, onChange: handleChangePage },
     sort: sortOptions,
     itemsPerPage,
-    resource: ResourcesTabsEnum.Categories,
+    resourceType: ResourcesTabsEnum.Categories,
     sx: styles.table
   }
 

--- a/src/containers/my-resources/lessons-container/LessonsContainer.tsx
+++ b/src/containers/my-resources/lessons-container/LessonsContainer.tsx
@@ -83,7 +83,7 @@ const LessonsContainer = () => {
   )
 
   const { mutate: handleDeleteLesson } = useMutation({
-    mutationFn: ResourceService.deleteLessonQuery,
+    mutationFn: ResourceService.deleteLesson,
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.lessons.successDeletion`)

--- a/src/containers/my-resources/lessons-container/LessonsContainer.tsx
+++ b/src/containers/my-resources/lessons-container/LessonsContainer.tsx
@@ -36,6 +36,8 @@ import { openAlert } from '~/redux/features/snackbarSlice'
 import { getErrorKey } from '~/utils/get-error-key'
 import { useModalContext } from '~/context/modal-context'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
+import useMutation from '~/hooks/use-mutation'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 const LessonsContainer = () => {
   const dispatch = useAppDispatch()
@@ -46,6 +48,7 @@ const LessonsContainer = () => {
   const searchTitle = useRef<string>('')
   const breakpoints = useBreakpoints()
   const [selectedItems, setSelectedItems] = useState<string[]>([])
+  const { handleErrorAlert, handleSuccessAlert } = useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -79,10 +82,15 @@ const LessonsContainer = () => {
     [page, itemsPerPage, sort, searchTitle, selectedItems]
   )
 
-  const deleteLesson = useCallback(
-    (id?: string) => ResourceService.deleteLesson(id ?? ''),
-    []
-  )
+  const { mutate: handleDeleteLesson } = useMutation({
+    mutationFn: ResourceService.deleteLessonQuery,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.lessons.successDeletion`)
+      void fetchData() // TODO: remove and replace with queryKey, when 3182 issue will be merged
+    }
+    // queryKey: ['lessons']
+  })
 
   const { response, loading, fetchData } = useAxios<
     ItemsWithCount<Lesson>,
@@ -110,11 +118,10 @@ const LessonsContainer = () => {
 
   const props = {
     columns: columnsToShow,
-    data: { response, getData: fetchData },
-    services: { deleteService: deleteLesson },
+    resourceItems: response,
     itemsPerPage,
-    actions: { onEdit },
-    resource: ResourcesTabsEnum.Lessons,
+    actions: { onEdit, onDelete: handleDeleteLesson },
+    resourceType: ResourcesTabsEnum.Lessons,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage }
   }

--- a/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
+++ b/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
@@ -9,9 +9,9 @@ import EnhancedTable, {
 } from '~/components/enhanced-table/EnhancedTable'
 
 import {
-  TableItem,
-  ResourcesTableData,
-  TableRowAction,
+  type TableItem,
+  type TableRowAction,
+  type ItemsWithCount,
   ResourcesTabsEnum
 } from '~/types'
 import { roundedBorderTable } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
@@ -19,9 +19,9 @@ import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-mod
 
 interface MyResourcesTableInterface<T>
   extends Omit<EnhancedTableProps<T, undefined>, 'data'> {
-  resource: ResourcesTabsEnum
+  resourceType: ResourcesTabsEnum
   itemsPerPage: number
-  data: ResourcesTableData<T>
+  resourceItems: ItemsWithCount<T>
   actions: {
     onEdit: (id: string) => void
     onDuplicate?: (id: string) => void
@@ -31,9 +31,9 @@ interface MyResourcesTableInterface<T>
 }
 
 const MyResourcesTable = <T extends TableItem>({
-  resource,
+  resourceType,
   itemsPerPage,
-  data,
+  resourceItems,
   actions,
   pagination,
   ...props
@@ -43,24 +43,22 @@ const MyResourcesTable = <T extends TableItem>({
   const { openModal } = useModalContext()
 
   const { page, onChange } = pagination
-  const { response } = data
   const { onEdit, onDuplicate, onDelete } = actions
 
   const handleDelete = (id: string, isConfirmed: boolean) => {
-    console.log('id', id)
     if (isConfirmed) {
       onDelete(id)
     }
   }
 
   const handleConfirmDelete = (id: string) => {
-    const currentResource = response.items.find((item) => item._id === id)
+    const currentResource = resourceItems.items.find((item) => item._id === id)
 
     const handleConfirm = () => {
       openDialog({
         message: 'myResourcesPage.confirmDeletionMessage',
         sendConfirm: (isConfirmed: boolean) => handleDelete(id, isConfirmed),
-        title: `myResourcesPage.${resource}.confirmDeletionTitle`
+        title: `myResourcesPage.${resourceType}.confirmDeletionTitle`
       })
     }
 
@@ -78,7 +76,7 @@ const MyResourcesTable = <T extends TableItem>({
   const rowActions: TableRowAction[] = [
     {
       label:
-        resource === ResourcesTabsEnum.Categories
+        resourceType === ResourcesTabsEnum.Categories
           ? t('common.rename')
           : t('common.edit'),
       func: onEdit
@@ -96,8 +94,8 @@ const MyResourcesTable = <T extends TableItem>({
   return (
     <>
       <EnhancedTable<T>
-        data={{ items: response.items }}
-        emptyTableKey={`myResourcesPage.${resource}.emptyItems`}
+        data={{ items: resourceItems.items }}
+        emptyTableKey={`myResourcesPage.${resourceType}.emptyItems`}
         rowActions={rowActions}
         sx={roundedBorderTable}
         {...props}
@@ -105,7 +103,7 @@ const MyResourcesTable = <T extends TableItem>({
       <AppPagination
         onChange={onChange}
         page={page}
-        pageCount={Math.ceil(response.count / itemsPerPage)}
+        pageCount={Math.ceil(resourceItems.count / itemsPerPage)}
       />
     </>
   )

--- a/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
+++ b/src/containers/my-resources/my-resources-table/MyResourcesTable.tsx
@@ -1,9 +1,6 @@
 import { useTranslation } from 'react-i18next'
-import { AxiosResponse } from 'axios'
 import { PaginationProps } from '@mui/material'
 
-import { useAppDispatch } from '~/hooks/use-redux'
-import useAxios from '~/hooks/use-axios'
 import useConfirm from '~/hooks/use-confirm'
 import { useModalContext } from '~/context/modal-context'
 import AppPagination from '~/components/app-pagination/AppPagination'
@@ -11,9 +8,7 @@ import EnhancedTable, {
   EnhancedTableProps
 } from '~/components/enhanced-table/EnhancedTable'
 
-import { snackbarVariants } from '~/constants'
 import {
-  ErrorResponse,
   TableItem,
   ResourcesTableData,
   TableRowAction,
@@ -21,8 +16,6 @@ import {
 } from '~/types'
 import { roundedBorderTable } from '~/containers/my-cooperations/cooperations-container/CooperationContainer.styles'
 import ChangeResourceConfirmModal from '~/containers/change-resource-confirm-modal/ChangeResourceConfirmModal'
-import { openAlert } from '~/redux/features/snackbarSlice'
-import { getErrorKey } from '~/utils/get-error-key'
 
 interface MyResourcesTableInterface<T>
   extends Omit<EnhancedTableProps<T, undefined>, 'data'> {
@@ -32,8 +25,8 @@ interface MyResourcesTableInterface<T>
   actions: {
     onEdit: (id: string) => void
     onDuplicate?: (id: string) => void
+    onDelete: (id: string) => void
   }
-  services: { deleteService: (id?: string) => Promise<AxiosResponse> }
   pagination: PaginationProps
 }
 
@@ -42,60 +35,31 @@ const MyResourcesTable = <T extends TableItem>({
   itemsPerPage,
   data,
   actions,
-  services,
   pagination,
   ...props
 }: MyResourcesTableInterface<T>) => {
   const { t } = useTranslation()
-  const dispatch = useAppDispatch()
   const { openDialog } = useConfirm()
   const { openModal } = useModalContext()
 
   const { page, onChange } = pagination
-  const { response, getData } = data
-  const { onEdit, onDuplicate } = actions
+  const { response } = data
+  const { onEdit, onDuplicate, onDelete } = actions
 
-  const onDeleteError = (error?: ErrorResponse) => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.error,
-        message: getErrorKey(error)
-      })
-    )
-  }
-
-  const onDeleteResponse = () => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.success,
-        message: `myResourcesPage.${resource}.successDeletion`
-      })
-    )
-  }
-
-  const { error, fetchData: deleteItem } = useAxios({
-    service: services.deleteService,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponseError: onDeleteError,
-    onResponse: onDeleteResponse
-  })
-
-  const handleDelete = async (id: string, isConfirmed: boolean) => {
+  const handleDelete = (id: string, isConfirmed: boolean) => {
+    console.log('id', id)
     if (isConfirmed) {
-      await deleteItem(id)
-      if (!error) await getData()
+      onDelete(id)
     }
   }
 
-  const onDelete = (id: string) => {
+  const handleConfirmDelete = (id: string) => {
     const currentResource = response.items.find((item) => item._id === id)
 
     const handleConfirm = () => {
       openDialog({
         message: 'myResourcesPage.confirmDeletionMessage',
-        sendConfirm: (isConfirmed: boolean) =>
-          void handleDelete(id, isConfirmed),
+        sendConfirm: (isConfirmed: boolean) => handleDelete(id, isConfirmed),
         title: `myResourcesPage.${resource}.confirmDeletionTitle`
       })
     }
@@ -121,7 +85,7 @@ const MyResourcesTable = <T extends TableItem>({
     },
     {
       label: t('common.delete'),
-      func: onDelete
+      func: handleConfirmDelete
     },
     onDuplicate && {
       label: t('common.duplicate'),

--- a/src/containers/my-resources/questions-container/QuestionsContainer.tsx
+++ b/src/containers/my-resources/questions-container/QuestionsContainer.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useQueryClient } from '@tanstack/react-query'
 import Box from '@mui/material/Box'
-import type { AxiosResponse } from 'axios'
 
 import { ResourceService } from '~/services/resource-service'
 import AddResourceWithInput from '~/containers/my-resources/add-resource-with-input/AddResourceWithInput'
@@ -24,19 +22,19 @@ import {
   removeColumnRules,
   DuplicateQuestionErrors
 } from '~/containers/my-resources/questions-container/QuestionsContainer.constants'
-import { ResourcesTabsEnum, type Question } from '~/types'
 import { getFullUrl } from '~/utils/get-full-url'
+import { ResourcesTabsEnum, type Question } from '~/types'
 import { adjustColumns, getScreenBasedLimit } from '~/utils/helper-functions'
 
 const QuestionsContainer: React.FC = () => {
   const sortOptions = useSort({ initialSort })
   const searchTitle = useRef('')
   const breakpoints = useBreakpoints()
-  const queryClient = useQueryClient()
-  const { handleAlert, handleErrorAlert } = useSnackbarAlert()
   const navigate = useNavigate()
   const { page, handleChangePage } = usePagination()
   const [selectedItems, setSelectedItems] = useState<string[]>([])
+  const { handleAlert, handleErrorAlert, handleSuccessAlert } =
+    useSnackbarAlert()
 
   const { sort } = sortOptions
   const itemsPerPage = getScreenBasedLimit(breakpoints, itemsLoadLimit)
@@ -69,14 +67,15 @@ const QuestionsContainer: React.FC = () => {
     }
   })
 
-  const deleteQuestion = useCallback(
-    async (id?: string): Promise<AxiosResponse<unknown>> => {
-      const response = await ResourceService.deleteQuestion(id ?? '')
-      await queryClient.invalidateQueries({ queryKey: ['questions'] })
-      return response
-    },
-    [queryClient]
-  )
+  const { mutate: handleDeleteQuestion } = useMutation({
+    mutationFn: ResourceService.deleteQuestion,
+    onError: handleErrorAlert,
+    onSuccess: () => {
+      handleSuccessAlert(`myResourcesPage.questions.successDeletion`)
+      void refetchQuestions() // TODO: remove and replace with queryKey, when 3184 issue will be merged
+    }
+    // queryKey: ['questions']
+  })
 
   const editQuestion = (id: string) => {
     navigate(
@@ -134,19 +133,14 @@ const QuestionsContainer: React.FC = () => {
 
   const props = {
     columns: columnsToShow,
-    data: {
-      response: questions ?? defaultResponses.itemsWithCount,
-      getData: getQuestions
-    },
-    services: {
-      deleteService: deleteQuestion
-    },
+    resourceItems: questions ?? defaultResponses.itemsWithCount,
     itemsPerPage,
     actions: {
       onEdit: editQuestion,
-      onDuplicate: duplicateItem
+      onDuplicate: duplicateItem,
+      onDelete: handleDeleteQuestion
     },
-    resource: ResourcesTabsEnum.Questions,
+    resourceType: ResourcesTabsEnum.Questions,
     sort: sortOptions,
     pagination: { page, onChange: handleChangePage }
   }

--- a/src/containers/my-resources/questions-container/QuestionsContainer.tsx
+++ b/src/containers/my-resources/questions-container/QuestionsContainer.tsx
@@ -72,9 +72,8 @@ const QuestionsContainer: React.FC = () => {
     onError: handleErrorAlert,
     onSuccess: () => {
       handleSuccessAlert(`myResourcesPage.questions.successDeletion`)
-      void refetchQuestions() // TODO: remove and replace with queryKey, when 3184 issue will be merged
-    }
-    // queryKey: ['questions']
+    },
+    queryKey: ['questions']
   })
 
   const editQuestion = (id: string) => {

--- a/src/hooks/use-snackbar-alert.tsx
+++ b/src/hooks/use-snackbar-alert.tsx
@@ -46,7 +46,18 @@ const useSnackbarAlert = () => {
     },
     [handleAlert]
   )
-  return { handleAlert, handleErrorAlert }
+
+  const handleSuccessAlert = useCallback(
+    (message: string) => {
+      handleAlert({
+        message,
+        severity: snackbarVariants.success
+      })
+    },
+    [handleAlert]
+  )
+
+  return { handleAlert, handleErrorAlert, handleSuccessAlert }
 }
 
 export default useSnackbarAlert

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -55,11 +55,7 @@ export const ResourceService = {
       })
     })
   },
-  deleteLesson: async (id: string): Promise<AxiosResponse<Lesson>> =>
-    await axiosClient.delete(
-      createUrlPath(URLs.resources.lessons.deleteOld, id)
-    ),
-  deleteLessonQuery: (id: string) => {
+  deleteLesson: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({
@@ -126,9 +122,7 @@ export const ResourceService = {
       data: quizData
     })
   },
-  deleteQuiz: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(createUrlPath(URLs.quizzes.deleteOld, id)),
-  deleteQuizQuery: (id: string) => {
+  deleteQuiz: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({
@@ -198,12 +192,7 @@ export const ResourceService = {
       headers: { 'Content-Type': 'multipart/form-data' }
     })
   },
-  deleteAttachment: async (id: string): Promise<AxiosResponse> => {
-    return await axiosClient.delete(
-      createUrlPath(URLs.resources.attachments.deleteOld, id)
-    )
-  },
-  deleteAttachmentQuery: (id: string) => {
+  deleteAttachment: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({
@@ -273,11 +262,7 @@ export const ResourceService = {
       data: params
     })
   },
-  deleteResourceCategory: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(
-      createUrlPath(URLs.resources.resourcesCategories.deleteOld, id)
-    ),
-  deleteResourceCategoryQuery: (id: string) => {
+  deleteResourceCategory: (id: string) => {
     return baseService.request<void>({
       method: 'DELETE',
       url: getFullUrl({

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -127,7 +127,16 @@ export const ResourceService = {
     })
   },
   deleteQuiz: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(createUrlPath(URLs.quizzes.delete, id)),
+    await axiosClient.delete(createUrlPath(URLs.quizzes.deleteOld, id)),
+  deleteQuizQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.quizzes.delete,
+        parameters: { id }
+      })
+    })
+  },
   addFinishedQuiz: async (data: CreateFinishedQuizParams) => {
     return baseService.request<FinishedQuiz>({
       method: 'POST',

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -243,10 +243,15 @@ export const ResourceService = {
       createUrlPath(URLs.resources.questions.patch, params?.id),
       params
     ),
-  deleteQuestion: async (id: string): Promise<AxiosResponse> =>
-    await axiosClient.delete(
-      createUrlPath(URLs.resources.questions.delete, id)
-    ),
+  deleteQuestion: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.resources.questions.delete,
+        parameters: { id }
+      })
+    })
+  },
   getResourcesCategories: (
     params?: GetResourcesCategoriesParams
   ): Promise<AxiosResponse<ItemsWithCount<Categories>>> => {

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -56,7 +56,18 @@ export const ResourceService = {
     })
   },
   deleteLesson: async (id: string): Promise<AxiosResponse<Lesson>> =>
-    await axiosClient.delete(createUrlPath(URLs.resources.lessons.delete, id)),
+    await axiosClient.delete(
+      createUrlPath(URLs.resources.lessons.deleteOld, id)
+    ),
+  deleteLessonQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.resources.lessons.delete,
+        parameters: { id }
+      })
+    })
+  },
   addLesson: async (data: LessonData) => {
     return baseService.request<Lesson & { category: string | null }>({
       method: 'POST',

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -173,14 +173,23 @@ export const ResourceService = {
       data: attachmentData
     })
   },
-  deleteAttachment: async (id: string): Promise<AxiosResponse> => {
-    return await axiosClient.delete(
-      createUrlPath(URLs.resources.attachments.delete, id)
-    )
-  },
   createAttachments: (data?: FormData): Promise<AxiosResponse> => {
     return axiosClient.post(URLs.attachments.post, data, {
       headers: { 'Content-Type': 'multipart/form-data' }
+    })
+  },
+  deleteAttachment: async (id: string): Promise<AxiosResponse> => {
+    return await axiosClient.delete(
+      createUrlPath(URLs.resources.attachments.deleteOld, id)
+    )
+  },
+  deleteAttachmentQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.resources.attachments.delete,
+        parameters: { id }
+      })
     })
   },
   getQuestions: (

--- a/src/services/resource-service.ts
+++ b/src/services/resource-service.ts
@@ -270,8 +270,17 @@ export const ResourceService = {
   },
   deleteResourceCategory: async (id: string): Promise<AxiosResponse> =>
     await axiosClient.delete(
-      createUrlPath(URLs.resources.resourcesCategories.delete, id)
-    )
+      createUrlPath(URLs.resources.resourcesCategories.deleteOld, id)
+    ),
+  deleteResourceCategoryQuery: (id: string) => {
+    return baseService.request<void>({
+      method: 'DELETE',
+      url: getFullUrl({
+        pathname: URLs.resources.resourcesCategories.delete,
+        parameters: { id }
+      })
+    })
+  }
 }
 
 export const resourceService = appApi.injectEndpoints({

--- a/src/types/my-resources/myResources.index.ts
+++ b/src/types/my-resources/myResources.index.ts
@@ -1,3 +1,2 @@
 export * from '~/types/my-resources/interfaces/myResources.interface'
-export * from '~/types/my-resources/types/myResources.types'
 export * from '~/types/my-resources/enum/myResources.enum'

--- a/src/types/my-resources/types/myResources.types.ts
+++ b/src/types/my-resources/types/myResources.types.ts
@@ -1,5 +1,0 @@
-import { ItemsWithCount } from '~/types'
-
-export type ResourcesTableData<T> = {
-  response: ItemsWithCount<T>
-}

--- a/src/types/my-resources/types/myResources.types.ts
+++ b/src/types/my-resources/types/myResources.types.ts
@@ -1,8 +1,5 @@
-import { ItemsWithCount, GetResourcesParams } from '~/types'
+import { ItemsWithCount } from '~/types'
 
 export type ResourcesTableData<T> = {
   response: ItemsWithCount<T>
-  getData: (
-    params?: GetResourcesParams
-  ) => Promise<void> | void | Promise<ItemsWithCount<T>>
 }

--- a/tests/unit/containers/my-resources/MyResourcesTable.spec.jsx
+++ b/tests/unit/containers/my-resources/MyResourcesTable.spec.jsx
@@ -46,17 +46,14 @@ const responseItemsMock = Array(10)
   }))
 
 const props = {
-  resource: 'lessons',
+  resourceType: 'lessons',
   pagination: {
     page: 1,
     onChange: vi.fn()
   },
-  data: {
-    response: {
-      items: responseItemsMock,
-      count: 10
-    },
-    getData: vi.fn()
+  resourceItems: {
+    items: responseItemsMock,
+    count: 10
   },
   actions: {
     onEdit: vi.fn(),

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -30,6 +30,20 @@ describe('resourseService tests', () => {
     )
   })
 
+  it('should delete a lesson', async () => {
+    const lessonId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.resources.lessons.delete.replace(':id', lessonId))
+      .reply(200)
+
+    await ResourceService.deleteLesson(lessonId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.lessons.delete.replace(':id', lessonId)
+    )
+  })
+
   it('should fetch a quiz by ID', async () => {
     const quizId = '6641388f36ebdb0432a3a2e5'
     const mockQuizData = {
@@ -124,6 +138,20 @@ describe('resourseService tests', () => {
   
     expect(createdQuiz).toEqual(mockResponse)
   })
+
+  it('should delete a quiz', async () => {
+    const quizId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.quizzes.delete.replace(':id', quizId))
+      .reply(200)
+
+    await ResourceService.deleteQuiz(quizId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.quizzes.delete.replace(':id', quizId)
+    )
+  })
   
   it('should get resource categories names', async () => {
     const mockResponse = [
@@ -156,34 +184,48 @@ describe('resourseService tests', () => {
     expect(response).toEqual(mockResponse)
   })
 
-   it('should edit an attachment', async () => {
-     const attachmentId = '6255bc080a75adf9223df444'
-     const attachment = {
-       description: 'Modified description',
-       category: '8655bc080a75adf9223df444'
-     }
-     const mockAttachmentResponse = {
-       ...attachment,
-       _id: attachmentId,
-       link: '1722535882408-test.pdf',
-       size: 15069,
-       resourceType: 'Attachment'
-     }
+  it('should delete a resource category', async () => {
+    const resourceCategoryId = '6255bc080a75adf9223df444'
 
-     mockAxiosClient.onPatch().reply((config) => {
-       expect(config.url).toBe(`/attachments/${attachmentId}`)
+    mockAxiosClient
+      .onDelete(URLs.resources.resourcesCategories.delete.replace(':id', resourceCategoryId))
+      .reply(200)
 
-       return [200, mockAttachmentResponse]
-     })
+    await ResourceService.deleteResourceCategory(resourceCategoryId)
 
-     const updatedAttachmentResponse =
-       await ResourceService.updateAttachmentQuery({
-         ...attachment,
-         id: attachmentId
-       })
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.resourcesCategories.delete.replace(':id', resourceCategoryId)
+    )
+  })
 
-     expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
-   })
+  it('should edit an attachment', async () => {
+    const attachmentId = '6255bc080a75adf9223df444'
+    const attachment = {
+      description: 'Modified description',
+      category: '8655bc080a75adf9223df444'
+    }
+    const mockAttachmentResponse = {
+      ...attachment,
+      _id: attachmentId,
+      link: '1722535882408-test.pdf',
+      size: 15069,
+      resourceType: 'Attachment'
+    }
+
+    mockAxiosClient.onPatch().reply((config) => {
+      expect(config.url).toBe(`/attachments/${attachmentId}`)
+
+      return [200, mockAttachmentResponse]
+    })
+
+    const updatedAttachmentResponse =
+      await ResourceService.updateAttachmentQuery({
+        ...attachment,
+        id: attachmentId
+      })
+
+    expect(updatedAttachmentResponse).toEqual(mockAttachmentResponse)
+  })
 
   it('should create a new question', async () => {
     const newQuestionData = {
@@ -235,6 +277,20 @@ describe('resourseService tests', () => {
 
     expect(mockAxiosClient.history.delete[0].url).toBe(
       URLs.resources.attachments.delete.replace(':id', attachmentId)
+    )
+  })
+
+  it('should delete a question', async () => {
+    const questionId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.resources.questions.delete.replace(':id', questionId))
+      .reply(200)
+
+    await ResourceService.deleteQuestion(questionId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.questions.delete.replace(':id', questionId)
     )
   })
 })

--- a/tests/unit/services/resource-service.spec.jsx
+++ b/tests/unit/services/resource-service.spec.jsx
@@ -223,4 +223,18 @@ describe('resourseService tests', () => {
 
     expect(createdQuestion).toEqual(mockResponse)
   })
+
+  it('should delete an attachment', async () => {
+    const attachmentId = '6255bc080a75adf9223df444'
+
+    mockAxiosClient
+      .onDelete(URLs.resources.attachments.delete.replace(':id', attachmentId))
+      .reply(200)
+
+    await ResourceService.deleteAttachment(attachmentId)
+
+    expect(mockAxiosClient.history.delete[0].url).toBe(
+      URLs.resources.attachments.delete.replace(':id', attachmentId)
+    )
+  })
 })


### PR DESCRIPTION
## 🛑 Blocked by containers useAxios --> useQuery  PR's

- Refactor MyResourcesTable component props
- Replace delete methods passed as props to MyResourcesTable with useMutation delete mutation
- Repalce delete<name>Query to delete<name> in resource-service. 
- Ensure that replaced delete<name> work correctly in other components that use methods
- Fix tests

// TODO: add previews
//TODO: add tests for alert (?)