### PR TITLE
Fix props error for first login  confirmation steps

### DIFF
--- a/src/components/user-steps-wrapper/UserStepsWrapper.tsx
+++ b/src/components/user-steps-wrapper/UserStepsWrapper.tsx
@@ -29,10 +29,10 @@ const UserStepsWrapper: React.FC<UserStepsWrapperProps> = ({ userRole }) => {
   }, [dispatch])
 
   const childrenArr = [
-    <GeneralInfoStep key='1' />,
-    <SubjectsStep key='2' />,
-    <LanguageStep key='3' />,
-    <AddPhotoStep key='4' />
+    <GeneralInfoStep btnsBox={undefined} key='1' />,
+    <SubjectsStep btnsBox={undefined} key='2' />,
+    <LanguageStep btnsBox={undefined} key='3' />,
+    <AddPhotoStep btnsBox={undefined} key='4' />
   ]
 
   const stepLabels = userRole === student ? studentStepLabels : tutorStepLabels

--- a/src/components/user-steps-wrapper/UserStepsWrapper.tsx
+++ b/src/components/user-steps-wrapper/UserStepsWrapper.tsx
@@ -29,10 +29,10 @@ const UserStepsWrapper: React.FC<UserStepsWrapperProps> = ({ userRole }) => {
   }, [dispatch])
 
   const childrenArr = [
-    <GeneralInfoStep btnsBox={undefined} key='1' />,
-    <SubjectsStep btnsBox={undefined} key='2' />,
-    <LanguageStep btnsBox={undefined} key='3' />,
-    <AddPhotoStep btnsBox={undefined} key='4' />
+    <GeneralInfoStep key='1' />,
+    <SubjectsStep key='2' />,
+    <LanguageStep key='3' />,
+    <AddPhotoStep key='4' />
   ]
 
   const stepLabels = userRole === student ? studentStepLabels : tutorStepLabels

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.tsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.tsx
@@ -14,7 +14,7 @@ import { validationData } from '~/containers/tutor-home-page/add-photo-step/cons
 import { style } from '~/containers/tutor-home-page/add-photo-step/AddPhotoStep.style'
 
 interface AddPhotoStepProps {
-  btnsBox: ReactNode
+  btnsBox?: ReactNode
 }
 
 const AddPhotoStep: FC<AddPhotoStepProps> = ({ btnsBox }) => {

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.tsx
@@ -19,7 +19,7 @@ import { userService } from '~/services/user-service'
 import { type UserGeneralInfo, type UserRole } from '~/types'
 
 interface GeneralInfoStepProps {
-  btnsBox: React.ReactNode
+  btnsBox?: React.ReactNode
 }
 
 type UserName = { firstName: string; lastName: string }

--- a/src/containers/tutor-home-page/language-step/LanguageStep.tsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.tsx
@@ -12,7 +12,7 @@ import img from '~/assets/img/tutor-home-page/become-tutor/languages.svg'
 import { languages } from '~/containers/tutor-home-page/language-step/constants'
 
 interface LanguageStepProps {
-  btnsBox: ReactNode
+  btnsBox?: ReactNode
 }
 
 const LanguageStep: FC<LanguageStepProps> = ({ btnsBox }) => {

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.tsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.tsx
@@ -19,7 +19,7 @@ import { subjectService } from '~/services/subject-service'
 import { CategoryNameInterface, SubjectNameInterface } from '~/types'
 
 interface SubjectsStepProps {
-  btnsBox: JSX.Element
+  btnsBox?: JSX.Element
 }
 
 interface SubjectsType {

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.tsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.tsx
@@ -19,7 +19,7 @@ import { subjectService } from '~/services/subject-service'
 import { CategoryNameInterface, SubjectNameInterface } from '~/types'
 
 interface SubjectsStepProps {
-  btnsBox?: JSX.Element
+  btnsBox?: React.ReactNode
 }
 
 interface SubjectsType {


### PR DESCRIPTION
- In components corresponding to first login steps made props optional to eliminate the error

With limited knowledge at hand i checked via Chrome browser(Version 134.0.6998.178 (Official Build) (64-bit version)) and didn`t spot any issues

After Change ( Student )

![image](https://github.com/user-attachments/assets/a18a581f-bbf5-4fc1-b5da-1633a3c3b1fb)

After Change ( Tutor )

![image](https://github.com/user-attachments/assets/7807317a-761c-42ae-a54a-82653e36cce1)




