### PR TITLE
Fixed cooperation closing banner overlapping

### DIFF
--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -292,7 +292,7 @@ const CooperationDetails = () => {
         <Box sx={styles.pageContent}>
           {activeTab === CooperationTabsEnum.Activities &&
             cooperationClosingModal}
-          <Box sx={styles.pageContent}>{pageContent()}</Box>
+          {pageContent()}
         </Box>
         {!isDesktop && isNotesOpen && (
           <AppDrawer

--- a/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
+++ b/src/containers/my-cooperations/cooperation-details/CooperationDetails.tsx
@@ -288,9 +288,12 @@ const CooperationDetails = () => {
           </Button>
         </Box>
       </Box>
-      {activeTab === CooperationTabsEnum.Activities && cooperationClosingModal}
       <Box sx={styles.notesBlock}>
-        <Box sx={styles.pageContent}>{pageContent()}</Box>
+        <Box sx={styles.pageContent}>
+          {activeTab === CooperationTabsEnum.Activities &&
+            cooperationClosingModal}
+          <Box sx={styles.pageContent}>{pageContent()}</Box>
+        </Box>
         {!isDesktop && isNotesOpen && (
           <AppDrawer
             anchor={PositionEnum.Right}


### PR DESCRIPTION
Fixed cooperation closing banner that overlapped notes section.
Before:
![Screenshot 2025-04-08 at 23 40 17](https://github.com/user-attachments/assets/6b3365e6-59e8-4518-9db6-1e80f172e7ee)

After:
![Screenshot 2025-04-08 at 23 39 20](https://github.com/user-attachments/assets/1dcf5ae6-7a95-4aee-a2ed-733592e7ff73)
![Screenshot 2025-04-08 at 23 38 59](https://github.com/user-attachments/assets/d535edb8-5a5f-4d7f-8a1d-50ba4fe3f50e)
