### PR TITLE
replace plain strings with authRoutes in ActiveStudentsBlock component

### DIFF
--- a/src/components/active-students/ActiveStudentsBlock.tsx
+++ b/src/components/active-students/ActiveStudentsBlock.tsx
@@ -12,10 +12,12 @@ import { styles } from './ActiveStudentsBlock.styles'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { defaultResponses } from '~/constants'
+import { authRoutes } from '~/router/constants/authRoutes'
 
 const ActiveStudentsBlock = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const { findOffers, cooperationDetails } = authRoutes
 
   const getMyCooperations = useCallback(
     () => cooperationService.getCooperations({ limit: 3, status: 'active' }),
@@ -39,11 +41,11 @@ const ActiveStudentsBlock = () => {
   }
 
   const onShowMoreClick = () => {
-    navigate('/my-cooperations')
+    navigate(cooperationDetails.path)
   }
 
   const onAddStudentClick = () => {
-    navigate('/categories/subjects/find-offers')
+    navigate(findOffers.path)
   }
 
   if (!data.items.length)

--- a/tests/unit/components/active-students/ActiveStudentsBlock.spec.jsx
+++ b/tests/unit/components/active-students/ActiveStudentsBlock.spec.jsx
@@ -1,4 +1,5 @@
 import { screen, fireEvent } from '@testing-library/react'
+import { authRoutes } from '~/router/constants/authRoutes'
 
 import { renderWithProviders } from '~tests/test-utils'
 import ActiveStudentsBlock from '~/components/active-students/ActiveStudentsBlock'
@@ -121,7 +122,9 @@ describe('ActiveStudentsBlock', () => {
     const showMoreButton = screen.getByTestId('showMore')
     fireEvent.click(showMoreButton)
 
-    expect(navigateMock).toHaveBeenCalledWith('/my-cooperations')
+    expect(navigateMock).toHaveBeenCalledWith(
+      authRoutes.cooperationDetails.path
+    )
   })
 
   it('should render Loader when loading', () => {
@@ -145,9 +148,7 @@ describe('ActiveStudentsBlock', () => {
     const showMoreButton = screen.getByTestId('addStudent')
     fireEvent.click(showMoreButton)
 
-    expect(navigateMock).toHaveBeenCalledWith(
-      '/categories/subjects/find-offers'
-    )
+    expect(navigateMock).toHaveBeenCalledWith(authRoutes.findOffers.path)
   })
 
   it('should not render on error', () => {


### PR DESCRIPTION
Replaced strings in `navigate` with `authRoutes`.

Before:
![image](https://github.com/user-attachments/assets/a9cb47ff-fa9e-4cb2-abc9-913a7b238506)

after: 
![image](https://github.com/user-attachments/assets/b48e825b-dabe-4ef7-81c6-e26668797fb9)
