### PR TITLE
[Edit profile. Profile]Verify that the tutor/student can change their saved native language to another language. #2731

### DIFF
--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.constants.js
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.constants.js
@@ -16,7 +16,7 @@ export const formDataMock = {
   firstName: '',
   lastName: '',
   mainSubjects: [],
-  nativeLanguage: 'English',
+  nativeLanguage: null,
   country: null,
   city: null,
   photo: 'photo.png',

--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.constants.js
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.constants.js
@@ -16,7 +16,7 @@ export const formDataMock = {
   firstName: '',
   lastName: '',
   mainSubjects: [],
-  nativeLanguage: null,
+  nativeLanguage: 'English',
   country: null,
   city: null,
   photo: 'photo.png',

--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -47,7 +47,7 @@ describe('ProfileTabForm', () => {
     URL.createObjectURL.mockReset()
   })
 
-  it('should handle the language input change', () => {
+  it('should update the native language after typing and selecting an option', () => {
     const newLanguageValue = 'Ukrainian'
     const languageField = screen.getByLabelText(
       'becomeTutor.languages.autocompleteLabel'
@@ -62,36 +62,34 @@ describe('ProfileTabForm', () => {
     expect(languageField.value).toBe(newLanguageValue)
   })
 
-  it('should allow changing the native language', async () => {
-    const newLanguage = 'German'
+  it('should display the initial native language value', () => {
     const languageField = screen.getByLabelText(
       'becomeTutor.languages.autocompleteLabel'
     )
+
     expect(languageField.value).toBe(initialLanguage)
+  })
 
+  it('should open the dropdown with all language options', async () => {
+    const languageField = screen.getByLabelText(
+      'becomeTutor.languages.autocompleteLabel'
+    )
     fireEvent.mouseDown(languageField)
-    await waitFor(() => {
-      const options = [
-        'English',
-        'Ukrainian',
-        'Polish',
-        'German',
-        'French',
-        'Spanish',
-        'Arabic'
-      ]
-      options.forEach(async (lang) => {
-        const option = await within(document.body).findByText(lang)
-        expect(option).toBeInTheDocument()
-      })
-    })
 
-    fireEvent.click(languageField)
-    fireEvent.change(languageField, { target: { value: newLanguage } })
-    const germanOption = screen.getByText(newLanguage)
-    fireEvent.click(germanOption)
+    const options = [
+      'English',
+      'Ukrainian',
+      'Polish',
+      'German',
+      'French',
+      'Spanish',
+      'Arabic'
+    ]
 
-    expect(languageField.value).toBe(newLanguage)
+    for (const lang of options) {
+      const option = await within(document.body).findByText(lang)
+      expect(option).toBeInTheDocument()
+    }
   })
 
   it('should clear the selected native language and change the value', async () => {

--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { renderWithProviders, TestSnackbar } from '~tests/test-utils'
 import { imageResize } from '~/utils/image-resize'
 import ProfileTabForm from '~/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm'
@@ -26,10 +26,15 @@ const props = {
 describe('ProfileTabForm', () => {
   URL.createObjectURL = vi.fn().mockReturnValue('photo')
 
+  const initialLanguage = 'English'
+  const propsWithInitialLanguage = {
+    ...props,
+    data: { ...formDataMock, nativeLanguage: initialLanguage }
+  }
   beforeEach(() => {
     renderWithProviders(
       <TestSnackbar>
-        <ProfileTabForm {...props} />
+        <ProfileTabForm {...propsWithInitialLanguage} />
       </TestSnackbar>
     )
   })
@@ -55,6 +60,38 @@ describe('ProfileTabForm', () => {
     fireEvent.click(option)
 
     expect(languageField.value).toBe(newLanguageValue)
+  })
+
+  it('should allow changing the native language', async () => {
+    const newLanguage = 'German'
+    const languageField = screen.getByLabelText(
+      'becomeTutor.languages.autocompleteLabel'
+    )
+    expect(languageField.value).toBe(initialLanguage)
+
+    fireEvent.mouseDown(languageField)
+    await waitFor(() => {
+      const options = [
+        'English',
+        'Ukrainian',
+        'Polish',
+        'German',
+        'French',
+        'Spanish',
+        'Arabic'
+      ]
+      options.forEach(async (lang) => {
+        const option = await within(document.body).findByText(lang)
+        expect(option).toBeInTheDocument()
+      })
+    })
+
+    fireEvent.click(languageField)
+    fireEvent.change(languageField, { target: { value: newLanguage } })
+    const germanOption = screen.getByText(newLanguage)
+    fireEvent.click(germanOption)
+
+    expect(languageField.value).toBe(newLanguage)
   })
 
   it('should clear the selected native language and change the value', async () => {

--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders, TestSnackbar } from '~tests/test-utils'
 import { imageResize } from '~/utils/image-resize'
 import ProfileTabForm from '~/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm'
@@ -82,7 +82,7 @@ describe('ProfileTabForm', () => {
     ]
 
     for (const lang of options) {
-      const option = await within(document.body).findByText(lang)
+      const option = await screen.findByText(lang)
       expect(option).toBeInTheDocument()
     }
   })

--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -26,15 +26,10 @@ const props = {
 describe('ProfileTabForm', () => {
   URL.createObjectURL = vi.fn().mockReturnValue('photo')
 
-  const initialLanguage = 'English'
-  const propsWithInitialLanguage = {
-    ...props,
-    data: { ...formDataMock, nativeLanguage: initialLanguage }
-  }
   beforeEach(() => {
     renderWithProviders(
       <TestSnackbar>
-        <ProfileTabForm {...propsWithInitialLanguage} />
+        <ProfileTabForm {...props} />
       </TestSnackbar>
     )
   })
@@ -67,7 +62,7 @@ describe('ProfileTabForm', () => {
       'becomeTutor.languages.autocompleteLabel'
     )
 
-    expect(languageField.value).toBe(initialLanguage)
+    expect(languageField.value).toBe(formDataMock.nativeLanguage)
   })
 
   it('should open the dropdown with all language options', async () => {

--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -62,7 +62,7 @@ describe('ProfileTabForm', () => {
       'becomeTutor.languages.autocompleteLabel'
     )
 
-    expect(languageField.value).toBe(formDataMock.nativeLanguage)
+    expect(languageField.value).toBe('English')
   })
 
   it('should open the dropdown with all language options', async () => {


### PR DESCRIPTION
Added tests for the ProfileTabForm component that cover updating the "native language" field:
- ensures the value updates correctly after input and selection
- verifies that the initial value is rendered as expected
- checks that all language options are available in the dropdown

![image](https://github.com/user-attachments/assets/cb1efb17-b22b-46d8-ac5b-06f578ce4eba)

