### PR TITLE
Update Cooperation Closing Banners Design

### DIFF
--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.styles.ts
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.styles.ts
@@ -1,15 +1,8 @@
-import { TypographyVariantEnum } from '~/types'
-import palette from '~/styles/app-theme/app.pallete'
-
 export const styles = {
   boldText: {
     fontWeight: 500
   },
   response: {
     paddingTop: '10px'
-  },
-  secondaryText: {
-    typography: TypographyVariantEnum.Body2,
-    color: palette.basic.bismark
   }
 }

--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
@@ -66,7 +66,7 @@ const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
                 {user}:
               </Typography>
               <br />
-              <Typography sx={styles.secondaryText}>{message}</Typography>
+              <Typography>{message}</Typography>
             </Box>
           )}
         </>

--- a/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.styles.ts
+++ b/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.styles.ts
@@ -6,7 +6,7 @@ export const styles = {
   container: {
     display: 'flex',
     flexDirection: 'column',
-    rowGap: '20px',
+    rowGap: '16px',
     padding: '24px',
     borderTop: `4px solid ${palette.basic.mediumRed}`,
     borderRadius: '5px',

--- a/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.styles.ts
+++ b/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.styles.ts
@@ -8,9 +8,11 @@ export const styles = {
     flexDirection: 'column',
     rowGap: '20px',
     padding: '24px',
-    border: `1px solid ${palette.basic.pinkishRed}`,
+    borderTop: `4px solid ${palette.basic.mediumRed}`,
     borderRadius: '5px',
-    backgroundColor: palette.basic.softGray
+    backgroundColor: palette.basic.softWhite,
+    boxShadow:
+      '0px 8px 16px rgba(0, 0, 0, 0.1), 0px 0px 6px rgba(0, 0, 0, 0.08)'
   },
   header: {
     display: 'flex',
@@ -18,8 +20,12 @@ export const styles = {
     columnGap: '8px',
     color: palette.basic.mediumRed
   },
+  headerText: {
+    fontWeight: 'medium',
+    fontSize: '18px'
+  },
   description: {
-    color: palette.basic.darkGray,
+    color: palette.basic.lightBlue,
     marginTop: '4px'
   },
   mainContentWrapper: {

--- a/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-action-banner/CooperationActionBanner.tsx
@@ -24,7 +24,7 @@ const CooperationActionBanner: React.FC<Properties> = ({
         <Box>
           <Box sx={styles.header}>
             {icon}
-            <Typography>{title}</Typography>
+            <Typography sx={styles.headerText}>{title}</Typography>
           </Box>
           <Typography sx={styles.description}>{description}</Typography>
         </Box>

--- a/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.styles.ts
+++ b/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.styles.ts
@@ -13,7 +13,7 @@ export const styles = {
     mt: '10px'
   },
   divider: {
-    marginBottom: '16px'
+    mb: '16px'
   },
   inputField: {
     flex: 1

--- a/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.styles.ts
+++ b/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.styles.ts
@@ -12,10 +12,17 @@ export const styles = {
     height: '50px',
     mt: '10px'
   },
+  divider: {
+    marginBottom: '16px'
+  },
   inputField: {
     flex: 1
   },
   textGray: {
-    color: palette.basic.darkGray
+    color: palette.basic.lightBlue
+  },
+  textMediumGray: {
+    color: palette.basic.lightBlue,
+    fontWeight: 'medium'
   }
 } satisfies Record<string, SxProps>

--- a/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
+++ b/src/containers/my-cooperations/cooperation-action-input/CooperationActionInput.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
-import { Box, Typography } from '@mui/material'
+import { Box, Divider, Typography } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 import InputField from '~/design-system/components/input-field/InputField'
@@ -71,7 +71,8 @@ const CooperationActionInput: React.FC<CooperationActionInputProps> = ({
   if (isInputShown) {
     return (
       <Box sx={styles.inputBox}>
-        <Typography sx={styles.textGray}>{inputLabel}</Typography>
+        <Divider sx={styles.divider} />
+        <Typography sx={styles.textMediumGray}>{inputLabel}</Typography>
         <Box sx={styles.inputContainer}>
           <InputField
             error={hasErrors}
@@ -96,7 +97,7 @@ const CooperationActionInput: React.FC<CooperationActionInputProps> = ({
     isReasonSubmitted &&
     !hasErrors && (
       <Box>
-        <Typography sx={styles.textGray}>
+        <Typography sx={styles.textMediumGray}>
           {t('cooperationDetailsPage.submitMessage')}
         </Typography>
         <Typography sx={styles.textGray}>

--- a/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.styles.ts
+++ b/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.styles.ts
@@ -1,12 +1,5 @@
-import { TypographyVariantEnum } from '~/types'
-import palette from '~/styles/app-theme/app.pallete'
-
 export const styles = {
   boldText: {
     fontWeight: 500
-  },
-  secondaryText: {
-    typography: TypographyVariantEnum.Body2,
-    color: palette.basic.bismark
   }
 }

--- a/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
@@ -48,7 +48,7 @@ const CooperationClosureDeclinedBanner: React.FC<
             i18nKey='cooperationDetailsPage.cooperationCloseDeclinedMessage'
             values={{ user: user }}
           />
-          <Typography sx={styles.secondaryText}>{message}</Typography>
+          <Typography>{message}</Typography>
         </>
       }
       icon={<ErrorOutlineRounded />}

--- a/src/styles/app-theme/app.pallete.ts
+++ b/src/styles/app-theme/app.pallete.ts
@@ -8,6 +8,7 @@ const palette = {
     black: '#000000',
     gray: '#B0BEC5',
     softGray: '#F1F2F3',
+    softWhite: '#F7F8F8',
     blue: '#0B8AF8',
     white: '#FFFFFF',
     grey: '#ECEFF1',


### PR DESCRIPTION
Updated `AcceptCooperationClosing` and `CooperationClosureDeclinedBanner` to match the new design
These banners now appear as follows:

After clicking `Close cooperation`:
<img width="1185" alt="Screenshot 2025-02-24 at 21 07 01" src="https://github.com/user-attachments/assets/a00766da-9f04-4f03-aeb2-66c051914a91" />

After clicking on `Decline` button:
<img width="1173" alt="Screenshot 2025-02-24 at 21 09 38" src="https://github.com/user-attachments/assets/e3ef218c-5487-4c9c-9cef-cfafbfb1975d" />

After submitting a reason for declining:
<img width="1175" alt="Screenshot 2025-02-24 at 21 10 30" src="https://github.com/user-attachments/assets/07531969-8706-492d-bd4b-b2d269323003" />

Opposite user's view:
<img width="1170" alt="Screenshot 2025-02-24 at 21 11 06" src="https://github.com/user-attachments/assets/ffd9ee0c-cd01-439c-81dd-8320cfe563ce" />

After clicking `Resend request`:
<img width="1175" alt="Screenshot 2025-02-24 at 21 11 32" src="https://github.com/user-attachments/assets/f02a86dc-44e7-418c-832f-d9e894068b53" />

After submitting a reason:
<img width="1171" alt="Screenshot 2025-02-24 at 21 11 57" src="https://github.com/user-attachments/assets/605f20f5-b35a-4a3e-87b4-1ef2a303f011" />

Declining one more time:
<img width="1177" alt="Screenshot 2025-02-24 at 21 14 34" src="https://github.com/user-attachments/assets/a94b7a1d-bd65-490d-8587-9c7016f94d6d" />

Previous design can be seen in the video [here](https://github.com/ita-social-projects/SpaceToStudy-Client/pull/3167)

----------------------------------------

- [x] updated cooperation closing process related banners design 