### PR TITLE
Now button disabled if user write incorrect password form 

### DIFF
--- a/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
+++ b/src/containers/edit-profile/password-security-tab/change-password-modal/ChangePasswordModal.tsx
@@ -142,6 +142,14 @@ const ChangePasswordModal = () => {
   const inputType = (isVisible: boolean) =>
     isVisible ? InputEnum.Text : InputEnum.Password
 
+  const isChangePasswordFormInvalid =
+    !data.password ||
+    !data.confirmPassword ||
+    !data.currentPassword ||
+    Boolean(errors.password) ||
+    Boolean(errors.confirmPassword) ||
+    Boolean(errors.currentPassword)
+
   return (
     <Box sx={styles.modalContainer}>
       <Box sx={styles.container}>
@@ -202,9 +210,7 @@ const ChangePasswordModal = () => {
               {t('common.cancel')}
             </Button>
             <Button
-              disabled={
-                !data.password || !data.confirmPassword || !data.currentPassword
-              }
+              disabled={isChangePasswordFormInvalid}
               size='md'
               sx={styles.saveButton}
               type={ButtonTypeEnum.Submit}

--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -233,4 +233,27 @@ describe('ChangePasswordModal', () => {
       expect(currentPasswordInput).toHaveValue('')
     })
   })
+
+  it('should show error when new password matches current password', () => {
+    const currentPasswordInput = screen.getByLabelText(/currentPassword/i)
+    const passwordInput = screen.getByLabelText(/newPassword/i)
+    const confirmPasswordInput = screen.getByLabelText(/retypePassword/i)
+    const saveButton = screen.getByText(/savePassword/i)
+
+    fireEvent.change(currentPasswordInput, {
+      target: { value: 'samePassword123' }
+    })
+    fireEvent.change(passwordInput, {
+      target: { value: 'samePassword123' }
+    })
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'samePassword123' }
+    })
+
+    fireEvent.click(saveButton)
+
+    expect(
+      screen.getByText(/common.errorMessages.currentAndNewPasswordsMatch/i)
+    ).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Added more password validity checks and made them a separate constant

Added a test for when the new password is equal to the old one 


RESULT:

1) When same password as before

<img width="733" alt="Знімок екрана 2025-04-12 о 12 19 45" src="https://github.com/user-attachments/assets/ee8625cf-e8e0-4d68-831c-259970564bdf" />

2) When new password

<img width="737" alt="Знімок екрана 2025-04-12 о 12 22 05" src="https://github.com/user-attachments/assets/c3c5b569-bdff-403a-b27c-196c45df01d5" />

