### PR TITLE
Fixed type errors in AsyncAutocomplete component

### DIFF
--- a/src/components/async-autocomplete/AsyncAutocomplete.tsx
+++ b/src/components/async-autocomplete/AsyncAutocomplete.tsx
@@ -6,6 +6,7 @@ import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
 import useQuery from '~/hooks/use-query'
 import { Category, ServiceFunctionNew } from '~/types'
 import { ResponseError } from '~/exceptions'
+import { AutocompleteFreeSoloValueMapping } from '@mui/material'
 
 export interface AsyncAutocompleteProps<
   Response,
@@ -81,8 +82,11 @@ const AsyncAutocomplete = <
   )
 
   const getOptionLabel = useMemo(
-    () => (option: TransformedResponse) =>
-      (labelField ? option[labelField] : option) || '',
+    () =>
+      (option: TransformedResponse | AutocompleteFreeSoloValueMapping<F>) =>
+        typeof option === 'object' && option !== null
+          ? String((labelField ? option[labelField] : option) || '')
+          : '',
     [labelField]
   )
 

--- a/src/components/async-autocomplete/AsyncAutocomplete.tsx
+++ b/src/components/async-autocomplete/AsyncAutocomplete.tsx
@@ -105,16 +105,28 @@ const AsyncAutocomplete = <
     fetchOnFocus && fetchFocusCondition && void fetchData()
   }
 
+  const { onChange, ...restProps } = props
+
+  const handleChange = (
+    event: React.SyntheticEvent<Element, Event>,
+    value: TransformedResponse | string | null
+  ) => {
+    if (onChange) {
+      onChange(event, value as TransformedResponse, 'selectOption')
+    }
+  }
+
   return (
     <AppAutoComplete
       getOptionLabel={getOptionLabel}
       isOptionEqualToValue={isOptionEqualToValue}
       loading={loading}
+      onChange={handleChange}
       onFocus={handleFocus}
       options={response as TransformedResponse[]}
       textFieldProps={textFieldProps}
       value={valueOption}
-      {...props}
+      {...restProps}
     />
   )
 }

--- a/src/components/async-autocomplete/AsyncAutocomplete.tsx
+++ b/src/components/async-autocomplete/AsyncAutocomplete.tsx
@@ -83,10 +83,13 @@ const AsyncAutocomplete = <
 
   const getOptionLabel = useMemo(
     () =>
-      (option: TransformedResponse | AutocompleteFreeSoloValueMapping<F>) =>
-        typeof option === 'object' && option !== null
-          ? String((labelField ? option[labelField] : option) || '')
-          : '',
+      (option: TransformedResponse | AutocompleteFreeSoloValueMapping<F>) => {
+        if (typeof option === 'object' && option !== null) {
+          const optionValue = labelField ? option[labelField] : option
+          return String(optionValue ?? '')
+        }
+        return ''
+      },
     [labelField]
   )
 


### PR DESCRIPTION
Fixed type errors in AsyncAutocomplete component. Fixed incorrect type of onFocus and onChange props, and also getOptionLabel.

**Before fix:**
![image](https://github.com/user-attachments/assets/83e048e1-898b-4699-8995-686d3cf702ef)

**After fix:**
![image](https://github.com/user-attachments/assets/1928b22a-6815-4755-9153-36caa9a7e84f)
