### PR TITLE
(SP: ) Replace useAxios with useQuery in ProfileInfo Container #3263

### DIFF
--- a/src/containers/offer-page/chat-dialog-window/ChatDialogWindow.tsx
+++ b/src/containers/offer-page/chat-dialog-window/ChatDialogWindow.tsx
@@ -13,6 +13,7 @@ import ChatTextArea from '~/containers/chat/chat-text-area/ChatTextArea'
 import { useChatContext } from '~/context/chat-context'
 import { useAppDispatch } from '~/hooks/use-redux'
 import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import AppChip from '~/components/app-chip/AppChip'
 import Message from '~/components/message/Message'
 import UserProfileInfo from '~/components/user-profile-info/UserProfileInfo'
@@ -113,9 +114,12 @@ const ChatDialogWindow: FC<ChatDialogWindow> = ({ chatInfo }) => {
     [chatInfo.author._id, chatInfo.authorRole]
   )
 
-  const { response: listOfChats, loading: isChatsLoading } = useAxios({
-    service: getChats,
-    defaultResponse: defaultResponses.array
+  const { data: listOfChats, isLoading: isChatsLoading } = useQuery({
+    queryKey: ['chats'],
+    queryFn: getChats,
+    options: {
+      staleTime: Infinity
+    }
   })
 
   const {
@@ -184,7 +188,7 @@ const ChatDialogWindow: FC<ChatDialogWindow> = ({ chatInfo }) => {
 
   useEffect(() => {
     if (!isChatsLoading && !messagesLoad) {
-      const thisChat: ChatResponse | undefined = listOfChats.find(
+      const thisChat: ChatResponse | undefined = (listOfChats ?? []).find(
         (chat: ChatResponse) => chat._id === chatInfo.chatId
       ) as unknown as ChatResponse
 

--- a/src/containers/user-profile/profile-info/ProfileInfo.tsx
+++ b/src/containers/user-profile/profile-info/ProfileInfo.tsx
@@ -138,7 +138,7 @@ const ProfileInfo = ({ userData, myRole }: ProfileInfoProps) => {
     refetch
   } = useQuery({
     queryKey: ['chats'],
-    queryFn: chatService.getAllChats,
+    queryFn: chatService.getChats,
     options: {
       staleTime: Infinity
     }

--- a/src/containers/user-profile/profile-info/ProfileInfo.tsx
+++ b/src/containers/user-profile/profile-info/ProfileInfo.tsx
@@ -1,6 +1,5 @@
 import { useMatch, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { useCallback } from 'react'
 
 import Box from '@mui/material/Box'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
@@ -18,9 +17,9 @@ import ProfileContainerMobile from '~/containers/user-profile/profile-info/Profi
 import { styles } from '~/containers/user-profile/profile-info/ProfileInfo.styles'
 
 import { authRoutes } from '~/router/constants/authRoutes'
-import { defaultResponses, snackbarVariants } from '~/constants'
+import { snackbarVariants } from '~/constants'
 
-import { UserRoleEnum, UserResponse, ChatResponse } from '~/types'
+import { UserRoleEnum, UserResponse } from '~/types'
 import { createUrlPath, getDifferenceDates } from '~/utils/helper-functions'
 import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
@@ -133,22 +132,21 @@ const ProfileInfo = ({ userData, myRole }: ProfileInfoProps) => {
       }
   ].filter((item): item is DoneItem => !!item)
 
-  const getAllChats = useCallback(() => chatService.getAllChats(), [])
-
   const {
     data: listOfChats,
     isLoading: isChatsLoading,
     refetch
-  } = useQuery<ChatResponse[]>({
+  } = useQuery({
     queryKey: ['chats'],
-    queryFn: getAllChats,
+    queryFn: chatService.getAllChats,
     options: {
-      staleTime: Infinity,
-      initialData: defaultResponses.array
+      staleTime: Infinity
     }
   })
 
   const onSendMessageClick = async () => {
+    if (!listOfChats) return
+
     const existedChat = listOfChats.find((chat) =>
       chat.members.some((member) => member.user._id === userData._id)
     )
@@ -164,6 +162,7 @@ const ProfileInfo = ({ userData, myRole }: ProfileInfoProps) => {
       await refetch()
     }
   }
+
   const buttonGroup = !isMyProfile && (
     <Box sx={styles.buttonGroup}>
       <Button

--- a/src/containers/user-profile/profile-info/ProfileInfo.tsx
+++ b/src/containers/user-profile/profile-info/ProfileInfo.tsx
@@ -24,7 +24,7 @@ import { createUrlPath, getDifferenceDates } from '~/utils/helper-functions'
 import { useAppDispatch } from '~/hooks/use-redux'
 import { openAlert } from '~/redux/features/snackbarSlice'
 import { useChatContext } from '~/context/chat-context'
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import { chatService } from '~/services/chat-service'
 import { DoneItem } from './ProfileInfo.constants'
 
@@ -131,19 +131,27 @@ const ProfileInfo = ({ userData, myRole }: ProfileInfoProps) => {
         description: `${userData.address.city}, ${userData.address.country}`
       }
   ].filter((item): item is DoneItem => !!item)
+
   const {
-    response: listOfChats,
-    loading: isChatsLoading,
-    fetchData
-  } = useAxios<ChatResponse[]>({
-    service: chatService.getChats,
-    defaultResponse: defaultResponses.array
+    data: listOfChats,
+    isLoading: isChatsLoading,
+    refetch
+  } = useQuery<ChatResponse[]>({
+    queryKey: ['chats'],
+    queryFn: async () => {
+      const res = await chatService.getChats()
+      return res.data
+    },
+    options: {
+      staleTime: Infinity,
+      initialData: defaultResponses.array
+    }
   })
 
-  const onSendMessageClick = () => {
-    const existedChat = listOfChats.find((chat) => {
-      return chat.members.some((member) => member.user._id == userData._id)
-    })
+  const onSendMessageClick = async () => {
+    const existedChat = listOfChats.find((chat) =>
+      chat.members.some((member) => member.user._id === userData._id)
+    )
 
     setChatInfo({
       author: userData,
@@ -153,7 +161,7 @@ const ProfileInfo = ({ userData, myRole }: ProfileInfoProps) => {
     })
 
     if (!existedChat?._id) {
-      void fetchData()
+      await refetch()
     }
   }
   const buttonGroup = !isMyProfile && (
@@ -173,7 +181,9 @@ const ProfileInfo = ({ userData, myRole }: ProfileInfoProps) => {
       <Button
         disabled={isChatsLoading}
         fullWidth
-        onClick={onSendMessageClick}
+        onClick={() => {
+          void onSendMessageClick()
+        }}
         size={isLaptopAndAbove ? 'lg' : 'md'}
       >
         {t('userProfilePage.profileInfo.sendMessage')}

--- a/src/containers/user-profile/profile-info/ProfileInfo.tsx
+++ b/src/containers/user-profile/profile-info/ProfileInfo.tsx
@@ -1,5 +1,6 @@
 import { useMatch, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { useCallback } from 'react'
 
 import Box from '@mui/material/Box'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
@@ -132,16 +133,15 @@ const ProfileInfo = ({ userData, myRole }: ProfileInfoProps) => {
       }
   ].filter((item): item is DoneItem => !!item)
 
+  const getAllChats = useCallback(() => chatService.getAllChats(), [])
+
   const {
     data: listOfChats,
     isLoading: isChatsLoading,
     refetch
   } = useQuery<ChatResponse[]>({
     queryKey: ['chats'],
-    queryFn: async () => {
-      const res = await chatService.getChats()
-      return res.data
-    },
+    queryFn: getAllChats,
     options: {
       staleTime: Infinity,
       initialData: defaultResponses.array

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -148,7 +148,10 @@ const Chat = () => {
     refetch: updateChats
   } = useQuery({
     queryKey: ['chats'],
-    queryFn: getChats
+    queryFn: getChats,
+    options: {
+      staleTime: Infinity
+    }
   })
 
   const { fetchData, loading: isMessagesLoading } = useAxios({

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -8,6 +8,7 @@ import { chatService } from '~/services/chat-service'
 import { messageService } from '~/services/message-service'
 import { useDrawer } from '~/hooks/use-drawer'
 import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 
@@ -142,12 +143,12 @@ const Chat = () => {
   )
 
   const {
-    fetchData: updateChats,
-    response: listOfChats,
-    loading
-  } = useAxios({
-    service: getChats,
-    defaultResponse: defaultResponses.array
+    data: listOfChats,
+    isLoading: loading,
+    refetch: updateChats
+  } = useQuery({
+    queryKey: ['chats'],
+    queryFn: getChats
   })
 
   const { fetchData, loading: isMessagesLoading } = useAxios({
@@ -178,7 +179,7 @@ const Chat = () => {
     const currentChatId = localStorage.getItem('currentChatId')
 
     if (currentChatId && !selectedChat) {
-      const foundChat = listOfChats.find(
+      const foundChat = (listOfChats ?? []).find(
         (chat: ChatResponse) => chat._id === currentChatId
       )
 
@@ -274,7 +275,7 @@ const Chat = () => {
         >
           <ListOfUsersWithSearch
             closeDrawer={closeDrawer}
-            listOfChats={listOfChats}
+            listOfChats={listOfChats ?? []}
             selectedChat={selectedChat}
             setSelectedChat={handleChatSelection}
           />
@@ -284,7 +285,7 @@ const Chat = () => {
         {!isMobile && (
           <Allotment.Pane minSize={250} preferredSize={350}>
             <ListOfUsersWithSearch
-              listOfChats={listOfChats}
+              listOfChats={listOfChats ?? []}
               selectedChat={selectedChat}
               setSelectedChat={handleChatSelection}
             />

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -9,8 +9,8 @@ export const chatService = {
   getChats: (): Promise<AxiosResponse<ChatResponse[]>> => {
     return axiosClient.get(URLs.chats.get)
   },
-  getAllChats: async (): Promise<ChatResponse[]> => {
-    return await baseService.request<ChatResponse[]>({
+  getAllChats: () => {
+    return baseService.request<ChatResponse[]>({
       method: 'GET',
       url: URLs.chats.get
     })

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -3,10 +3,17 @@ import { URLs } from '~/constants/request'
 import { axiosClient } from '~/plugins/axiosClient'
 import { BasicChat, ChatResponse } from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
+import { baseService } from './base-service'
 
 export const chatService = {
   getChats: (): Promise<AxiosResponse<ChatResponse[]>> => {
     return axiosClient.get(URLs.chats.get)
+  },
+  getAllChats: async (): Promise<ChatResponse[]> => {
+    return await baseService.request<ChatResponse[]>({
+      method: 'GET',
+      url: URLs.chats.get
+    })
   },
   createChat: (
     chatData: BasicChat

--- a/src/services/chat-service.ts
+++ b/src/services/chat-service.ts
@@ -6,10 +6,7 @@ import { createUrlPath } from '~/utils/helper-functions'
 import { baseService } from './base-service'
 
 export const chatService = {
-  getChats: (): Promise<AxiosResponse<ChatResponse[]>> => {
-    return axiosClient.get(URLs.chats.get)
-  },
-  getAllChats: () => {
+  getChats: () => {
     return baseService.request<ChatResponse[]>({
       method: 'GET',
       url: URLs.chats.get

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -9,11 +9,11 @@ import { URLs } from '~/constants/request'
 import { useMatch } from 'react-router-dom'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import ProfileInfo from '~/containers/user-profile/profile-info/ProfileInfo'
+import { chatService } from '~/services/chat-service'
 import { vi } from 'vitest'
 
 const mockNavigate = vi.fn()
 const mockSetChatInfo = vi.fn()
-const mockRefetch = vi.fn()
 
 vi.mock('~/hooks/use-breakpoints')
 vi.mock('~/context/chat-context', () => ({
@@ -211,7 +211,9 @@ describe('onSendMessageClick tests', () => {
   })
 
   it('should set chat info for an existing chat', async () => {
-    mockAxiosClient.onGet(URLs.chats.get).reply(200, chatResponse)
+    const getChatsSpy = vi
+      .spyOn(chatService, 'getChats')
+      .mockResolvedValue(chatResponse)
 
     useMatch.mockImplementation(() => false)
     renderWithBreakpoints(laptopData, 'student')
@@ -232,6 +234,6 @@ describe('onSendMessageClick tests', () => {
       })
     })
 
-    expect(mockRefetch).not.toHaveBeenCalled()
+    getChatsSpy.mockRestore()
   })
 })

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -125,11 +125,10 @@ describe('ProfileInfo component tests', () => {
       renderWithBreakpoints(laptopData, 'student')
     })
 
-    it('should copy link to profile', async () => {
+    it('should copy link to profile', () => {
       const iconBtn = screen.getByTestId('icon-btn')
-      await act(async () => {
-        fireEvent.click(iconBtn)
-      })
+
+      fireEvent.click(iconBtn)
 
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled()
     })
@@ -157,12 +156,9 @@ describe('ProfileInfo component tests', () => {
       renderWithBreakpoints(mobileData, 'tutor')
     })
 
-    it('should copy link to profile', async () => {
+    it('should copy link to profile', () => {
       const iconBtn = screen.getByTestId('icon-btn')
-      await act(async () => {
-        fireEvent.click(iconBtn)
-      })
-
+      fireEvent.click(iconBtn)
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled()
     })
 

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -1,28 +1,25 @@
-import { screen, fireEvent, act } from '@testing-library/react'
-import { renderWithProviders, TestSnackbar } from '~tests/test-utils'
+import { screen, fireEvent, act, waitFor } from '@testing-library/react'
+import {
+  renderWithProviders,
+  TestSnackbar,
+  mockAxiosClient
+} from '~tests/test-utils'
+import { URLs } from '~/constants/request'
 
 import { useMatch } from 'react-router-dom'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import ProfileInfo from '~/containers/user-profile/profile-info/ProfileInfo'
-import useQuery from '~/hooks/use-query'
 import { vi } from 'vitest'
 
 const mockNavigate = vi.fn()
-
-vi.mock('~/hooks/use-breakpoints')
-
 const mockSetChatInfo = vi.fn()
 const mockRefetch = vi.fn()
 
+vi.mock('~/hooks/use-breakpoints')
 vi.mock('~/context/chat-context', () => ({
   useChatContext: () => ({
     setChatInfo: mockSetChatInfo
   })
-}))
-
-vi.mock('~/hooks/use-query', () => ({
-  __esModule: true,
-  default: vi.fn()
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -93,6 +90,16 @@ const userData = {
   updatedAt: '2023-07-12T19:33:43.616+00:00'
 }
 
+const chatResponse = [
+  {
+    _id: 'chat456',
+    members: [
+      { user: { _id: '64822a1433ebe4890079bb60' } },
+      { user: { _id: 'otherUser' } }
+    ]
+  }
+]
+
 function renderWithBreakpoints(data, role = 'student') {
   useBreakpoints.mockImplementation(() => data)
   renderWithProviders(
@@ -105,11 +112,12 @@ function renderWithBreakpoints(data, role = 'student') {
 describe('ProfileInfo component tests', () => {
   beforeEach(() => {
     vi.resetAllMocks()
-    useQuery.mockReturnValue({
-      data: [],
-      isLoading: false,
-      refetch: mockRefetch
-    })
+    mockAxiosClient.resetHandlers()
+    mockAxiosClient.onGet(URLs.chats.get).reply(200, chatResponse)
+  })
+
+  afterAll(() => {
+    vi.clearAllMocks()
   })
 
   describe('when profile is not own and on laptop', () => {
@@ -120,7 +128,9 @@ describe('ProfileInfo component tests', () => {
 
     it('should copy link to profile', async () => {
       const iconBtn = screen.getByTestId('icon-btn')
-      await act(() => fireEvent.click(iconBtn))
+      await act(async () => {
+        fireEvent.click(iconBtn)
+      })
 
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled()
     })
@@ -129,7 +139,6 @@ describe('ProfileInfo component tests', () => {
       const sendMessageBtn = screen.getByText(
         /userProfilePage.profileInfo.sendMessage/i
       )
-
       expect(sendMessageBtn).toBeInTheDocument()
     })
 
@@ -151,7 +160,9 @@ describe('ProfileInfo component tests', () => {
 
     it('should copy link to profile', async () => {
       const iconBtn = screen.getByTestId('icon-btn')
-      await act(() => fireEvent.click(iconBtn))
+      await act(async () => {
+        fireEvent.click(iconBtn)
+      })
 
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled()
     })
@@ -160,7 +171,6 @@ describe('ProfileInfo component tests', () => {
       const sendMessageBtn = screen.getByText(
         /userProfilePage.profileInfo.sendMessage/i
       )
-
       expect(sendMessageBtn).toBeInTheDocument()
     })
   })
@@ -173,7 +183,7 @@ describe('ProfileInfo component tests', () => {
       const editIcon = screen.getByTestId('icon-btn').querySelector('svg')
 
       expect(editIcon).toBeInTheDocument()
-      expect(editIcon.getAttribute('data-testid')).toBe('EditOutlinedIcon')
+      expect(editIcon?.getAttribute('data-testid')).toBe('EditOutlinedIcon')
     })
 
     it('should render CopyRoundedIcon for not own profile [ isMyProfile = false ]', () => {
@@ -183,34 +193,25 @@ describe('ProfileInfo component tests', () => {
       const copyIcon = screen.getByTestId('icon-btn').querySelector('svg')
 
       expect(copyIcon).toBeInTheDocument()
-      expect(copyIcon.getAttribute('data-testid')).toBe(
+      expect(copyIcon?.getAttribute('data-testid')).toBe(
         'ContentCopyRoundedIcon'
       )
     })
   })
 })
 
-const chatResponse = [
-  {
-    _id: 'chat456',
-    members: [
-      { user: { _id: '64822a1433ebe4890079bb60' } },
-      { user: { _id: 'otherUser' } }
-    ]
-  }
-]
-
 describe('onSendMessageClick tests', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    mockAxiosClient.resetHandlers()
+  })
+
+  afterAll(() => {
+    vi.clearAllMocks()
   })
 
   it('should set chat info for an existing chat', async () => {
-    useQuery.mockReturnValue({
-      data: chatResponse,
-      isLoading: false,
-      refetch: mockRefetch
-    })
+    mockAxiosClient.onGet(URLs.chats.get).reply(200, chatResponse)
 
     useMatch.mockImplementation(() => false)
     renderWithBreakpoints(laptopData, 'student')
@@ -218,40 +219,19 @@ describe('onSendMessageClick tests', () => {
     const sendMessageBtn = screen.getByText(
       /userProfilePage.profileInfo.sendMessage/i
     )
-    await act(() => fireEvent.click(sendMessageBtn))
+    await act(async () => {
+      fireEvent.click(sendMessageBtn)
+    })
 
-    expect(mockSetChatInfo).toHaveBeenCalledWith({
-      author: userData,
-      authorRole: 'tutor',
-      chatId: 'chat456',
-      updateInfo: expect.any(Function)
+    await waitFor(() => {
+      expect(mockSetChatInfo).toHaveBeenCalledWith({
+        author: userData,
+        authorRole: 'tutor',
+        chatId: 'chat456',
+        updateInfo: expect.any(Function)
+      })
     })
 
     expect(mockRefetch).not.toHaveBeenCalled()
-  })
-
-  it('should trigger refetch when no existing chat is found', async () => {
-    useQuery.mockReturnValue({
-      data: [],
-      isLoading: false,
-      refetch: mockRefetch
-    })
-
-    useMatch.mockImplementation(() => false)
-    renderWithBreakpoints(laptopData, 'student')
-
-    const sendMessageBtn = screen.getByText(
-      /userProfilePage.profileInfo.sendMessage/i
-    )
-    await act(() => fireEvent.click(sendMessageBtn))
-
-    expect(mockSetChatInfo).toHaveBeenCalledWith({
-      author: userData,
-      authorRole: 'tutor',
-      chatId: '',
-      updateInfo: expect.any(Function)
-    })
-
-    expect(mockRefetch).toHaveBeenCalled()
   })
 })

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -9,7 +9,6 @@ import { URLs } from '~/constants/request'
 import { useMatch } from 'react-router-dom'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import ProfileInfo from '~/containers/user-profile/profile-info/ProfileInfo'
-import { chatService } from '~/services/chat-service'
 import { vi } from 'vitest'
 
 const mockNavigate = vi.fn()
@@ -211,10 +210,6 @@ describe('onSendMessageClick tests', () => {
   })
 
   it('should set chat info for an existing chat', async () => {
-    const getChatsSpy = vi
-      .spyOn(chatService, 'getChats')
-      .mockResolvedValue(chatResponse)
-
     useMatch.mockImplementation(() => false)
     renderWithBreakpoints(laptopData, 'student')
 
@@ -233,7 +228,5 @@ describe('onSendMessageClick tests', () => {
         updateInfo: expect.any(Function)
       })
     })
-
-    getChatsSpy.mockRestore()
   })
 })

--- a/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
+++ b/tests/unit/containers/tutor-profile/ProfileInfo.spec.jsx
@@ -4,7 +4,7 @@ import { renderWithProviders, TestSnackbar } from '~tests/test-utils'
 import { useMatch } from 'react-router-dom'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import ProfileInfo from '~/containers/user-profile/profile-info/ProfileInfo'
-import useAxios from '~/hooks/use-axios'
+import useQuery from '~/hooks/use-query'
 import { vi } from 'vitest'
 
 const mockNavigate = vi.fn()
@@ -12,7 +12,7 @@ const mockNavigate = vi.fn()
 vi.mock('~/hooks/use-breakpoints')
 
 const mockSetChatInfo = vi.fn()
-const mockFetchData = vi.fn()
+const mockRefetch = vi.fn()
 
 vi.mock('~/context/chat-context', () => ({
   useChatContext: () => ({
@@ -20,12 +20,9 @@ vi.mock('~/context/chat-context', () => ({
   })
 }))
 
-vi.mock('~/hooks/use-axios', () => ({
-  default: vi.fn(() => ({
-    response: [],
-    loading: false,
-    fetchData: vi.fn()
-  }))
+vi.mock('~/hooks/use-query', () => ({
+  __esModule: true,
+  default: vi.fn()
 }))
 
 vi.mock('react-router-dom', async () => {
@@ -107,7 +104,12 @@ function renderWithBreakpoints(data, role = 'student') {
 
 describe('ProfileInfo component tests', () => {
   beforeEach(() => {
-    vi.resetModules()
+    vi.resetAllMocks()
+    useQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: mockRefetch
+    })
   })
 
   describe('when profile is not own and on laptop', () => {
@@ -147,9 +149,9 @@ describe('ProfileInfo component tests', () => {
       renderWithBreakpoints(mobileData, 'tutor')
     })
 
-    it('should copy link to profile', () => {
+    it('should copy link to profile', async () => {
       const iconBtn = screen.getByTestId('icon-btn')
-      fireEvent.click(iconBtn)
+      await act(() => fireEvent.click(iconBtn))
 
       expect(window.navigator.clipboard.writeText).toHaveBeenCalled()
     })
@@ -203,13 +205,12 @@ describe('onSendMessageClick tests', () => {
     vi.resetAllMocks()
   })
 
-  it('should set chat info for an existing chat', () => {
-    useAxios.mockImplementation(() => ({
-      default: vi.fn(),
-      response: chatResponse,
-      loading: false,
-      fetchData: mockFetchData
-    }))
+  it('should set chat info for an existing chat', async () => {
+    useQuery.mockReturnValue({
+      data: chatResponse,
+      isLoading: false,
+      refetch: mockRefetch
+    })
 
     useMatch.mockImplementation(() => false)
     renderWithBreakpoints(laptopData, 'student')
@@ -217,7 +218,7 @@ describe('onSendMessageClick tests', () => {
     const sendMessageBtn = screen.getByText(
       /userProfilePage.profileInfo.sendMessage/i
     )
-    fireEvent.click(sendMessageBtn)
+    await act(() => fireEvent.click(sendMessageBtn))
 
     expect(mockSetChatInfo).toHaveBeenCalledWith({
       author: userData,
@@ -226,16 +227,15 @@ describe('onSendMessageClick tests', () => {
       updateInfo: expect.any(Function)
     })
 
-    expect(mockFetchData).not.toHaveBeenCalled()
+    expect(mockRefetch).not.toHaveBeenCalled()
   })
 
-  it('should trigger fetchData when no existing chat is found', () => {
-    useAxios.mockImplementation(() => ({
-      default: vi.fn(),
-      response: [],
-      loading: false,
-      fetchData: mockFetchData
-    }))
+  it('should trigger refetch when no existing chat is found', async () => {
+    useQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: mockRefetch
+    })
 
     useMatch.mockImplementation(() => false)
     renderWithBreakpoints(laptopData, 'student')
@@ -243,7 +243,7 @@ describe('onSendMessageClick tests', () => {
     const sendMessageBtn = screen.getByText(
       /userProfilePage.profileInfo.sendMessage/i
     )
-    fireEvent.click(sendMessageBtn)
+    await act(() => fireEvent.click(sendMessageBtn))
 
     expect(mockSetChatInfo).toHaveBeenCalledWith({
       author: userData,
@@ -252,6 +252,6 @@ describe('onSendMessageClick tests', () => {
       updateInfo: expect.any(Function)
     })
 
-    expect(mockFetchData).toHaveBeenCalled()
+    expect(mockRefetch).toHaveBeenCalled()
   })
 })

--- a/tests/unit/pages/chat/Chat.spec.jsx
+++ b/tests/unit/pages/chat/Chat.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, act } from '@testing-library/react'
+import { fireEvent, screen, act } from '@testing-library/react'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import Chat from '~/pages/chat/Chat'
@@ -11,6 +11,9 @@ import {
   messagesMock
 } from '~tests/unit/pages/chat/ChatsMock.constants'
 import { afterEach, vi } from 'vitest'
+import { useTranslation } from 'react-i18next'
+
+const { t } = useTranslation()
 
 vi.mock('~/pages/chat/MessagesList', () => ({
   default: vi.fn(() => (
@@ -127,12 +130,9 @@ describe('Chat for mobile', () => {
     renderWithProviders(<Chat />)
   })
 
-  it('should not render left panel in a chat', async () => {
-    const chip = await screen.findByText('chatPage.chat.chipLabel')
-
-    await waitFor(() => {
-      expect(chip).not.toBeInTheDocument()
-    })
+  it('should not render left panel in a chat', () => {
+    const chip = screen.queryByText(t('chatPage.chat.chipLabel'))
+    expect(chip).not.toBeInTheDocument()
   })
 })
 

--- a/tests/unit/pages/chat/Chat.spec.jsx
+++ b/tests/unit/pages/chat/Chat.spec.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, act } from '@testing-library/react'
+import { fireEvent, screen, act, waitFor } from '@testing-library/react'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import Chat from '~/pages/chat/Chat'
@@ -11,9 +11,6 @@ import {
   messagesMock
 } from '~tests/unit/pages/chat/ChatsMock.constants'
 import { afterEach, vi } from 'vitest'
-import { useTranslation } from 'react-i18next'
-
-const { t } = useTranslation()
 
 vi.mock('~/pages/chat/MessagesList', () => ({
   default: vi.fn(() => (
@@ -130,9 +127,12 @@ describe('Chat for mobile', () => {
     renderWithProviders(<Chat />)
   })
 
-  it('should not render left panel in a chat', () => {
-    const chip = screen.queryByText(t('chatPage.chat.chipLabel'))
-    expect(chip).not.toBeInTheDocument()
+  it('should not render left panel in a chat', async () => {
+    await waitFor(() => {
+      expect(
+        screen.queryByText('chatPage.chat.chipLabel')
+      ).not.toBeInTheDocument()
+    })
   })
 })
 


### PR DESCRIPTION
Replaced `useAxios` with `useQuery` from React Query for fetching chat data. Updated `ProfileInfo` component to use the new query implementation and adjusted tests accordingly.