### PR TITLE
Fixed errors in SearchAutocomplete component

### DIFF
--- a/src/components/app-auto-complete/AppAutoComplete.tsx
+++ b/src/components/app-auto-complete/AppAutoComplete.tsx
@@ -3,16 +3,13 @@ import { Fragment, SyntheticEvent, FocusEvent } from 'react'
 import TextField, { TextFieldProps } from '@mui/material/TextField'
 import Autocomplete, {
   createFilterOptions,
-  AutocompleteProps
+  AutocompleteProps,
+  AutocompleteChangeReason,
+  AutocompleteChangeDetails
 } from '@mui/material/Autocomplete'
 
 import Loader from '~/components/loader/Loader'
 import { ChipTypeMap, FilterOptionsState } from '@mui/material'
-
-import {
-  AutocompleteChangeReason,
-  AutocompleteChangeDetails
-} from '@mui/material/Autocomplete'
 
 const defaultFilterOptions = <T,>(
   options: T[],

--- a/src/components/app-auto-complete/AppAutoComplete.tsx
+++ b/src/components/app-auto-complete/AppAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { Fragment, SyntheticEvent } from 'react'
+import { Fragment, SyntheticEvent, FocusEvent } from 'react'
 
 import TextField, { TextFieldProps } from '@mui/material/TextField'
 import Autocomplete, {
@@ -8,6 +8,11 @@ import Autocomplete, {
 
 import Loader from '~/components/loader/Loader'
 import { ChipTypeMap, FilterOptionsState } from '@mui/material'
+
+import {
+  AutocompleteChangeReason,
+  AutocompleteChangeDetails
+} from '@mui/material/Autocomplete'
 
 const defaultFilterOptions = <T,>(
   options: T[],
@@ -20,8 +25,13 @@ const defaultFilterOptions = <T,>(
 type CustomProps<T> = {
   textFieldProps?: TextFieldProps
   hideClearIcon?: boolean
-  onChange?: (_: SyntheticEvent, value: string | null) => void | Promise<void>
-  onFocus?: (_: SyntheticEvent, value: string | null) => void | Promise<void>
+  onChange?: (
+    _: SyntheticEvent,
+    value: string | null,
+    reason: AutocompleteChangeReason,
+    _details?: AutocompleteChangeDetails<string>
+  ) => void | Promise<void>
+  onFocus?: (event: FocusEvent<HTMLDivElement>) => void
 } & Omit<T, 'renderInput'>
 
 const AppAutoComplete = <

--- a/src/components/search-autocomplete/SearchAutocomplete.tsx
+++ b/src/components/search-autocomplete/SearchAutocomplete.tsx
@@ -4,7 +4,6 @@ import {
   Dispatch,
   SetStateAction,
   SyntheticEvent,
-  ChangeEvent,
   KeyboardEvent
 } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -32,11 +31,11 @@ import { styles } from '~/components/search-autocomplete/SearchAutocomplete.styl
 import { SizeEnum, VisibilityEnum, TextFieldVariantEnum } from '~/types'
 
 interface SearchAutocompleteProps
-  extends Omit<AutocompleteProps<string, false, true, true>, 'renderInput'> {
+  extends Omit<AutocompleteProps<string, false, false, true>, 'renderInput'> {
   search: string
   setSearch: Dispatch<SetStateAction<string>>
   onSearchChange?: () => void
-  textFieldProps: TextFieldProps
+  textFieldProps: TextFieldProps<'standard'>
   renderInput?: (params: AutocompleteRenderInputParams) => ReactNode
 }
 
@@ -60,13 +59,16 @@ const SearchAutocomplete = ({
     return defaultFilterOptions(options, state).slice(0, 6)
   }
 
-  const onInputChange = (_: ChangeEvent<HTMLInputElement>, value: string) => {
+  const onInputChange = (_: SyntheticEvent, value: string) => {
     setSearchInput(value)
   }
 
-  const handleAutoCompleteChange = (_: SyntheticEvent, value: string) => {
+  const handleAutoCompleteChange = (
+    _: SyntheticEvent,
+    value: string | null
+  ) => {
     onSearchChange && onSearchChange()
-    setSearch(value)
+    setSearch(value ?? '')
   }
 
   const onSearch = () => {
@@ -86,7 +88,7 @@ const SearchAutocomplete = ({
 
   const labelStyle = {
     ...styles.inputLabel,
-    visibility: searchInput && VisibilityEnum.Hidden
+    visibility: searchInput ? VisibilityEnum.Hidden : VisibilityEnum.Visible
   }
   const clearIconVisibility = {
     visibility: searchInput ? VisibilityEnum.Visible : VisibilityEnum.Hidden


### PR DESCRIPTION
Fixed type erros in "SearchAutocomplete" component.

Path:
![Screenshot 2025-04-08 132215](https://github.com/user-attachments/assets/d4c70aa6-023c-4f83-bf3c-4ce62be5c365)

Before:
![Screenshot 2025-04-08 132029](https://github.com/user-attachments/assets/0b6df8c0-9448-4cff-8d58-84ec6c76609e)

After:
![Screenshot 2025-04-08 132013](https://github.com/user-attachments/assets/086b0ae4-9b8c-4c29-a2e8-b0fba122ddd4)
