### PR TITLE
[Edit Tutor’s profile] Verify that error messages appear when the fields “Current password” and “New password” will enter only alphabetic characters #2774

### DIFF
--- a/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/ChangePasswordModal.spec.jsx
@@ -256,4 +256,29 @@ describe('ChangePasswordModal', () => {
       screen.getByText(/common.errorMessages.currentAndNewPasswordsMatch/i)
     ).toBeInTheDocument()
   })
+  it('should throw an error at entering alphabetic values', async () => {
+    const currentPasswordInput = screen.getByLabelText(
+      /editProfilePage.profile.passwordSecurityTab.currentPassword/i
+    )
+    const saveButton = screen.getByText(
+      /editProfilePage.profile.passwordSecurityTab.savePassword/i
+    )
+    fireEvent.change(currentPasswordInput, {
+      target: { value: 'ABCDabcdef' }
+    })
+    fireEvent.change(screen.getByLabelText(/newPassword/i), {
+      target: { value: 'ABCDabcdef' }
+    })
+    fireEvent.change(screen.getByLabelText(/retypePassword/i), {
+      target: { value: 'ABCDabcdef' }
+    })
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/common.errorMessages.passwordAlphabeticAndNumeric/i)
+      ).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
Click on the “Change password” button.
Expected Results:
The mock-up “Change password” is opened.

Fill in the fields “Current password” and “New password the next data:

ABCDabcdef
Click on the “Save the password” button.
Expected Results:
The field is highlighted in red, and a red error message appears under the field with the text “Password must contain at least one alphabetic, one numeric and one special character”.

Test Result:
![image](https://github.com/user-attachments/assets/8708ceea-c184-4b04-962b-b20729b6d7b1)
