### PR TITLE
Fixed button's loader in `CreateOrEditOffer` container

### DIFF
--- a/src/containers/offer-page/create-or-edit-offer/CreateOrEditOffer.tsx
+++ b/src/containers/offer-page/create-or-edit-offer/CreateOrEditOffer.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, Dispatch, SetStateAction } from 'react'
+import { FC, useEffect, useState, Dispatch, SetStateAction } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
 import LeakAddSharpIcon from '@mui/icons-material/LeakAddSharp'
@@ -53,6 +53,8 @@ const CreateOrEditOffer: FC<CreateOrUpdateOfferProps> = ({
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { hash } = useLocation()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isDrafting, setIsDrafting] = useState(false)
 
   const offerAction = existingOffer
     ? OfferActionsEnum.Edit
@@ -128,6 +130,15 @@ const CreateOrEditOffer: FC<CreateOrUpdateOfferProps> = ({
   const changeStatus = () =>
     handleNonInputValueChange('status', StatusEnum.Draft)
 
+  const handleSubmitClick = () => {
+    setIsSubmitting(true)
+  }
+
+  const handleDraftClick = () => {
+    setIsDrafting(true)
+    changeStatus()
+  }
+
   const isMovableToDrafts =
     existingOffer?.status !== StatusEnum.Closed &&
     existingOffer?.status !== StatusEnum.Draft
@@ -164,7 +175,8 @@ const CreateOrEditOffer: FC<CreateOrUpdateOfferProps> = ({
       />
       <Box sx={styles.buttonBox}>
         <Button
-          loading={loading}
+          loading={loading && isSubmitting}
+          onClick={handleSubmitClick}
           size='lg'
           sx={styles.submit}
           type={ButtonTypeEnum.Submit}
@@ -173,7 +185,8 @@ const CreateOrEditOffer: FC<CreateOrUpdateOfferProps> = ({
         </Button>
         {isMovableToDrafts && (
           <Button
-            onClick={changeStatus}
+            loading={loading && isDrafting}
+            onClick={handleDraftClick}
             size='lg'
             type={ButtonTypeEnum.Submit}
             variant='tonal'


### PR DESCRIPTION
After clicking on `Add to draft` button loader works on this button and NOT on the `Create Offer` as it was before.

Loader after clicking on `Add to draft`:
![image](https://github.com/user-attachments/assets/4bc893a5-5b1e-46db-8513-4dafb402846b)

Loader after clicking on `Create Offer`:
![image](https://github.com/user-attachments/assets/7b617e08-0ab6-48a1-bc77-e03ed40cbd34)

Issue: #3140 