### PR TITLE
[Edit profile. Profile] Verify that the tutor/student couldn't save the first name only with space characters

### DIFF
--- a/tests/unit/containers/edit-profile/ProfileTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/ProfileTab.spec.jsx
@@ -233,4 +233,35 @@ describe('ProfileTab', () => {
     expect(errorMessage).toBeInTheDocument()
     expect(lastNameInput).toHaveValue(tooManyCharacters)
   })
+
+  it('should show an error when "First name" empty', async () => {
+    renderWithMockData()
+
+    const firstNameInput = screen.getByPlaceholderText('firstName')
+
+    await userEvent.clear(firstNameInput)
+    expect(firstNameInput.value).toBe('')
+
+    const errorMessage = await screen.findByText(
+      /common.errorMessages.emptyField/i
+    )
+    expect(errorMessage).toBeInTheDocument()
+    expect(firstNameInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('should show an error when "First name" contains only spaces', async () => {
+    renderWithMockData()
+
+    const firstNameInput = screen.getByPlaceholderText('firstName')
+
+    await userEvent.clear(firstNameInput)
+    await userEvent.type(firstNameInput, '   ')
+    expect(firstNameInput.value).toBe('   ')
+
+    const errorMessage = await screen.findByText(
+      /common.errorMessages.hasOnlySpaces/i
+    )
+    expect(errorMessage).toBeInTheDocument()
+    expect(firstNameInput).toHaveAttribute('aria-invalid', 'true')
+  })
 })

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -577,48 +577,4 @@ describe('EditProfile', () => {
       title: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.title'
     })
   })
-
-  it('should show an error when "First name" empty and Update button becomes disabled and inactive', async () => {
-    const mockHandleInputChange = vi.fn()
-    const mockT = vi.fn((key) => {
-      const translations = {
-        'common.labels.firstName': 'First Name',
-        'common.errorMessages.hasOnlySpaces':
-          'This field must contain at least one non-space character'
-      }
-      return translations[key] || key
-    })
-    const mockError = {
-      firstName: 'common.errorMessages.hasOnlySpaces'
-    }
-
-    renderWithProviders(
-      <ProfileTabForm
-        data={mockData}
-        errors={mockError}
-        handleBlur={() => {}}
-        handleInputChange={mockHandleInputChange}
-        openAlert={() => {}}
-        t={mockT}
-      />
-    )
-
-    const firstNameInput = screen.getByLabelText(/common.labels.firstName/i)
-    expect(firstNameInput).toBeInTheDocument()
-
-    fireEvent.change(firstNameInput, { target: { value: '   ' } })
-    fireEvent.blur(firstNameInput)
-    expect(mockHandleInputChange).toHaveBeenCalled()
-
-    fireEvent.click(firstNameInput)
-    const updateButton = screen.getByText('editProfilePage.updateBtn')
-    expect(updateButton).toBeInTheDocument()
-    // expect(updateButton).toBeDisabled()
-
-    const errorMessage = await screen.findByText(
-      /common.errorMessages.hasOnlySpaces/i
-    )
-    expect(errorMessage).toBeInTheDocument()
-    expect(firstNameInput).toHaveAttribute('aria-invalid', 'true')
-  })
 })

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -578,22 +578,25 @@ describe('EditProfile', () => {
     })
   })
 
-  it('should show an error when "First name" is cleared', async () => {
+  it('should show an error when "First name" empty and Update button becomes disabled and inactive', async () => {
     const mockHandleInputChange = vi.fn()
-    const mockHandleBlur = vi.fn()
     const mockT = vi.fn((key) => {
       const translations = {
         'common.labels.firstName': 'First Name',
-        'common.errorMessages.emptyField': 'This field cannot be empty'
+        'common.errorMessages.hasOnlySpaces':
+          'This field must contain at least one non-space character'
       }
       return translations[key] || key
     })
+    const mockError = {
+      firstName: 'common.errorMessages.hasOnlySpaces'
+    }
 
     renderWithProviders(
       <ProfileTabForm
         data={mockData}
-        errors={mockData.errors}
-        handleBlur={mockHandleBlur}
+        errors={mockError}
+        handleBlur={() => {}}
         handleInputChange={mockHandleInputChange}
         openAlert={() => {}}
         t={mockT}
@@ -601,9 +604,21 @@ describe('EditProfile', () => {
     )
 
     const firstNameInput = screen.getByLabelText(/common.labels.firstName/i)
-    fireEvent.change(firstNameInput, { target: { value: 'John' } })
+    expect(firstNameInput).toBeInTheDocument()
+
+    fireEvent.change(firstNameInput, { target: { value: '   ' } })
+    fireEvent.blur(firstNameInput)
     expect(mockHandleInputChange).toHaveBeenCalled()
-    // await waitFor(() => expect(firstNameInput.value).toBe('John'))
-    // value doesn't change
+
+    fireEvent.click(firstNameInput)
+    const updateButton = screen.getByText('editProfilePage.updateBtn')
+    expect(updateButton).toBeInTheDocument()
+    // expect(updateButton).toBeDisabled()
+
+    const errorMessage = await screen.findByText(
+      /common.errorMessages.hasOnlySpaces/i
+    )
+    expect(errorMessage).toBeInTheDocument()
+    expect(firstNameInput).toHaveAttribute('aria-invalid', 'true')
   })
 })

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -577,4 +577,33 @@ describe('EditProfile', () => {
       title: 'editProfilePage.profile.profileTab.saveUnsavedChangesModal.title'
     })
   })
+
+  it('should show an error when "First name" is cleared', async () => {
+    const mockHandleInputChange = vi.fn()
+    const mockHandleBlur = vi.fn()
+    const mockT = vi.fn((key) => {
+      const translations = {
+        'common.labels.firstName': 'First Name',
+        'common.errorMessages.emptyField': 'This field cannot be empty'
+      }
+      return translations[key] || key
+    })
+
+    renderWithProviders(
+      <ProfileTabForm
+        data={mockData}
+        errors={mockData.errors}
+        handleBlur={mockHandleBlur}
+        handleInputChange={mockHandleInputChange}
+        openAlert={() => {}}
+        t={mockT}
+      />
+    )
+
+    const firstNameInput = screen.getByLabelText(/common.labels.firstName/i)
+    fireEvent.change(firstNameInput, { target: { value: 'John' } })
+    expect(mockHandleInputChange).toHaveBeenCalled()
+    // await waitFor(() => expect(firstNameInput.value).toBe('John'))
+    // value doesn't change
+  })
 })


### PR DESCRIPTION
**Added tests for the validation of the "First name" text field in the "ProfileTab" component.**

_Although these tests did not increase coverage, they clearly target important edge cases in form validation, improving confidence in the component's behavior._

![Screenshot 2025-04-15 180405](https://github.com/user-attachments/assets/b2d12c64-1bc7-44cb-8eef-29d459718e4b)
