### PR TITLE
Enable downloading attachments

### DIFF
--- a/src/containers/course-section/resource-item/ResourceItem.styles.ts
+++ b/src/containers/course-section/resource-item/ResourceItem.styles.ts
@@ -7,7 +7,8 @@ export const styles = {
     p: '16px 24px',
     display: 'flex',
     justifyContent: 'space-between',
-    ml: isView ? '15px' : '38px'
+    ml: isView ? '15px' : '38px',
+    cursor: 'pointer'
   }),
   availabilitySelectionContainer: {
     display: 'flex',

--- a/src/containers/course-section/resource-item/ResourceItem.tsx
+++ b/src/containers/course-section/resource-item/ResourceItem.tsx
@@ -191,15 +191,21 @@ const ResourceItem: FC<ResourceItemProps> = ({
     </Box>
   )
 
-  const isAttachment = (resource: CourseResource): resource is Attachment => {
-    return resource.resourceType === ResourceType.Attachment
+  const isAttachment = (
+    resource: CourseResource,
+    type: ResourceType
+  ): resource is Attachment => {
+    return (
+      resource.resourceType === ResourceType.Attachment &&
+      type === ResourceType.Attachment
+    )
   }
 
   const onResourceItemClick = () => {
     if (!isView || status !== ResourceAvailabilityStatusEnum.Open) return
     const type = resourceType ?? resource.resourceType
 
-    if (type === ResourceType.Attachment && isAttachment(resource)) {
+    if (isAttachment(resource, type)) {
       window.open(resource.link, '_blank')
       return
     }

--- a/src/containers/course-section/resource-item/ResourceItem.tsx
+++ b/src/containers/course-section/resource-item/ResourceItem.tsx
@@ -23,6 +23,7 @@ import {
 import { styles } from '~/containers/course-section/resource-item/ResourceItem.styles'
 
 import {
+  Attachment,
   CourseResource,
   ResourceAvailability,
   ResourceAvailabilityStatusEnum,
@@ -190,20 +191,26 @@ const ResourceItem: FC<ResourceItemProps> = ({
     </Box>
   )
 
+  const isAttachment = (resource: CourseResource): resource is Attachment => {
+    return resource.resourceType === ResourceType.Attachment
+  }
+
   const onResourceItemClick = () => {
     if (!isView || status !== ResourceAvailabilityStatusEnum.Open) return
     const type = resourceType ?? resource.resourceType
 
-    if (type === ResourceType.Attachment) {
-      console.log('download the attachment / go to the attachment view')
+    if (type === ResourceType.Attachment && isAttachment(resource)) {
+      window.open(resource.link, '_blank')
       return
     }
 
-    navigate(
-      `${routeMap[type as ResourceType.Lesson | ResourceType.Quiz]}${
-        resource._id
-      }${type === ResourceType.Quiz ? '/attempts' : ''}`
-    )
+    if (type === ResourceType.Lesson || type === ResourceType.Quiz) {
+      navigate(
+        `${routeMap[type]}${
+          resource._id
+        }${type === ResourceType.Quiz ? '/attempts' : ''}`
+      )
+    }
   }
 
   return (

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants.js
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants.js
@@ -48,7 +48,28 @@ export const mockedAttachmentDataOriginal = {
   resourceType: ResourceType.Attachment
 }
 
+export const mockedAttachmentDataDuplicate = {
+  _id: '66b67eafb58ba31be667ee83',
+  author: '6658f73f93885febb491e08b',
+  fileName: 'Exploring Systems of Linear Equations.png',
+  link: '1723236050559-Exploring Systems of Linear Equations.png',
+  size: 39340,
+  category: '6684175179e5232bce4579ed',
+  resourceType: ResourceType.Attachment,
+  isDuplicate: true
+}
+
 export const mockAvailabilityOpen = {
   status: 'open',
+  date: null
+}
+
+export const mockAvailabilityOpenFrom = {
+  status: 'openFrom',
+  date: '9999-12-28T21:00:00.000Z'
+}
+
+export const mockAvailabilityClosed = {
+  status: 'closed',
   date: null
 }

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -214,14 +214,6 @@ describe('ResourceItem tests when resourceType attachment', () => {
 
   beforeEach(() => {
     windowOpenMock = vi.spyOn(window, 'open').mockImplementation(() => {})
-
-    // renderWithProviders(
-    //   <ResourceItem
-    //     availability={mockAvailabilityOpen}
-    //     isView
-    //     resource={mockedAttachmentDataOriginal}
-    //   />
-    // )
   })
 
   afterEach(() => {
@@ -300,6 +292,20 @@ describe('ResourceItem tests when resourceType attachment', () => {
 
     const attachmentItem = screen.getByText(/png/)
 
+    fireEvent.click(attachmentItem)
+    expect(windowOpenMock).not.toHaveBeenCalled()
+  })
+
+  it('should not download attachment if isView is false', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        resource={mockedAttachmentDataOriginal}
+        resourceType={ResourcesTypesEnum.Attachment}
+      />
+    )
+
+    const attachmentItem = screen.getByText(/png/)
     fireEvent.click(attachmentItem)
     expect(windowOpenMock).not.toHaveBeenCalled()
   })

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -1,5 +1,6 @@
 import { renderWithProviders } from '~tests/test-utils'
 import { fireEvent, screen } from '@testing-library/react'
+import { ResourcesTypesEnum } from '~/types'
 
 import {
   mockedLessonDataOriginal,
@@ -214,13 +215,13 @@ describe('ResourceItem tests when resourceType attachment', () => {
   beforeEach(() => {
     windowOpenMock = vi.spyOn(window, 'open').mockImplementation(() => {})
 
-    renderWithProviders(
-      <ResourceItem
-        availability={mockAvailabilityOpen}
-        isView
-        resource={mockedAttachmentDataOriginal}
-      />
-    )
+    // renderWithProviders(
+    //   <ResourceItem
+    //     availability={mockAvailabilityOpen}
+    //     isView
+    //     resource={mockedAttachmentDataOriginal}
+    //   />
+    // )
   })
 
   afterEach(() => {
@@ -228,11 +229,27 @@ describe('ResourceItem tests when resourceType attachment', () => {
   })
 
   it('should properly display attachment', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedAttachmentDataOriginal}
+      />
+    )
+
     const attachmentItem = screen.getByText(/png/)
     expect(attachmentItem).toBeInTheDocument()
   })
 
   it('should download attachment when clicked', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedAttachmentDataOriginal}
+      />
+    )
+
     const attachmentItem = screen.getByText(/png/)
 
     fireEvent.click(attachmentItem)
@@ -242,7 +259,7 @@ describe('ResourceItem tests when resourceType attachment', () => {
     )
   })
 
-  it('should not download anything if resourceType is not Attachment', () => {
+  it('should not download anything if resource.resourceType is not Attachment', () => {
     renderWithProviders(
       <ResourceItem
         availability={mockAvailabilityOpen}
@@ -253,6 +270,22 @@ describe('ResourceItem tests when resourceType attachment', () => {
     const nonAttachmentItem = screen.getByText(mockedLessonDataOriginal.title)
 
     fireEvent.click(nonAttachmentItem)
+    expect(windowOpenMock).not.toHaveBeenCalled()
+  })
+
+  it('should not download anything if resourceType is not Attachment but resource.resourceType IS an Attachment', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedAttachmentDataOriginal}
+        resourceType={ResourcesTypesEnum.Quiz}
+      />
+    )
+
+    const attachmentItem = screen.getByText(/png/)
+
+    fireEvent.click(attachmentItem)
     expect(windowOpenMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -6,13 +6,16 @@ import {
   mockedLessonDataOriginal,
   mockedQuizDataDuplicate,
   mockedAttachmentDataOriginal,
+  mockedAttachmentDataDuplicate,
   mockAvailabilityForLesson,
   mockAvailabilityForQuizDataDuplicate,
-  mockAvailabilityOpen
+  mockAvailabilityOpen,
+  mockAvailabilityOpenFrom,
+  mockAvailabilityClosed
 } from '~tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants'
 
 import ResourceItem from '~/containers/course-section/resource-item/ResourceItem'
-import { afterEach, expect, vi } from 'vitest'
+import { afterEach, expect, it, vi } from 'vitest'
 
 const mockDeleteResource = vi.fn()
 const mockEditResource = vi.fn()
@@ -258,6 +261,54 @@ describe('ResourceItem tests when resourceType attachment', () => {
       '1723236050559-Exploring Systems of Linear Equations.png',
       '_blank'
     )
+  })
+
+  it('should download attachment when isDuplicate is true', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedAttachmentDataDuplicate}
+      />
+    )
+
+    const attachmentItem = screen.getByText(/png/)
+
+    fireEvent.click(attachmentItem)
+    expect(windowOpenMock).toHaveBeenCalledWith(
+      '1723236050559-Exploring Systems of Linear Equations.png',
+      '_blank'
+    )
+  })
+
+  it('should not download attachment when its availability is set to open from', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpenFrom}
+        isView
+        resource={mockedAttachmentDataDuplicate}
+      />
+    )
+
+    const attachmentItem = screen.getByText(/png/)
+
+    fireEvent.click(attachmentItem)
+    expect(windowOpenMock).not.toHaveBeenCalledWith()
+  })
+
+  it('should not download attachment when its availability is set to closed', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityClosed}
+        isView
+        resource={mockedAttachmentDataDuplicate}
+      />
+    )
+
+    const attachmentItem = screen.getByText(/png/)
+
+    fireEvent.click(attachmentItem)
+    expect(windowOpenMock).not.toHaveBeenCalledWith()
   })
 
   it('should not download anything if resource.resourceType is not Attachment', () => {

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -273,6 +273,21 @@ describe('ResourceItem tests when resourceType attachment', () => {
     expect(windowOpenMock).not.toHaveBeenCalled()
   })
 
+  it('should not download anything if resource.resourceType is not Attachment but resourceType IS an attachment', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedLessonDataOriginal}
+        resourceType={ResourcesTypesEnum.Attachment}
+      />
+    )
+    const nonAttachmentItem = screen.getByText(mockedLessonDataOriginal.title)
+
+    fireEvent.click(nonAttachmentItem)
+    expect(windowOpenMock).not.toHaveBeenCalled()
+  })
+
   it('should not download anything if resourceType is not Attachment but resource.resourceType IS an Attachment', () => {
     renderWithProviders(
       <ResourceItem

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -12,11 +12,20 @@ import {
 } from '~tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants'
 
 import ResourceItem from '~/containers/course-section/resource-item/ResourceItem'
-import { expect, vi } from 'vitest'
+import { afterEach, expect, vi } from 'vitest'
 
 const mockDeleteResource = vi.fn()
 const mockEditResource = vi.fn()
 const mockUpdateAvailability = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  }
+})
 
 vi.mock('@mui/x-date-pickers/LocalizationProvider', async () => {
   const actual = await vi.importActual(
@@ -308,5 +317,45 @@ describe('ResourceItem tests when resourceType attachment', () => {
     const attachmentItem = screen.getByText(/png/)
     fireEvent.click(attachmentItem)
     expect(windowOpenMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('ResourceItem navigation', () => {
+  afterEach(() => {
+    mockNavigate.mockReset()
+  })
+
+  it('should navigate to lesson page when resourceType is Lesson', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedLessonDataOriginal}
+      />
+    )
+
+    const lessonItem = screen.getByText(mockedLessonDataOriginal.title)
+    fireEvent.click(lessonItem)
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `lesson-details/${mockedLessonDataOriginal._id}`
+    )
+  })
+
+  it('should navigate to quiz attempts page when resourceType is Quiz', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedQuizDataDuplicate}
+      />
+    )
+
+    const quizItem = screen.getByText(mockedQuizDataDuplicate.title)
+    fireEvent.click(quizItem)
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `quizzes/${mockedQuizDataDuplicate._id}/attempts`
+    )
   })
 })

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -11,7 +11,7 @@ import {
 } from '~tests/unit/containers/course-section/resource-item/ResourceItem.spec.constants'
 
 import ResourceItem from '~/containers/course-section/resource-item/ResourceItem'
-import { vi } from 'vitest'
+import { expect, vi } from 'vitest'
 
 const mockDeleteResource = vi.fn()
 const mockEditResource = vi.fn()
@@ -209,7 +209,11 @@ describe('ResourceItem tests when isDuplicate=true and resourceType quiz', () =>
 })
 
 describe('ResourceItem tests when resourceType attachment', () => {
+  let windowOpenMock
+
   beforeEach(() => {
+    windowOpenMock = vi.spyOn(window, 'open').mockImplementation(() => {})
+
     renderWithProviders(
       <ResourceItem
         availability={mockAvailabilityOpen}
@@ -219,16 +223,36 @@ describe('ResourceItem tests when resourceType attachment', () => {
     )
   })
 
+  afterEach(() => {
+    windowOpenMock.mockRestore()
+  })
+
   it('should properly display attachment', () => {
     const attachmentItem = screen.getByText(/png/)
     expect(attachmentItem).toBeInTheDocument()
   })
 
   it('should download attachment when clicked', () => {
-    const windowOpenMock = vi.spyOn(window, 'open').mockImplementation(() => {})
     const attachmentItem = screen.getByText(/png/)
 
     fireEvent.click(attachmentItem)
-    expect(windowOpenMock).toHaveBeenCalled()
+    expect(windowOpenMock).toHaveBeenCalledWith(
+      '1723236050559-Exploring Systems of Linear Equations.png',
+      '_blank'
+    )
+  })
+
+  it('should not download anything if resourceType is not Attachment', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedLessonDataOriginal}
+      />
+    )
+    const nonAttachmentItem = screen.getByText(mockedLessonDataOriginal.title)
+
+    fireEvent.click(nonAttachmentItem)
+    expect(windowOpenMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -358,4 +358,19 @@ describe('ResourceItem navigation', () => {
       `quizzes/${mockedQuizDataDuplicate._id}/attempts`
     )
   })
+
+  it('should not call navigate if resource is an attachment', () => {
+    renderWithProviders(
+      <ResourceItem
+        availability={mockAvailabilityOpen}
+        isView
+        resource={mockedAttachmentDataOriginal}
+      />
+    )
+
+    const attachmentItem = screen.getByText(/png/)
+    fireEvent.click(attachmentItem)
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
 })

--- a/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
+++ b/tests/unit/containers/course-section/resource-item/ResourceItem.spec.jsx
@@ -213,17 +213,22 @@ describe('ResourceItem tests when resourceType attachment', () => {
     renderWithProviders(
       <ResourceItem
         availability={mockAvailabilityOpen}
-        deleteResource={mockDeleteResource}
-        editResource={mockEditResource}
+        isView
         resource={mockedAttachmentDataOriginal}
-        updateAvailability={mockUpdateAvailability}
       />
     )
   })
 
   it('should properly display attachment', () => {
     const attachmentItem = screen.getByText(/png/)
-
     expect(attachmentItem).toBeInTheDocument()
+  })
+
+  it('should download attachment when clicked', () => {
+    const windowOpenMock = vi.spyOn(window, 'open').mockImplementation(() => {})
+    const attachmentItem = screen.getByText(/png/)
+
+    fireEvent.click(attachmentItem)
+    expect(windowOpenMock).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
- [x] Implemented `isAttachment` type guard to ensure safe access to the link field on attachments.
- [x] Updated the `onResourceItemClick` handler to open attachments in a new tab using `window.open` when the resource is of type `Attachment`.
- [x] Preserved navigation behavior for other resource types (`Lesson`, `Quiz`), unchanged.
- [x] Added tests to ensure everything works as expected

https://github.com/user-attachments/assets/8ae509e5-ce31-44e8-8363-c102c9e033cb

