### PR TITLE
Replaced useAxios with useMutation in useSteps hook

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -21,6 +21,7 @@ export const URLs = {
     get: '/users',
     getUserById: '/users/:id',
     update: '/users',
+    updateById: '/users/:id',
     delete: '/users/delete',
     deactivate: '/users/deactivate',
     activate: '/users/activate',

--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -21,7 +21,6 @@ export const URLs = {
     get: '/users',
     getUserById: '/users/:id',
     update: '/users',
-    updateById: '/users/:id',
     delete: '/users/delete',
     deactivate: '/users/deactivate',
     activate: '/users/activate',

--- a/src/hooks/use-steps.tsx
+++ b/src/hooks/use-steps.tsx
@@ -5,7 +5,12 @@ import { useModalContext } from '~/context/modal-context'
 import { useStepContext } from '~/context/step-context'
 import { userService } from '~/services/user-service'
 import { snackbarVariants } from '~/constants'
-import { type StepData, type UpdateUserParams } from '~/types'
+import {
+  type EditProfilePhoto,
+  type UpdatedPhoto,
+  type StepData,
+  type UpdateUserParams
+} from '~/types'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
@@ -74,8 +79,23 @@ const useSteps = ({ steps }: UseSteps) => {
     const { firstName, lastName, country, city, professionalSummary } =
       stepData.generalInfo.data
 
+    let formattedPhoto: EditProfilePhoto | undefined = undefined
+
+    if (stepData.photo && stepData.photo.length > 0) {
+      const firstPhoto = stepData.photo[0]
+
+      if (firstPhoto instanceof File) {
+        formattedPhoto = {
+          src: URL.createObjectURL(firstPhoto),
+          name: firstPhoto.name
+        }
+      } else {
+        formattedPhoto = firstPhoto as UpdatedPhoto
+      }
+    }
+
     const data: UpdateUserParams = {
-      photo: stepData.photo[0] ? stepData.photo[0] : '',
+      photo: formattedPhoto,
       firstName,
       lastName,
       address: {
@@ -101,7 +121,13 @@ const useSteps = ({ steps }: UseSteps) => {
     setActiveStep
   }
 
-  return { activeStep, stepErrors, isLastStep, stepOperation, loading }
+  return {
+    activeStep,
+    stepErrors,
+    isLastStep,
+    stepOperation,
+    loading
+  }
 }
 
 export default useSteps

--- a/src/hooks/use-steps.tsx
+++ b/src/hooks/use-steps.tsx
@@ -5,12 +5,7 @@ import { useModalContext } from '~/context/modal-context'
 import { useStepContext } from '~/context/step-context'
 import { userService } from '~/services/user-service'
 import { snackbarVariants } from '~/constants'
-import {
-  type EditProfilePhoto,
-  type UpdatedPhoto,
-  type StepData,
-  type UpdateUserParams
-} from '~/types'
+import { type StepData, type UpdateUserParams } from '~/types'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
@@ -79,23 +74,8 @@ const useSteps = ({ steps }: UseSteps) => {
     const { firstName, lastName, country, city, professionalSummary } =
       stepData.generalInfo.data
 
-    let formattedPhoto: EditProfilePhoto | undefined = undefined
-
-    if (stepData.photo && stepData.photo.length > 0) {
-      const firstPhoto = stepData.photo[0]
-
-      if (firstPhoto instanceof File) {
-        formattedPhoto = {
-          src: URL.createObjectURL(firstPhoto),
-          name: firstPhoto.name
-        }
-      } else {
-        formattedPhoto = firstPhoto as UpdatedPhoto
-      }
-    }
-
     const data: UpdateUserParams = {
-      photo: formattedPhoto,
+      photo: stepData.photo[0] ? stepData.photo[0] : '',
       firstName,
       lastName,
       address: {

--- a/src/hooks/use-steps.tsx
+++ b/src/hooks/use-steps.tsx
@@ -1,15 +1,13 @@
-import { useCallback, useState } from 'react'
-
-import useAxios from '~/hooks/use-axios'
+import { useState, useCallback } from 'react'
+import useMutation from '~/hooks/use-mutation'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
-
 import { useModalContext } from '~/context/modal-context'
 import { useStepContext } from '~/context/step-context'
 import { userService } from '~/services/user-service'
 import { snackbarVariants } from '~/constants'
-import { ErrorResponse, StepData, UpdateUserParams } from '~/types'
+import { type StepData, type UpdateUserParams } from '~/types'
 import { openAlert } from '~/redux/features/snackbarSlice'
-import { getErrorKey } from '~/utils/get-error-key'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 interface UseSteps {
   steps: string[]
@@ -21,20 +19,14 @@ const useSteps = ({ steps }: UseSteps) => {
   const { stepData } = useStepContext()
   const dispatch = useAppDispatch()
   const { userId } = useAppSelector((state) => state.appMain)
+  const { handleErrorAlert } = useSnackbarAlert()
 
-  const updateUser = useCallback(
-    (params?: UpdateUserParams) => userService.updateUser(userId, params!),
+  const handleUpdateUser = useCallback(
+    (params?: UpdateUserParams) => {
+      return userService.updateUser(userId, params!)
+    },
     [userId]
   )
-
-  const handleResponseError = (error?: ErrorResponse) => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.error,
-        message: getErrorKey(error)
-      })
-    )
-  }
 
   const handleResponse = () => {
     dispatch(
@@ -46,12 +38,10 @@ const useSteps = ({ steps }: UseSteps) => {
     closeModal()
   }
 
-  const { loading, fetchData } = useAxios({
-    service: updateUser,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponse: handleResponse,
-    onResponseError: handleResponseError
+  const { mutate: updateUser, isPending: loading } = useMutation({
+    mutationFn: handleUpdateUser,
+    onSuccess: handleResponse,
+    onError: handleErrorAlert
   })
 
   const stepDataValues = Object.values(stepData) as Array<
@@ -78,7 +68,7 @@ const useSteps = ({ steps }: UseSteps) => {
 
   const isLastStep = activeStep === steps.length - 1
 
-  const handleSubmit = async () => {
+  const handleSubmit = () => {
     const hasErrors = stepErrors.some((stepError) => Boolean(stepError))
 
     const { firstName, lastName, country, city, professionalSummary } =
@@ -100,7 +90,7 @@ const useSteps = ({ steps }: UseSteps) => {
     }
 
     if (!hasErrors) {
-      await fetchData(data)
+      updateUser(data)
     }
   }
 

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -23,6 +23,7 @@ import {
   UserRoleEnum
 } from '~/types'
 import { userService } from '~/services/user-service'
+import { ResponseError } from '~/exceptions'
 
 export interface EditProfileState {
   firstName: string
@@ -154,10 +155,12 @@ export const updateUser = createAsyncThunk(
   ) => {
     try {
       const response = await userService.updateUser(userId, params)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return response.data
     } catch (e) {
-      const error = e as AxiosError<ErrorResponse>
-      return rejectWithValue(error.response?.data.code)
+      if (e instanceof ResponseError) {
+        return rejectWithValue(e.code)
+      }
     }
   }
 )

--- a/src/services/user-service.tsx
+++ b/src/services/user-service.tsx
@@ -48,8 +48,7 @@ export const userService = {
     return baseService.request<null>({
       method: 'PATCH',
       url: getFullUrl({
-        pathname: URLs.users.updateById,
-        parameters: { id: userId }
+        pathname: `${URLs.users.update}/${userId}`
       }),
       data: params
     })

--- a/src/services/user-service.tsx
+++ b/src/services/user-service.tsx
@@ -4,7 +4,7 @@ import { URLs } from '~/constants/request'
 import { createUrlPath } from '~/utils/helper-functions'
 import { getFullUrl } from '~/utils/get-full-url'
 import { baseService } from './base-service'
-import {
+import type {
   GetUsersParams,
   UpdateUserParams,
   UserResponse,
@@ -27,7 +27,6 @@ export const userService = {
       createUrlPath(URLs.users.get, userId, { role: userRole, isEdit })
     )
   },
-
   getUserByIdWithBaseService: (
     id: string,
     userRole: UserRole,
@@ -45,12 +44,15 @@ export const userService = {
       })
     })
   },
-
-  updateUser: (
-    userId: string,
-    params: UpdateUserParams
-  ): Promise<AxiosResponse<null>> => {
-    return axiosClient.patch(createUrlPath(URLs.users.update, userId), params)
+  updateUser: (userId: string, params: UpdateUserParams) => {
+    return baseService.request<null>({
+      method: 'PATCH',
+      url: getFullUrl({
+        pathname: URLs.users.updateById,
+        parameters: { id: userId }
+      }),
+      data: params
+    })
   },
   deleteUser: (userId: string): Promise<AxiosResponse<null>> => {
     return axiosClient.delete(createUrlPath(URLs.users.get, userId))
@@ -58,7 +60,6 @@ export const userService = {
   deleteUsers: (userIds: string[]): Promise<AxiosResponse<null>> => {
     return axiosClient.post(URLs.users.delete, userIds)
   },
-
   deactivateUser: (userId: string) => {
     return baseService.request<null>({
       method: 'PATCH',
@@ -67,7 +68,6 @@ export const userService = {
       })
     })
   },
-
   activateUser: (userId: string) => {
     return baseService.request<null>({
       method: 'PATCH',
@@ -76,7 +76,6 @@ export const userService = {
       })
     })
   },
-
   toggleBookmark: (userId: string, offerId: string) => {
     return baseService.request<string[]>({
       method: 'PATCH',
@@ -86,7 +85,6 @@ export const userService = {
       })
     })
   },
-
   getBookmarkedOffers: async (
     userId: string,
     params?: GetOffersParams

--- a/src/services/user-service.tsx
+++ b/src/services/user-service.tsx
@@ -45,7 +45,7 @@ export const userService = {
     })
   },
   updateUser: (userId: string, params: UpdateUserParams) => {
-    return baseService.request<null>({
+    return baseService.request<void>({
       method: 'PATCH',
       url: getFullUrl({
         pathname: `${URLs.users.update}/${userId}`

--- a/tests/unit/redux/editProfileSlice.spec.js
+++ b/tests/unit/redux/editProfileSlice.spec.js
@@ -941,29 +941,55 @@ describe('editProfileSlice test', () => {
     const expectedState = createState({ loading: LoadingStatusEnum.Fulfilled })
 
     mockAxiosClient
-      .onPatch(createUrlPath(URLs.users.updateById, userId), params)
-      .reply(200)
+      .onPatch(createUrlPath(URLs.users.update, userId), params)
+      .reply(200, { firstName: 'new firstname' })
 
     await store.dispatch(updateUser({ userId, params }))
-    expect(store.getState().editProfile).toEqual(expectedState)
+
+    const actualState = store.getState().editProfile
+
+    expect(actualState).toEqual(expectedState)
+    expect(actualState.loading).toEqual(LoadingStatusEnum.Fulfilled)
+    expect(actualState.error).toBeNull()
   })
 
   it('updateUser should handle rejected state', async () => {
     const userId = '123'
     const params = { firstName: 'new firstname' }
-    const error = new Error('Failed to update user')
+    //const error = new Error('Failed to update user')
     const errorCode = 'USER_NOT_FOUND'
-    error.code = errorCode
+    //error.code = errorCode
+    // const expectedState = createState({
+    //   loading: LoadingStatusEnum.Rejected,
+    //   error: errorCode
+    // })
+
+    //const mockError = { code: 'USER_NOT_FOUND' }
+
+    const mockError = {
+      code: 'USER_NOT_FOUND',
+      message: 'User not found',
+      status: 404
+    }
+
+    mockAxiosClient
+      .onPatch(createUrlPath(URLs.users.update, userId), params)
+      .reply(404, mockError)
+
     const expectedState = createState({
       loading: LoadingStatusEnum.Rejected,
       error: errorCode
     })
 
-    mockAxiosClient
-      .onPatch(createUrlPath(URLs.users.updateById, userId), params)
-      .reply(404, error)
-
     await store.dispatch(updateUser({ userId, params }))
-    expect(store.getState().editProfile).toEqual(expectedState)
+
+    const actualState = store.getState().editProfile
+    console.log(actualState)
+
+    console.log('state:', store.getState())
+
+    expect(actualState).toEqual(expectedState)
+    expect(actualState.loading).toEqual(LoadingStatusEnum.Rejected)
+    //expect(actualState.error).toEqual(errorCode)
   })
 })

--- a/tests/unit/redux/editProfileSlice.spec.js
+++ b/tests/unit/redux/editProfileSlice.spec.js
@@ -941,7 +941,7 @@ describe('editProfileSlice test', () => {
     const expectedState = createState({ loading: LoadingStatusEnum.Fulfilled })
 
     mockAxiosClient
-      .onPatch(createUrlPath(URLs.users.update, userId), params)
+      .onPatch(createUrlPath(URLs.users.updateById, userId), params)
       .reply(200)
 
     await store.dispatch(updateUser({ userId, params }))
@@ -960,7 +960,7 @@ describe('editProfileSlice test', () => {
     })
 
     mockAxiosClient
-      .onPatch(createUrlPath(URLs.users.update, userId), params)
+      .onPatch(createUrlPath(URLs.users.updateById, userId), params)
       .reply(404, error)
 
     await store.dispatch(updateUser({ userId, params }))

--- a/tests/unit/redux/editProfileSlice.spec.js
+++ b/tests/unit/redux/editProfileSlice.spec.js
@@ -942,7 +942,7 @@ describe('editProfileSlice test', () => {
 
     mockAxiosClient
       .onPatch(createUrlPath(URLs.users.update, userId), params)
-      .reply(200, { firstName: 'new firstname' })
+      .reply(200)
 
     await store.dispatch(updateUser({ userId, params }))
 
@@ -956,40 +956,23 @@ describe('editProfileSlice test', () => {
   it('updateUser should handle rejected state', async () => {
     const userId = '123'
     const params = { firstName: 'new firstname' }
-    //const error = new Error('Failed to update user')
     const errorCode = 'USER_NOT_FOUND'
-    //error.code = errorCode
-    // const expectedState = createState({
-    //   loading: LoadingStatusEnum.Rejected,
-    //   error: errorCode
-    // })
-
-    //const mockError = { code: 'USER_NOT_FOUND' }
-
-    const mockError = {
-      code: 'USER_NOT_FOUND',
-      message: 'User not found',
-      status: 404
-    }
-
-    mockAxiosClient
-      .onPatch(createUrlPath(URLs.users.update, userId), params)
-      .reply(404, mockError)
 
     const expectedState = createState({
       loading: LoadingStatusEnum.Rejected,
       error: errorCode
     })
 
+    mockAxiosClient
+      .onPatch(createUrlPath(URLs.users.update, userId), params)
+      .reply(404, { code: errorCode, message: 'User has not been found' })
+
     await store.dispatch(updateUser({ userId, params }))
 
     const actualState = store.getState().editProfile
-    console.log(actualState)
-
-    console.log('state:', store.getState())
 
     expect(actualState).toEqual(expectedState)
     expect(actualState.loading).toEqual(LoadingStatusEnum.Rejected)
-    //expect(actualState.error).toEqual(errorCode)
+    expect(actualState.error).toEqual(errorCode)
   })
 })


### PR DESCRIPTION
- Replaced `useAxios` with `useMutation` for improved API request handling.
- Extracted error handling into `useSnackbarAlert` for better separation of concerns.
- Refactored `updateUser` service to simplify logic.
- Replaced `axiosClient.patch` with `baseService.request` for a more flexible and consistent API service structure.
- Improved readability and maintainability of the `useSteps` hook.
- Updated tests in `EditProfileSlice.spec.js` file.

Using the hook:
![image](https://github.com/user-attachments/assets/28d224c7-7148-4784-a00f-7e62dfa76ba7)
(Stepper after the first user registration)

Successfully created PATCH request:
![image](https://github.com/user-attachments/assets/64fdf252-25da-4655-b039-180713de09d0)

**Issue: #3237**