### PR TITLE
(SP:) [Edit profile. Professional info] Verify that the user can't select the subject by typing invalid values in the "Category subject" field. #2825

### DIFF
--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -206,7 +206,7 @@ describe('AddProfessionalCategoryModal without initial value', () => {
       target: { value: 'Invalid Subject' }
     })
 
-    expect(professionalSubjects[0].value).not.toBe('Invalid Subject')
+    expect(professionalSubjects[0]).not.toHaveValue('Invalid Subject')
 
     const option = screen.queryByText('Invalid Subject')
     expect(option).not.toBeInTheDocument()

--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -194,6 +194,23 @@ describe('AddProfessionalCategoryModal without initial value', () => {
 
     expect(subjectAutocomplete).toBeDisabled()
   })
+
+  it('should prevent Tutor and Student from selecting invalid subjects', async () => {
+    const professionalSubjects = screen.getAllByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+
+    expect(professionalSubjects.length).toBeGreaterThan(0)
+
+    fireEvent.change(professionalSubjects[0], {
+      target: { value: 'Invalid Subject' }
+    })
+
+    expect(professionalSubjects[0].value).not.toBe('Invalid Subject')
+
+    const option = screen.queryByText('Invalid Subject')
+    expect(option).not.toBeInTheDocument()
+  })
 })
 
 describe('AddProfessionalCategoryModal with initial value', () => {


### PR DESCRIPTION
Added a test to ensure that Tutor and Student roles cannot input invalid values in the "Category subject" field on the Edit Profile > Professional Info tab > Professional Info tab modal. 