### PR TITLE
Fix a bug when selecting a level in offer filtering

### DIFF
--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -60,6 +60,10 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
   const handleFilterChange = (key: keyof FindOffersFilters) => () =>
     updateFilterByKey(key)
 
+  const handleCheckboxChange =
+    (key: keyof FindOffersFilters) => (newValues?: ProficiencyLevelEnum[]) =>
+      updateFilterByKey(key)(newValues)
+
   const getOptionLabelForLanguage = (option: LanguageFilter | null): string => {
     return option?.trim() ? option : t('common.languages.allLanguages')
   }
@@ -101,7 +105,7 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
       <CheckboxList
         {...checkboxListProps}
         items={levelOptions}
-        onChange={handleFilterChange('proficiencyLevel')}
+        onChange={handleCheckboxChange('proficiencyLevel')}
         value={filters.proficiencyLevel}
         variant={'body2'}
       />

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -93,8 +93,6 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
     <Typography sx={styles.title}>{title}</Typography>
   )
 
-  console.log(filters.proficiencyLevel)
-
   const checkboxListProps =
     userRole === UserRoleEnum.Tutor
       ? { fillRange: true }

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -59,7 +59,7 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
 
   const handleCheckboxChange =
     (key: keyof FindOffersFilters) => (newValues: ProficiencyLevelEnum[]) => {
-      const cleanedValues = newValues.filter((v) => v)
+      const cleanedValues = newValues.filter((value) => value)
       updateFilterByKey(key)(cleanedValues)
     }
 
@@ -105,7 +105,7 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
         {...checkboxListProps}
         items={levelOptions}
         onChange={handleCheckboxChange('proficiencyLevel')}
-        value={filters.proficiencyLevel || []}
+        value={filters.proficiencyLevel ?? []}
         variant={'body2'}
       />
 

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -57,8 +57,9 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
   const handleChecked = (_: SyntheticEvent<Element, Event>, checked: boolean) =>
     updateFiltersInQuery({ native: checked.toString() })
 
-  const handleFilterChange = (key: keyof FindOffersFilters) => () =>
-    updateFilterByKey(key)
+  const handleCheckboxChange =
+    (key: keyof FindOffersFilters) => (newValues?: ProficiencyLevelEnum[]) =>
+      updateFilterByKey(key)(newValues)
 
   const getOptionLabelForLanguage = (option: LanguageFilter | null): string => {
     return option?.trim() ? option : t('common.languages.allLanguages')
@@ -101,7 +102,7 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
       <CheckboxList
         {...checkboxListProps}
         items={levelOptions}
-        onChange={handleFilterChange('proficiencyLevel')}
+        onChange={handleCheckboxChange('proficiencyLevel')}
         value={filters.proficiencyLevel}
         variant={'body2'}
       />

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -58,8 +58,10 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
     updateFiltersInQuery({ native: checked.toString() })
 
   const handleCheckboxChange =
-    (key: keyof FindOffersFilters) => (newValues?: ProficiencyLevelEnum[]) =>
-      updateFilterByKey(key)(newValues)
+    (key: keyof FindOffersFilters) => (newValues: ProficiencyLevelEnum[]) => {
+      const cleanedValues = newValues.filter((v) => v)
+      updateFilterByKey(key)(cleanedValues)
+    }
 
   const getOptionLabelForLanguage = (option: LanguageFilter | null): string => {
     return option?.trim() ? option : t('common.languages.allLanguages')

--- a/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
+++ b/src/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.tsx
@@ -93,10 +93,12 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
     <Typography sx={styles.title}>{title}</Typography>
   )
 
+  console.log(filters.proficiencyLevel)
+
   const checkboxListProps =
     userRole === UserRoleEnum.Tutor
       ? { fillRange: true }
-      : { singleSelect: true }
+      : { singleSelect: false }
 
   return (
     <>
@@ -105,9 +107,10 @@ const OfferFilterList: FC<OfferFilterListProps> = ({
         {...checkboxListProps}
         items={levelOptions}
         onChange={handleCheckboxChange('proficiencyLevel')}
-        value={filters.proficiencyLevel}
+        value={filters.proficiencyLevel || []}
         variant={'body2'}
       />
+
       {filterTitle(t('findOffers.filterTitles.language'))}
       {languagesFilter}
       {filterTitle(t('findOffers.filterTitles.price'))}

--- a/tests/unit/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.spec.jsx
+++ b/tests/unit/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.spec.jsx
@@ -6,8 +6,9 @@ import OfferFilterList from '~/containers/find-offer/offer-filter-block/offer-fi
 import { ProficiencyLevelEnum, UserRoleEnum } from '~/types'
 import { selectOption, renderWithProviders } from '~tests/test-utils'
 
-const mockUpdateFilterByKey = vi.fn()
 const mockUpdateFiltersInQuery = vi.fn()
+const mockInnerFn = vi.fn()
+const mockUpdateFilterByKey = vi.fn().mockImplementation(() => mockInnerFn)
 
 const defaultFilters = {
   language: null,
@@ -70,11 +71,11 @@ describe('OfferFilterList for Tutor', () => {
   })
 
   it('calls updateFilterByKey when proficiency level is changed', () => {
-    const proficiencyCheckbox = screen.getByLabelText(
-      ProficiencyLevelEnum.Beginner
-    )
-    fireEvent.click(proficiencyCheckbox)
+    const checkbox = screen.getByLabelText(ProficiencyLevelEnum.Beginner)
+    fireEvent.click(checkbox)
+
     expect(mockUpdateFilterByKey).toHaveBeenCalledWith('proficiencyLevel')
+    expect(mockInnerFn).toHaveBeenCalledWith([ProficiencyLevelEnum.Beginner])
   })
 
   it('calls updateFilterByKey when price range is changed', () => {

--- a/tests/unit/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.spec.jsx
+++ b/tests/unit/containers/find-offer/offer-filter-block/offer-filter-list/OfferFilterList.spec.jsx
@@ -72,11 +72,12 @@ describe('OfferFilterList for Tutor', () => {
   })
 
   it('calls updateFilterByKey when proficiency level is changed', () => {
-    const proficiencyCheckbox = screen.getByLabelText(
-      ProficiencyLevelEnum.Beginner
-    )
-    fireEvent.click(proficiencyCheckbox)
+    const checkbox = screen.getByLabelText(ProficiencyLevelEnum.Beginner)
+    fireEvent.click(checkbox)
     expect(mockUpdateFilterByKey).toHaveBeenCalledWith('proficiencyLevel')
+    expect(mockUpdateFiltersInQuery).toHaveBeenCalledWith({
+      proficiencyLevel: [ProficiencyLevelEnum.Beginner]
+    })
   })
 
   it('calls updateFilterByKey when price range is changed', () => {


### PR DESCRIPTION
Fixed a bug with the proficiency level filter in the "Find Offer" screen. Previously, selecting levels via checkboxes didn’t correctly update the filter state. Created a new handler function to manage checkbox changes properly and refactored related tests.

The previous implementation used a generic filter change handler that did not take into account the specific behavior of checkboxes, namely returning an array with a value. It expected a simple event or value, which caused the filter to receive incorrect or empty data when interacting with the checkbox.



https://github.com/user-attachments/assets/2c73b9a0-b5aa-4725-9e56-d51babc01dd7


