### PR TITLE
Add ability to visit closed cooperation

### DIFF
--- a/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
+++ b/src/containers/my-cooperations/cooperations-container/CooperationContainer.tsx
@@ -44,10 +44,7 @@ const CooperationContainer: React.FC<CooperationContainerProps> = ({
       ? openModal({
           component: <AcceptCooperationModal cooperation={item} />
         })
-      : (item.status === StatusEnum.Active ||
-          item.status === StatusEnum.RequestToClose ||
-          item.status === StatusEnum.NeedAction) &&
-        navigate(`./${item._id}`)
+      : navigate(`./${item._id}`)
   }
 
   const cooperationGrid = (


### PR DESCRIPTION
Previously, for cooperations with the status `closed`, there was no opportunity to view the details. Now, you can freely access the cooperation detail page.

https://github.com/user-attachments/assets/b289ef7a-7e37-4c90-98d9-7c781aeb843b

