### PR TITLE
Added react-query to userProfileLoader

### DIFF
--- a/src/router/constants/crumbs.ts
+++ b/src/router/constants/crumbs.ts
@@ -1,6 +1,7 @@
 import { authRoutes } from '~/router/constants/authRoutes'
 import { guestRoutes } from '~/router/constants/guestRoutes'
 import { UserResponse } from '~/types'
+import { queryClient } from '~/plugins/queryClient'
 
 export const home = {
   name: 'breadCrumbs.home',
@@ -107,9 +108,15 @@ export const editQuiz = {
   path: authRoutes.myResources.editQuiz.route
 }
 
-export const userProfile = ({ data }: { data: UserResponse }) => ({
-  name: `${data.firstName} ${data.lastName}`
-})
+export const userProfile = (data: Pick<UserResponse, '_id' | 'role'>) => {
+  const userData = queryClient.getQueryData([
+    'user',
+    data._id,
+    data.role
+  ]) as UserResponse
+
+  return { name: `${userData.firstName} ${userData.lastName}` }
+}
 
 export const newQuestion = {
   name: 'breadCrumbs.newQuestion',

--- a/src/router/constants/loaders.ts
+++ b/src/router/constants/loaders.ts
@@ -1,12 +1,22 @@
-import { LoaderFunctionArgs, defer } from 'react-router-dom'
+import { LoaderFunctionArgs } from 'react-router-dom'
 import { userService } from '~/services/user-service'
 import { UserRoleEnum } from '~/types'
+import { queryClient } from '~/plugins/queryClient'
 
 export const userProfileLoader = async ({
   request,
   params
 }: LoaderFunctionArgs) => {
   const role = new URL(request.url).searchParams.get('role') as UserRoleEnum
-  const result = await userService.getUserById(params.id ?? '', role)
-  return defer({ data: result.data })
+  await queryClient.prefetchQuery({
+    queryKey: ['user', params.id, role],
+    queryFn: () =>
+      userService.getUserByIdWithBaseService(params.id ?? '', role),
+    staleTime: Infinity
+  })
+
+  return {
+    _id: params.id,
+    role
+  }
 }

--- a/tests/unit/router/loaders.spec.jsx
+++ b/tests/unit/router/loaders.spec.jsx
@@ -1,0 +1,87 @@
+import { vi } from 'vitest'
+import { userProfileLoader } from '~/router/constants/loaders'
+import { userProfile } from '~/router/constants/crumbs'
+import { userService } from '~/services/user-service'
+import { queryClient } from '~/plugins/queryClient'
+import { URLs } from '~/constants/request'
+
+const userId = '6748e02e1490ebab736edb94'
+const userRole = 'tutor'
+const mockUserData = {
+  _id: userId,
+  role: userRole,
+  firstName: 'John',
+  lastName: 'Smith',
+  email: 'john.smith@gmail.com'
+}
+
+const request = {
+  url: `https://mockurl${URLs.users.getUserById.replace(':id', userId)}?role=${userRole}`
+}
+const params = { id: userId }
+
+vi.mock('~/plugins/queryClient', () => ({
+  queryClient: {
+    prefetchQuery: vi.fn(),
+    getQueryData: vi.fn()
+  }
+}))
+
+vi.mock('~/services/user-service', () => ({
+  userService: {
+    getUserByIdWithBaseService: vi.fn()
+  }
+}))
+
+describe('userProfileLoader and userProfile tests', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call prefetchQuery with correct parameters', async () => {
+    await userProfileLoader({ request, params })
+
+    expect(queryClient.prefetchQuery).toHaveBeenCalledWith({
+      queryKey: ['user', userId, userRole],
+      queryFn: expect.any(Function),
+      staleTime: Infinity
+    })
+  })
+
+  it('should call getUserByIdWithBaseService with correct parameters', async () => {
+    await userProfileLoader({ request, params })
+
+    const prefetchQueryCall = vi.mocked(queryClient.prefetchQuery).mock
+      .calls[0][0]
+    await prefetchQueryCall.queryFn()
+
+    expect(userService.getUserByIdWithBaseService).toHaveBeenCalledWith(
+      userId,
+      userRole
+    )
+  })
+
+  it('should call getUserByIdWithBaseService without id', async () => {
+    await userProfileLoader({ request, params: { id: undefined } })
+
+    const prefetchQueryCall = vi.mocked(queryClient.prefetchQuery).mock
+      .calls[0][0]
+    await prefetchQueryCall.queryFn()
+
+    expect(userService.getUserByIdWithBaseService).toHaveBeenCalledWith(
+      '',
+      userRole
+    )
+  })
+
+  it('should retrieve user data from queryClient with correct query key', () => {
+    vi.mocked(queryClient.getQueryData).mockReturnValue(mockUserData)
+    userProfile({ _id: userId, role: userRole })
+
+    expect(queryClient.getQueryData).toHaveBeenCalledWith([
+      'user',
+      userId,
+      userRole
+    ])
+  })
+})


### PR DESCRIPTION
Added react-query to userProfileLoader. Used prefetchQuery function to fetch the query and put it in the cache, then handle function on user-profile route gets that data and renders crumb.

https://github.com/user-attachments/assets/79f3989d-949d-4782-a219-1bbcb42b45d7

