### PR TITLE
Fixed spacing in `CreateOrEditOffer` Container

### DIFF
--- a/src/containers/offer-page/OfferPage.styles.ts
+++ b/src/containers/offer-page/OfferPage.styles.ts
@@ -8,15 +8,15 @@ export const styles = {
     maxWidth: { md: '700px' },
     px: { sm: '16px', md: '32px' },
     color: 'primary.700',
-    gap: '12px',
+    gap: '25px',
     boxSizing: 'border-box',
     ...column
   },
   title: {
     display: 'flex',
     alignItems: 'center',
-    mb: '12px',
-    gap: '10px',
+    mt: '14px',
+    mb: '7px',
     typography: { xs: 'midTitle', sm: 'h5' },
     pt: { xs: '5px', sm: 0 },
     width: '100%',
@@ -27,15 +27,16 @@ export const styles = {
     pl: { sm: '32px' }
   },
   inputBlock: {
-    ...column,
-    gap: '12px'
+    ...column
   },
   icon: {
     width: { xs: '18px', sm: '22px' }
   },
   description: {
     color: 'primary.500',
-    typography: { xs: 'body2', sm: 'body1' }
+    typography: { xs: 'body2', sm: 'body1' },
+    mt: '14px',
+    mb: '7px'
   },
   currencyIcon: { width: '10px' },
   buttonBox: {
@@ -45,17 +46,34 @@ export const styles = {
     mt: { xs: '16px', sm: '24px' }
   },
   category: {
-    mb: '12px'
+    mt: '14px',
+    mb: '7px'
   },
   inputs: {
-    mb: '6px'
+    mt: '14px'
   },
-  faqError: { minHeight: '20px', typography: 'caption', color: 'error.500' },
+  faqError: {
+    minHeight: '20px',
+    typography: 'caption',
+    color: 'error.500'
+  },
   faqButton: {
     width: 'fit-content',
     alignSelf: 'start'
   },
-  faqInputsBlock: { display: 'flex', gap: '12px', alignItems: 'start' },
-  faqInputs: { flex: 1 },
-  submit: { minWidth: '166px' }
+  faqInputsBlock: {
+    display: 'flex',
+    gap: '12px',
+    alignItems: 'start',
+    mt: '14px',
+    mb: '10px'
+  },
+  faqInputs: {
+    ...column,
+    flex: 1,
+    gap: '12px'
+  },
+  submit: {
+    minWidth: '166px'
+  }
 }

--- a/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
+++ b/src/containers/offer-page/specialization-block/SpecializationBlock.tsx
@@ -74,7 +74,7 @@ const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
             textFieldProps={{
               label: t('offerPage.labels.category'),
               error: Boolean(errors.category),
-              helperText: errors.category ? t(errors.category) : ' ',
+              helperText: errors.category ? t(errors.category) : '',
               required: true
             }}
             value={data.category}
@@ -90,7 +90,7 @@ const SpecializationBlock = <T extends CreateOrUpdateOfferData>({
             sx={styles.inputs}
             textFieldProps={{
               error: Boolean(subjectError),
-              helperText: subjectError ? t(errors.subject) : ' ',
+              helperText: subjectError ? t(errors.subject) : '',
               label: t('offerPage.labels.subject'),
               required: true
             }}

--- a/src/containers/offer-page/teaching-block/TeachingBlock.tsx
+++ b/src/containers/offer-page/teaching-block/TeachingBlock.tsx
@@ -104,7 +104,7 @@ const TeachingBlock = <T extends CreateOrUpdateOfferData>({
             options={Object.values(LanguagesEnum)}
             textFieldProps={{
               error: Boolean(errors.languages),
-              helperText: t(errors.languages) || ' ',
+              helperText: t(errors.languages) || '',
               label: t('offerPage.labels.language')
             }}
             value={null}


### PR DESCRIPTION
Fixed spacing between blocks, input fields, titles of each input field.

![image](https://github.com/user-attachments/assets/7bd19b2d-1265-489a-8b2b-246577dc3313)
![image](https://github.com/user-attachments/assets/511732a0-6dea-406b-9f92-735c07ae066c)
![image](https://github.com/user-attachments/assets/e0607e9c-e81e-49e9-9315-e45bdc845d47)
![image](https://github.com/user-attachments/assets/a838e7a7-241f-4340-8da4-cb2f4f326035)

All changes match the design in [Figma](https://www.figma.com/design/liJZDYhUnDP15Pi9bipDcv/Space2Study-(Students)?node-id=4877-63949&t=0M3tnh7SviBEvn1v-0)

Issue: #3191 
