### PR TITLE
Replaced useAxios with useMutation in AcceptCooperationModal

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -32,6 +32,7 @@ export const URLs = {
   offers: {
     create: '/offers',
     update: '/offers',
+    updateById: '/offers/:id',
     get: '/categories/subjects/offers',
     getByCategoryAndSubjectId:
       '/categories/:categoryId/subjects/:subjectId/offers',

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -10,7 +10,6 @@ import SliderWithInput from '~/components/slider-with-input/SliderWithInput'
 import Button from '~scss-components/button/Button'
 import Loader from '~/components/loader/Loader'
 import useForm from '~/hooks/use-form'
-import useAxios from '~/hooks/use-axios'
 import useMutation from '~/hooks/use-mutation'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import useConfirm from '~/hooks/use-confirm'
@@ -61,7 +60,9 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
 
   const updateOffer = useCallback(
     () =>
-      OfferService.updateOffer(cooperation.offer._id, { enrolledUsers: [] }),
+      OfferService.updateOfferWithBaseService(cooperation.offer._id, {
+        enrolledUsers: []
+      }),
     [cooperation.offer._id]
   )
 
@@ -92,11 +93,10 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
       onError: onResponseError
     })
 
-  const { loading: updateLoading, fetchData: fetchUpdateOffer } = useAxios({
-    service: updateOffer,
-    fetchOnMount: false,
-    defaultResponse: null,
-    onResponseError
+  const { isPending: updateLoading, mutate: fetchUpdateOffer } = useMutation({
+    mutationFn: updateOffer,
+    queryKey: ['cooperations'],
+    onError: onResponseError
   })
 
   const handleAcceptCooperation = useCallback(async () => {
@@ -121,7 +121,7 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
     })
 
     if (confirmed) {
-      await fetchUpdateOffer()
+      fetchUpdateOffer()
       updateCooperation({ status: StatusEnum.Closed })
     }
   }, [checkConfirmation, fetchUpdateOffer, t, updateCooperation])

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -58,7 +58,7 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
     [cooperation._id]
   )
 
-  const updateOffer = useCallback(
+  const handleUpdateOffer = useCallback(
     () =>
       OfferService.updateOfferWithBaseService(cooperation.offer._id, {
         enrolledUsers: []
@@ -93,8 +93,8 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
       onError: onResponseError
     })
 
-  const { isPending: updateLoading, mutate: fetchUpdateOffer } = useMutation({
-    mutationFn: updateOffer,
+  const { isPending: updateLoading, mutate: updateOffer } = useMutation({
+    mutationFn: handleUpdateOffer,
     queryKey: ['cooperations'],
     onError: onResponseError
   })
@@ -121,10 +121,10 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
     })
 
     if (confirmed) {
-      fetchUpdateOffer()
+      updateOffer()
       updateCooperation({ status: StatusEnum.Closed })
     }
-  }, [checkConfirmation, fetchUpdateOffer, t, updateCooperation])
+  }, [checkConfirmation, updateOffer, t, updateCooperation])
 
   const handleResendCooperation = useCallback(
     async (data?: Record<'price', number>) => {

--- a/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.tsx
@@ -22,15 +22,12 @@ import {
   ButtonTypeEnum,
   ComponentEnum,
   type Cooperation,
-  type ErrorResponse,
   StatusEnum,
   type UpdateCooperationsParams
 } from '~/types'
 import { snackbarVariants } from '~/constants'
 import { styles } from '~/containers/my-cooperations/accept-cooperation-modal/AcceptCooperation.styles'
-import { useAppDispatch } from '~/hooks/use-redux'
-import { openAlert } from '~/redux/features/snackbarSlice'
-import { getErrorKey } from '~/utils/get-error-key'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 
 interface AcceptCooperationModalProps {
   cooperation: Cooperation
@@ -43,7 +40,7 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
   const { isDesktop } = useBreakpoints()
   const { closeModal } = useModalContext()
   const { checkConfirmation } = useConfirm()
-  const dispatch = useAppDispatch()
+  const { handleAlert, handleErrorAlert } = useSnackbarAlert()
   const [minPrice, maxPrice] = minMaxPrice(cooperation.offer.price, 0.25)
 
   const needAction = cooperation.user.role !== cooperation.needAction.role
@@ -67,22 +64,12 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
   )
 
   const onResponse = () => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.success,
-        message: 'cooperationsPage.acceptModal.successMessage'
-      })
-    )
-    closeModal()
-  }
+    handleAlert({
+      severity: snackbarVariants.success,
+      message: 'cooperationsPage.acceptModal.successMessage'
+    })
 
-  const onResponseError = (error?: ErrorResponse) => {
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.error,
-        message: getErrorKey(error)
-      })
-    )
+    closeModal()
   }
 
   const { isPending: isUpdateCooperationPending, mutate: updateCooperation } =
@@ -90,13 +77,13 @@ const AcceptCooperationModal: React.FC<AcceptCooperationModalProps> = ({
       mutationFn: handleUpdateCooperation,
       queryKey: ['cooperations'],
       onSuccess: onResponse,
-      onError: onResponseError
+      onError: handleErrorAlert
     })
 
   const { isPending: updateLoading, mutate: updateOffer } = useMutation({
     mutationFn: handleUpdateOffer,
     queryKey: ['cooperations'],
-    onError: onResponseError
+    onError: handleErrorAlert
   })
 
   const handleAcceptCooperation = useCallback(async () => {

--- a/src/services/offer-service.ts
+++ b/src/services/offer-service.ts
@@ -58,6 +58,20 @@ export const OfferService = {
   ): Promise<AxiosResponse> =>
     await axiosClient.patch(createUrlPath(URLs.offers.update, id), updateData),
 
+  updateOfferWithBaseService: async (
+    id: string,
+    updateData?: Partial<CreateOrUpdateOfferData>
+  ) => {
+    return baseService.request<void>({
+      method: 'PATCH',
+      data: updateData,
+      url: getFullUrl({
+        pathname: URLs.offers.updateById,
+        parameters: { id }
+      })
+    })
+  },
+
   getOffer: async (id: string): Promise<AxiosResponse<Offer>> =>
     await axiosClient.get(createUrlPath(URLs.offers.get, id)),
 

--- a/tests/unit/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.spec.jsx
+++ b/tests/unit/containers/my-cooperations/accept-cooperation-modal/AcceptCooperationModal.spec.jsx
@@ -28,7 +28,7 @@ describe('AcceptCooperationModal component ', () => {
       .reply(200)
 
     mockAxiosClient
-      .onPatch(`${URLs.offers.update}/${mockedCoop._id}`)
+      .onPatch(URLs.offers.updateById.replace(':id', mockedCoop._id))
       .reply(200, { updateData: null })
 
     renderWithProviders(


### PR DESCRIPTION
Replaced useAxios with useMutation in AcceptCooperationModal component, specifically in updateOffer function. Added new function updateOfferWithBaseService for updating offer in offer-service that will be removed after all useAxios occurrences are replaced.

https://github.com/user-attachments/assets/7666d2c7-0c8c-49df-95d3-7945fe3894cc

