### PR TITLE
Removed unnecessary generic U in RadioButtonInputs component

### DIFF
--- a/src/components/radio-button-inputs/RadioButtonInputs.tsx
+++ b/src/components/radio-button-inputs/RadioButtonInputs.tsx
@@ -7,20 +7,19 @@ import Box from '@mui/material/Box'
 import { RadioButtonType } from '~/types'
 import { styles } from './RadioButtonInputs.styles'
 
-interface RadioButtonInputsProps<T, U>
-  extends Omit<RadioGroupProps, 'onChange'> {
-  items: RadioButtonType<T, U>[]
+interface RadioButtonInputsProps<T> extends Omit<RadioGroupProps, 'onChange'> {
+  items: RadioButtonType<T>[]
   onChange: (value: string) => void
   value: T
   title?: string
 }
 
-const RadioButtonInputs = <T, U>({
+const RadioButtonInputs = <T,>({
   onChange,
   items,
   value,
   title
-}: RadioButtonInputsProps<T, U>) => {
+}: RadioButtonInputsProps<T>) => {
   const handleValueUpdate = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange(event.target.value)
   }
@@ -30,7 +29,7 @@ const RadioButtonInputs = <T, U>({
       checked={value === radio.value}
       control={<RadioButton label='' />}
       key={String(radio.value)}
-      label={String(radio.title)}
+      label={radio.title}
       sx={styles.radioItems}
       value={radio.value}
     />

--- a/src/components/radio-button-inputs/RadioButtonInputs.tsx
+++ b/src/components/radio-button-inputs/RadioButtonInputs.tsx
@@ -30,7 +30,7 @@ const RadioButtonInputs = <T, U>({
       checked={value === radio.value}
       control={<RadioButton label='' />}
       key={String(radio.value)}
-      label={radio.title}
+      label={String(radio.title)}
       sx={styles.radioItems}
       value={radio.value}
     />

--- a/src/types/components/radioButtonInputs/RadioButtonInputs.types.ts
+++ b/src/types/components/radioButtonInputs/RadioButtonInputs.types.ts
@@ -1,4 +1,6 @@
-export type RadioButtonType<T, U> = {
-  title: U
+import React from 'react'
+
+export type RadioButtonType<T> = {
+  title: React.ReactNode
   value: T
 }


### PR DESCRIPTION
Ensure radio title is always a string, because title always string format after useTranslation() in the parent container

<img width="433" alt="Знімок екрана 2025-04-01 о 20 27 46" src="https://github.com/user-attachments/assets/1af1a9d4-bf72-462a-859f-23295a10495b" />


UPDATE:
remove  unused U generic from RadioButtonType. 
Now bug fixed without string()
