### PR TITLE
Fix bug with unreachable radio button

### DIFF
--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -117,7 +117,7 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
       {filterTitle(t('findOffers.filterTitles.rating'))}
       <RadioButtonInputs
         items={radioOptions}
-        onChange={handleFilterChange('rating')}
+        onChange={updateFilterByKey('rating')}
         value={Number(filters.rating)}
       />
       {!isLaptopAndAbove && (

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -98,6 +98,10 @@ const FindOffers = () => {
   })
 
   const price = useMemo(() => {
+    if (!items.length) {
+      return { minPrice: 0, maxPrice: 0 }
+    }
+
     const filterItems = items.map((item) => item.price)
     const minPrice = Math.min(...filterItems)
     const maxPrice = Math.max(...filterItems)

--- a/tests/unit/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.spec.jsx
+++ b/tests/unit/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.spec.jsx
@@ -6,7 +6,9 @@ import OfferFilterList from '~/containers/find-offer/offer-filter-block/offer-fi
 import { ProficiencyLevelEnum, UserRoleEnum } from '~/types'
 import { selectOption, renderWithProviders } from '~tests/test-utils'
 
-const mockUpdateFilterByKey = vi.fn()
+const mockUpdateFilterByKey = vi.fn().mockImplementation((key) => (value) => {
+  mockUpdateFiltersInQuery({ [key]: value })
+})
 const mockUpdateFiltersInQuery = vi.fn()
 
 const defaultFilters = {


### PR DESCRIPTION
I use now in RadioInput updateFilterByKey from props instead of handleFilterChange()

And i add check for length of items is not empty, because now filters are working and i see result of
price =  [-Infiniti, Infiniti]
Now in this case it would be [0,0]

Result:

https://github.com/user-attachments/assets/7fc83159-860e-44e9-94ee-d4bd6fc0f50b

