### PR TITLE
Bugfix/3214/fix div inside p warning in cooperationdetails

### DIFF
--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.styles.ts
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.styles.ts
@@ -3,6 +3,7 @@ export const styles = {
     fontWeight: 500
   },
   response: {
-    paddingTop: '10px'
+    paddingTop: '10px',
+    display: 'block'
   }
 }

--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
@@ -60,13 +60,13 @@ const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
           </Typography>
           {t('cooperationDetailsPage.closingMessage2')}
           {message && (
-            <Box sx={styles.response}>
+            <Box component='span' sx={{ ...styles.response, display: 'block' }}>
               <Typography component='span' sx={styles.boldText}>
                 {t('cooperationDetailsPage.answer')}
                 {user}:
               </Typography>
               <br />
-              <Typography>{message}</Typography>
+              <Typography component='span'>{message}</Typography>
             </Box>
           )}
         </>

--- a/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
+++ b/src/containers/my-cooperations/accept-cooperation-close/AcceptCooperationClosing.tsx
@@ -60,7 +60,7 @@ const AcceptCooperationClosing: React.FC<AcceptCooperationClosureProps> = ({
           </Typography>
           {t('cooperationDetailsPage.closingMessage2')}
           {message && (
-            <Box component='span' sx={{ ...styles.response, display: 'block' }}>
+            <Box component='span' sx={styles.response}>
               <Typography component='span' sx={styles.boldText}>
                 {t('cooperationDetailsPage.answer')}
                 {user}:

--- a/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
+++ b/src/containers/my-cooperations/cooperation-closure-declined-banner/CooperationClosureDeclinedBanner.tsx
@@ -48,7 +48,7 @@ const CooperationClosureDeclinedBanner: React.FC<
             i18nKey='cooperationDetailsPage.cooperationCloseDeclinedMessage'
             values={{ user: user }}
           />
-          <Typography>{message}</Typography>
+          <Typography component='span'>{message}</Typography>
         </>
       }
       icon={<ErrorOutlineRounded />}


### PR DESCRIPTION
Refactor `AcceptCooperationClosing`  and `CooperationClosureDeclinedBanner `components to fix invalid HTML nesting:

Before:
![image](https://github.com/user-attachments/assets/b16d9438-cc40-4e1a-a9e4-db2a9b54478e)

After: 
![image](https://github.com/user-attachments/assets/5326601b-a1e5-421f-a64a-6a0d5d2d3d8e)
