### PR TITLE
 [Edit Tutor’s profile] Verify that the Tutor can not change the password with invalid data #2770

### DIFF
--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -234,7 +234,7 @@ describe('ChangePasswordModal', () => {
     })
   })
 
-  it.only('should display an error message for incorrect new password', async () => {
+  it('should display an error message for incorrect new password', async () => {
     const testData = ['A1!', 'ABCDEFGHIJKabcdefghijk1234567890!@#$%^&*()_+?><', 'ABab12!', 'ABCDEFGabcdefg123456!@#$%^'];
     const currentPasswordInput = screen.getByLabelText(
       /editProfilePage.profile.passwordSecurityTab.currentPassword/i

--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -233,4 +233,36 @@ describe('ChangePasswordModal', () => {
       expect(currentPasswordInput).toHaveValue('')
     })
   })
+
+  it.only('should display an error message for incorrect new password', async () => {
+    const testData = ['A1!', 'ABCDEFGHIJKabcdefghijk1234567890!@#$%^&*()_+?><', 'ABab12!', 'ABCDEFGabcdefg123456!@#$%^'];
+    const currentPasswordInput = screen.getByLabelText(
+      /editProfilePage.profile.passwordSecurityTab.currentPassword/i
+    )
+    const newPasswordInput = screen.getByLabelText(/newPassword/i)
+    const retypePasswordInput = screen.getByLabelText(/retypePassword/i)
+    const saveButton = screen.getByText(
+      /editProfilePage.profile.passwordSecurityTab.savePassword/i
+    )
+  
+    for(const data of testData){
+      fireEvent.change(currentPasswordInput, {
+        target: { value: userDataMock.currentPassword }
+      })
+      fireEvent.change(newPasswordInput, {
+        target: { value: data } 
+      })
+      fireEvent.change(retypePasswordInput, {
+        target: { value: data }
+      })
+      
+      fireEvent.click(saveButton)
+      
+      await waitFor(() => {
+        expect(
+          screen.getByText(/common.errorMessages/i)
+        ).toBeInTheDocument()
+      })
+    }
+  })
 })

--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -235,7 +235,12 @@ describe('ChangePasswordModal', () => {
   })
 
   it('should display an error message for incorrect new password', async () => {
-    const testData = ['A1!', 'ABCDEFGHIJKabcdefghijk1234567890!@#$%^&*()_+?><', 'ABab12!', 'ABCDEFGabcdefg123456!@#$%^'];
+    const testData = [
+      'A1!',
+      'ABCDEFGHIJKabcdefghijk1234567890!@#$%^&*()_+?><',
+      'ABab12!',
+      'ABCDEFGabcdefg123456!@#$%^'
+    ]
     const currentPasswordInput = screen.getByLabelText(
       /editProfilePage.profile.passwordSecurityTab.currentPassword/i
     )
@@ -244,24 +249,22 @@ describe('ChangePasswordModal', () => {
     const saveButton = screen.getByText(
       /editProfilePage.profile.passwordSecurityTab.savePassword/i
     )
-  
-    for(const data of testData){
+
+    for (const data of testData) {
       fireEvent.change(currentPasswordInput, {
         target: { value: userDataMock.currentPassword }
       })
       fireEvent.change(newPasswordInput, {
-        target: { value: data } 
+        target: { value: data }
       })
       fireEvent.change(retypePasswordInput, {
         target: { value: data }
       })
-      
+
       fireEvent.click(saveButton)
-      
+
       await waitFor(() => {
-        expect(
-          screen.getByText(/common.errorMessages/i)
-        ).toBeInTheDocument()
+        expect(screen.getByText(/common.errorMessages/i)).toBeInTheDocument()
       })
     }
   })


### PR DESCRIPTION
Written test for inability to enter invalid data
1. Click on the “Change password” button.
Expected Results:
The mock-up “Change password” is opened.
2. Fill in the field “Current password” by current password.
3. Fill in the following fields for invalid data: “New Password”, Re-type new password”.:
- “A1!”
- “ABCDEFGHIJKabcdefghijk1234567890!@#$%^&*()_+?><”
- “ABab12!”
- “ABCDEFGabcdefg123456!@#$%^”
4. Click on the button “Save the password”
5, Expected Results:
The error messages will appear.

Test is successfully executed

![image](https://github.com/user-attachments/assets/31d29ad2-adab-4875-9dbb-d55c959a9821)
