### PR TITLE
[Edit profile. Profile]Verify that the tutor/student couldn't save the last name only with space characters

### DIFF
--- a/tests/unit/containers/edit-profile/ProfileTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/ProfileTab.spec.jsx
@@ -233,4 +233,35 @@ describe('ProfileTab', () => {
     expect(errorMessage).toBeInTheDocument()
     expect(lastNameInput).toHaveValue(tooManyCharacters)
   })
+
+  it('should show an error when "Last name" empty', async () => {
+    renderWithMockData()
+
+    const lastNameInput = screen.getByPlaceholderText('lastName')
+
+    await userEvent.clear(lastNameInput)
+    expect(lastNameInput.value).toBe('')
+
+    const errorMessage = await screen.findByText(
+      /common.errorMessages.emptyField/i
+    )
+    expect(errorMessage).toBeInTheDocument()
+    expect(lastNameInput).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('should show an error when "Last name" contains only spaces', async () => {
+    renderWithMockData()
+
+    const lastNameInput = screen.getByPlaceholderText('lastName')
+
+    await userEvent.clear(lastNameInput)
+    await userEvent.type(lastNameInput, '   ')
+    expect(lastNameInput.value).toBe('   ')
+
+    const errorMessage = await screen.findByText(
+      /common.errorMessages.hasOnlySpaces/i
+    )
+    expect(errorMessage).toBeInTheDocument()
+    expect(lastNameInput).toHaveAttribute('aria-invalid', 'true')
+  })
 })


### PR DESCRIPTION
**Added tests for the validation of the "Last name" text field in the "ProfileTab" component.**

_Although these tests did not increase coverage, they clearly target important edge cases in form validation, improving confidence in the component's behavior._

![Screenshot 2025-04-15 181351](https://github.com/user-attachments/assets/51d497d9-d4a2-409c-8ffd-18c593a1b38f)
