### PR TITLE
Fixed login popup width for invalid email #2788

### DIFF
--- a/src/containers/guest-home-page/login-form/LoginForm.styles.js
+++ b/src/containers/guest-home-page/login-form/LoginForm.styles.js
@@ -13,7 +13,8 @@ export const styles = {
     mb: '10px'
   },
   input: {
-    maxWidth: '343px'
+    maxWidth: '343px',
+    mb: '5px'
   },
   loginButton: {
     width: '100%',

--- a/src/containers/guest-home-page/login-form/LoginForm.tsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.tsx
@@ -71,7 +71,7 @@ const LoginForm: React.FC<LoginFormProps> = ({
         onChange={handleChange('email')}
         required
         size='medium'
-        sx={{ mb: '5px' }}
+        sx={styles.input}
         type='email'
         value={data.email}
       />


### PR DESCRIPTION
Fixed size of login popup that was bigger than the default one when typing an invalid email.

Before:
![Screenshot 2025-04-06 at 12 23 16](https://github.com/user-attachments/assets/9d4faed9-e050-4c2e-88aa-1e1767ab22a0)


After:
![Screenshot 2025-04-06 at 12 23 40](https://github.com/user-attachments/assets/acbb0d12-31a1-40d8-8c49-2d3bc1cfc079)
