### PR TITLE
 [Edit profile. Profile]Verify that Tutor/Student can`t add more than 200 characters into Professional headline field. #2736

### DIFF
--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -54,6 +54,17 @@ describe('ProfileTabForm', () => {
     expect(languageField.value).toBe(newLanguageValue)
   })
 
+  it('should not allow typing more than 200 characters in "Professional headline"', async () => {
+    const longText = 'a'.repeat(250)
+    const input = screen
+      .getAllByRole('textbox')
+      .find((el) => el.getAttribute('maxlength') === '200')
+
+    await userEvent.type(input, longText)
+
+    expect(input).toHaveValue('a'.repeat(200))
+  })
+
   it('should handle photo deletion', () => {
     const removePhotoBtn = screen.getByRole('button', { name: 'common.remove' })
     fireEvent.click(removePhotoBtn)


### PR DESCRIPTION
Added a test to check that the user can`t add more characters than 200 in the Professional headline field 
- added userEvent for better testing 
![image](https://github.com/user-attachments/assets/5892d4f6-cb0a-4076-b6d0-9628fbc51912)
