### PR TITLE
Refactor filter change handler in CoursesFiltersDrawer

### DIFF
--- a/src/components/filter-input/FilterInput.tsx
+++ b/src/components/filter-input/FilterInput.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '~/design-system/components/icon-button/IconButton'
 import AppTextField from '~/components/app-text-field/AppTextField'
 
 interface FilterInputProps extends Omit<TextFieldProps, 'onChange'> {
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  onChange: (value: string) => void
   value?: string
 }
 
@@ -16,7 +16,7 @@ const FilterInput: FC<FilterInputProps> = ({ value, onChange, ...props }) => {
     const event = {
       target: { value: '' }
     } as React.ChangeEvent<HTMLInputElement>
-    onChange(event)
+    onChange(event.target.value)
   }
 
   const inputProps = {
@@ -36,7 +36,7 @@ const FilterInput: FC<FilterInputProps> = ({ value, onChange, ...props }) => {
   return (
     <AppTextField
       InputProps={inputProps}
-      onChange={onChange}
+      onChange={(event) => onChange(event.target.value)}
       size='small'
       value={value}
       {...props}

--- a/src/containers/bookmarked-offers/BookmarksToolbar.tsx
+++ b/src/containers/bookmarked-offers/BookmarksToolbar.tsx
@@ -36,8 +36,8 @@ const BookmarksToolbar = forwardRef<HTMLDivElement, BookmarksToolbarProps>(
     const { t } = useTranslation()
     const { isLaptopAndAbove } = useBreakpoints()
 
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      setTitle(event.target.value)
+    const handleInputChange = (value: string) => {
+      setTitle(value)
     }
 
     const handleInputSubmit = (e: FormEvent<HTMLFormElement>) => {

--- a/src/containers/chat/list-of-users-with-search/ListOfUsersWithSearch.tsx
+++ b/src/containers/chat/list-of-users-with-search/ListOfUsersWithSearch.tsx
@@ -32,8 +32,8 @@ const ListOfUsersWithSearch: FC<ListOfUsersWithSearchProps> = ({
   const { userId } = useAppSelector((state) => state.appMain)
   const { t } = useTranslation()
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSearch(event.target.value)
+  const handleInputChange = (value: string) => {
+    setSearch(value)
   }
 
   const filteredChats = filterChats(listOfChats, userId, search)

--- a/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
+++ b/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useCallback, SyntheticEvent, ChangeEvent } from 'react'
+import { FC, ReactNode, useCallback, SyntheticEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import FilterListIcon from '@mui/icons-material/FilterList'
@@ -81,12 +81,6 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
     onClose()
   }
 
-  const handleFilterChange =
-    <K extends keyof CourseFilters>(key: K) =>
-    (event: ChangeEvent<HTMLInputElement>) => {
-      updateFilterByKey(key)(event.target.value as CourseFilters[K])
-    }
-
   return (
     <AppDrawer anchor={PositionEnum.Left} onClose={onClose} open={isOpen}>
       <Box sx={styles.titleWithIcon}>
@@ -167,7 +161,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
         {t('myCoursesPage.coursesFilter.search')}:
       </Typography>
       <FilterInput
-        onChange={handleFilterChange('title')}
+        onChange={updateFilterByKey('title')}
         placeholder={t('common.search')}
         value={filters.title}
       />

--- a/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
+++ b/src/containers/my-courses/courses-filters-drawer/CoursesFiltersDrawer.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useCallback, SyntheticEvent } from 'react'
+import { FC, ReactNode, useCallback, SyntheticEvent, ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import FilterListIcon from '@mui/icons-material/FilterList'
@@ -80,6 +80,13 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
     updateFiltersInQuery(additionalParams)
     onClose()
   }
+
+  const handleFilterChange =
+    <K extends keyof CourseFilters>(key: K) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      updateFilterByKey(key)(event.target.value as CourseFilters[K])
+    }
+
   return (
     <AppDrawer anchor={PositionEnum.Left} onClose={onClose} open={isOpen}>
       <Box sx={styles.titleWithIcon}>
@@ -160,7 +167,7 @@ const CoursesFiltersDrawer: FC<CoursesFiltersDrawerProps> = ({
         {t('myCoursesPage.coursesFilter.search')}:
       </Typography>
       <FilterInput
-        onChange={updateFilterByKey('title')}
+        onChange={handleFilterChange('title')}
         placeholder={t('common.search')}
         value={filters.title}
       />

--- a/tests/unit/components/filter-input/FilterInput.spec.jsx
+++ b/tests/unit/components/filter-input/FilterInput.spec.jsx
@@ -15,24 +15,27 @@ describe('FilterInput', () => {
   })
 
   it('calls the onChange function when text is entered', () => {
-    const { getByRole } = render(<FilterInput onChange={handleChange} />)
+    const { getByRole } = render(
+      <FilterInput onChange={handleChange} value='' />
+    )
 
     const input = getByRole('textbox')
     fireEvent.change(input, { target: { value: 'test' } })
 
-    const [firstArgument] = handleChange.mock.lastCall
-
-    expect(firstArgument.target.value).toBe('test')
+    // Проверяем, что handleChange был вызван с строкой 'test', а не с объектом
+    const firstArgument = handleChange.mock.calls[0][0]
+    expect(firstArgument).toBe('test') // Ожидаем строку, а не объект события
   })
 
   it('clears the input when the clear button is clicked', () => {
-    const handleChange = vi.fn()
     const { getByTestId } = render(
       <FilterInput onChange={handleChange} value='test' />
     )
     const clearButton = getByTestId('clear-button')
     fireEvent.click(clearButton)
+
+    // Ожидаем, что handleChange был вызван с пустой строкой, а не объектом
     expect(handleChange).toHaveBeenCalledTimes(1)
-    expect(handleChange).toHaveBeenCalledWith({ target: { value: '' } })
+    expect(handleChange).toHaveBeenCalledWith('') // Ожидаем, что будет передана пустая строка
   })
 })

--- a/tests/unit/components/filter-input/FilterInput.spec.jsx
+++ b/tests/unit/components/filter-input/FilterInput.spec.jsx
@@ -27,6 +27,7 @@ describe('FilterInput', () => {
   })
 
   it('clears the input when the clear button is clicked', () => {
+    const handleChange = vi.fn()
     const { getByTestId } = render(
       <FilterInput onChange={handleChange} value='test' />
     )

--- a/tests/unit/components/filter-input/FilterInput.spec.jsx
+++ b/tests/unit/components/filter-input/FilterInput.spec.jsx
@@ -22,9 +22,8 @@ describe('FilterInput', () => {
     const input = getByRole('textbox')
     fireEvent.change(input, { target: { value: 'test' } })
 
-    // Проверяем, что handleChange был вызван с строкой 'test', а не с объектом
     const firstArgument = handleChange.mock.calls[0][0]
-    expect(firstArgument).toBe('test') // Ожидаем строку, а не объект события
+    expect(firstArgument).toBe('test')
   })
 
   it('clears the input when the clear button is clicked', () => {
@@ -34,8 +33,7 @@ describe('FilterInput', () => {
     const clearButton = getByTestId('clear-button')
     fireEvent.click(clearButton)
 
-    // Ожидаем, что handleChange был вызван с пустой строкой, а не объектом
     expect(handleChange).toHaveBeenCalledTimes(1)
-    expect(handleChange).toHaveBeenCalledWith('') // Ожидаем, что будет передана пустая строка
+    expect(handleChange).toHaveBeenCalledWith('')
   })
 })


### PR DESCRIPTION
The solution refactors the filter change handler by creating a higher-order function **_handleFilterChange_**, which accepts a filter key and returns an event handler. This handler extracts the input value from the event and passes it to the **_updateFilterByKey_** function, simplifying the handling of multiple filter changes with a single reusable function.