### PR TITLE
(SP:) [Edit profile. Professional info] Verify that the user can delete a subject in the "Your professional category" pop-up. 

### DIFF
--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -186,6 +186,68 @@ describe('AddProfessionalCategoryModal without initial value', () => {
 
     expect(submitButton).toBeDisabled()
   })
+  it('should allow to select and delete subject, disable save button, and clear field', async () => {
+    const categoryAutocomplete = screen.getByLabelText(
+      /editProfilePage.profile.professionalTab.mainStudyCategory/
+    )
+    const professionalSubjects = screen.getAllByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+
+    await selectOption(
+      categoryAutocomplete,
+      t(`categories.${titleToCamel('Cooking')}`, { defaultValue: 'Cooking' }),
+      'findByText'
+    )
+    expect(categoryAutocomplete).toHaveValue('Cooking')
+
+    const button = screen.getByText(
+      /editProfilePage.profile.professionalTab.addCategoryModal.addSubjectBtn/
+    )
+    fireEvent.click(button)
+
+    await act(() =>
+      fireEvent.change(professionalSubjects[0], {
+        target: { value: 'Gastronomy' }
+      })
+    )
+    expect(professionalSubjects[0].value).toBe('Gastronomy')
+
+    const deleteIcons = screen.getAllByTestId('DeleteIcon')
+    await act(() => fireEvent.click(deleteIcons[0]))
+
+    expect(screen.queryByDisplayValue('Gastronomy')).not.toBeInTheDocument()
+
+    const submitButton = screen.getByText(
+      /editProfilePage.profile.professionalTab.addCategoryModal.submitBtn/
+    ).parentNode
+    expect(submitButton).toBeDisabled()
+
+    await selectOption(
+      categoryAutocomplete,
+      t(`categories.${titleToCamel('Cooking')}`, { defaultValue: 'Cooking' }),
+      'findByDisplayValue'
+    )
+
+    await act(() =>
+      fireEvent.change(professionalSubjects[0], {
+        target: { value: 'Updated Gastronomy' }
+      })
+    )
+    expect(professionalSubjects[0].value).toBe('Updated Gastronomy')
+
+    const clearButton = screen.getByLabelText('Clear')
+    fireEvent.click(clearButton)
+
+    fireEvent.click(button)
+
+    const updatedProfessionalSubjects = screen.getAllByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+    expect(updatedProfessionalSubjects[0].value).toBe('')
+
+    expect(submitButton).toBeDisabled()
+  })
 
   it('subject field should be disabled if category is disabled', async () => {
     const subjectAutocomplete = screen.getByLabelText(

--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -186,7 +186,8 @@ describe('AddProfessionalCategoryModal without initial value', () => {
 
     expect(submitButton).toBeDisabled()
   })
-  it('should allow to select and delete subject, disable save button, and clear field', async () => {
+
+  it('should allow clearing the field', async () => {
     const categoryAutocomplete = screen.getByLabelText(
       /editProfilePage.profile.professionalTab.mainStudyCategory/
     )
@@ -199,7 +200,6 @@ describe('AddProfessionalCategoryModal without initial value', () => {
       t(`categories.${titleToCamel('Cooking')}`, { defaultValue: 'Cooking' }),
       'findByText'
     )
-    expect(categoryAutocomplete).toHaveValue('Cooking')
 
     const button = screen.getByText(
       /editProfilePage.profile.professionalTab.addCategoryModal.addSubjectBtn/
@@ -211,42 +211,22 @@ describe('AddProfessionalCategoryModal without initial value', () => {
         target: { value: 'Gastronomy' }
       })
     )
-    expect(professionalSubjects[0].value).toBe('Gastronomy')
-
-    const deleteIcons = screen.getAllByTestId('DeleteIcon')
-    await act(() => fireEvent.click(deleteIcons[0]))
-
-    expect(screen.queryByDisplayValue('Gastronomy')).not.toBeInTheDocument()
-
-    const submitButton = screen.getByText(
-      /editProfilePage.profile.professionalTab.addCategoryModal.submitBtn/
-    ).parentNode
-    expect(submitButton).toBeDisabled()
-
-    await selectOption(
-      categoryAutocomplete,
-      t(`categories.${titleToCamel('Cooking')}`, { defaultValue: 'Cooking' }),
-      'findByDisplayValue'
-    )
-
-    await act(() =>
-      fireEvent.change(professionalSubjects[0], {
-        target: { value: 'Updated Gastronomy' }
-      })
-    )
-    expect(professionalSubjects[0].value).toBe('Updated Gastronomy')
 
     const clearButton = screen.getByLabelText('Clear')
     fireEvent.click(clearButton)
-
     fireEvent.click(button)
 
     const updatedProfessionalSubjects = screen.getAllByLabelText(
       /editProfilePage.profile.professionalTab.subject/
     )
     expect(updatedProfessionalSubjects[0].value).toBe('')
+  })
 
-    expect(submitButton).toBeDisabled()
+  it('should remove a subject from the list', async () => {
+    const deleteIcons = screen.getAllByTestId('DeleteIcon')
+    await act(() => fireEvent.click(deleteIcons[0]))
+
+    expect(screen.queryByDisplayValue('Gastronomy')).not.toBeInTheDocument()
   })
 
   it('subject field should be disabled if category is disabled', async () => {

--- a/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/add-professional-category-modal/AddProfessionalCategoryModal.spec.jsx
@@ -120,7 +120,7 @@ describe('AddProfessionalCategoryModal without initial value', () => {
     expect(professionalSubjects).toHaveLength(3)
   })
 
-  it('should update professional category value in autocomplete and load subjects', async () => {
+  it('should update professional category value in autocomplete,load subjects and allow clearing the field ', async () => {
     const categoryAutocomplete = screen.getByLabelText(
       /editProfilePage.profile.professionalTab.mainStudyCategory/
     )
@@ -137,7 +137,18 @@ describe('AddProfessionalCategoryModal without initial value', () => {
         target: { value: 'Varenychky' }
       })
     )
+    const button = screen.getByText(
+      /editProfilePage.profile.professionalTab.addCategoryModal.addSubjectBtn/
+    )
     expect(professionalSubjects.value).toBe('Varenychky')
+    const clearButton = screen.getByLabelText('Clear')
+    fireEvent.click(clearButton)
+    fireEvent.click(button)
+
+    const updatedProfessionalSubjects = screen.getAllByLabelText(
+      /editProfilePage.profile.professionalTab.subject/
+    )
+    expect(updatedProfessionalSubjects[0].value).toBe('')
   })
 
   it('should update only the subject with matching index and not others', async () => {
@@ -185,41 +196,6 @@ describe('AddProfessionalCategoryModal without initial value', () => {
     )
 
     expect(submitButton).toBeDisabled()
-  })
-
-  it('should allow clearing the field', async () => {
-    const categoryAutocomplete = screen.getByLabelText(
-      /editProfilePage.profile.professionalTab.mainStudyCategory/
-    )
-    const professionalSubjects = screen.getAllByLabelText(
-      /editProfilePage.profile.professionalTab.subject/
-    )
-
-    await selectOption(
-      categoryAutocomplete,
-      t(`categories.${titleToCamel('Cooking')}`, { defaultValue: 'Cooking' }),
-      'findByText'
-    )
-
-    const button = screen.getByText(
-      /editProfilePage.profile.professionalTab.addCategoryModal.addSubjectBtn/
-    )
-    fireEvent.click(button)
-
-    await act(() =>
-      fireEvent.change(professionalSubjects[0], {
-        target: { value: 'Gastronomy' }
-      })
-    )
-
-    const clearButton = screen.getByLabelText('Clear')
-    fireEvent.click(clearButton)
-    fireEvent.click(button)
-
-    const updatedProfessionalSubjects = screen.getAllByLabelText(
-      /editProfilePage.profile.professionalTab.subject/
-    )
-    expect(updatedProfessionalSubjects[0].value).toBe('')
   })
 
   it('should remove a subject from the list', async () => {


### PR DESCRIPTION
Added a unit test to cover subject deletion functionality in the "Your professional category" popup.
Before:
![image](https://github.com/user-attachments/assets/83f56165-53a5-4552-9530-ac084e6b32d4)
After: 

![image](https://github.com/user-attachments/assets/c58a57fc-bc23-4281-80b5-d28900fcd633)

