### PR TITLE
Fixed error in editProfileSlice

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -20,7 +20,7 @@ export const URLs = {
   users: {
     get: '/users',
     getUserById: '/users/:id',
-    update: '/users',
+    update: '/users/:id',
     delete: '/users/delete',
     deactivate: '/users/deactivate',
     activate: '/users/activate',

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -155,7 +155,6 @@ export const updateUser = createAsyncThunk(
   ) => {
     try {
       await userService.updateUser(userId, params)
-      return
     } catch (e) {
       if (e instanceof ResponseError) {
         return rejectWithValue(e.code)

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -155,7 +155,7 @@ export const updateUser = createAsyncThunk(
   ) => {
     try {
       await userService.updateUser(userId, params)
-      return true
+      return
     } catch (e) {
       if (e instanceof ResponseError) {
         return rejectWithValue(e.code)

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -157,10 +157,7 @@ export const updateUser = createAsyncThunk(
       await userService.updateUser(userId, params)
       return true
     } catch (e) {
-      const error = e as AxiosError<ErrorResponse>
-      if (error.response?.data?.code) {
-        return rejectWithValue(error.response.data.code)
-      } else if (e instanceof ResponseError) {
+      if (e instanceof ResponseError) {
         return rejectWithValue(e.code)
       }
     }

--- a/src/redux/features/editProfileSlice.ts
+++ b/src/redux/features/editProfileSlice.ts
@@ -154,11 +154,13 @@ export const updateUser = createAsyncThunk(
     { rejectWithValue }
   ) => {
     try {
-      const response = await userService.updateUser(userId, params)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return response.data
+      await userService.updateUser(userId, params)
+      return true
     } catch (e) {
-      if (e instanceof ResponseError) {
+      const error = e as AxiosError<ErrorResponse>
+      if (error.response?.data?.code) {
+        return rejectWithValue(error.response.data.code)
+      } else if (e instanceof ResponseError) {
         return rejectWithValue(e.code)
       }
     }
@@ -346,6 +348,7 @@ const editProfileSlice = createSlice({
       })
       .addCase(updateUser.fulfilled, (state) => {
         state.loading = LoadingStatusEnum.Fulfilled
+        state.error = null
       })
       .addCase(updateUser.rejected, (state, action) => {
         state.loading = LoadingStatusEnum.Rejected

--- a/src/services/user-service.tsx
+++ b/src/services/user-service.tsx
@@ -48,7 +48,8 @@ export const userService = {
     return baseService.request<void>({
       method: 'PATCH',
       url: getFullUrl({
-        pathname: `${URLs.users.update}/${userId}`
+        pathname: URLs.users.update,
+        parameters: { id: userId }
       }),
       data: params
     })

--- a/tests/unit/redux/editProfileSlice.spec.js
+++ b/tests/unit/redux/editProfileSlice.spec.js
@@ -937,6 +937,17 @@ describe('editProfileSlice test', () => {
     expect(store.getState().editProfile).toEqual(expectedState)
   })
 
+  it('updateUser should complete without returning anything', async () => {
+    const userId = '123'
+    const params = { firstName: 'new firstname' }
+
+    vi.spyOn(userService, 'updateUser').mockResolvedValueOnce(undefined)
+
+    await store.dispatch(updateUser({ userId, params }))
+
+    expect(userService.updateUser).toHaveBeenCalledWith(userId, params)
+  })
+
   it('updateUser should handle fulfilled state', async () => {
     const userId = '123'
     const params = { firstName: 'new firstname' }

--- a/tests/unit/redux/editProfileSlice.spec.js
+++ b/tests/unit/redux/editProfileSlice.spec.js
@@ -18,6 +18,8 @@ import { mockAxiosClient } from '~tests/test-utils'
 import { createUrlPath } from '~/utils/helper-functions'
 import { URLs } from '~/constants/request'
 import { LoadingStatusEnum } from '~/redux/redux.constants'
+import { ResponseError } from '~/exceptions'
+import { userService } from '~/services/user-service'
 
 const userDataMock = {
   firstName: 'John',
@@ -963,16 +965,20 @@ describe('editProfileSlice test', () => {
       error: errorCode
     })
 
-    mockAxiosClient
-      .onPatch(createUrlPath(URLs.users.update, userId), params)
-      .reply(404, { code: errorCode, message: 'User has not been found' })
+    vi.spyOn(userService, 'updateUser').mockRejectedValueOnce(
+      new ResponseError({
+        code: errorCode,
+        message: 'User not found',
+        status: 404
+      })
+    )
 
     await store.dispatch(updateUser({ userId, params }))
 
     const actualState = store.getState().editProfile
 
-    expect(actualState).toEqual(expectedState)
     expect(actualState.loading).toEqual(LoadingStatusEnum.Rejected)
     expect(actualState.error).toEqual(errorCode)
+    expect(actualState).toEqual(expectedState)
   })
 })


### PR DESCRIPTION
- Removed `response.data` return. Now `updateUser` service returns void (no data expected from PATCH requests), so we simply await completion.
- Explicit `return true` on success. Replaced unsafe type-ignored returns with a clear success flag for better intent and type safety.
- Updated endpoint and service.
- Updated test.


Examples of successful updating of the data:
![image](https://github.com/user-attachments/assets/70204102-0f8a-48d2-bcee-e2f290e82e73)

![image](https://github.com/user-attachments/assets/dfb9dc8c-aa42-4413-9a10-d9b0fc2fba5c)

![image](https://github.com/user-attachments/assets/e5becfd1-ffd3-4154-8c21-4d64be01acc8)

![image](https://github.com/user-attachments/assets/82fb89a5-5919-4dc7-9456-d94790b16a73)

**Issue: #3284**

