### PR TITLE
(SP: ) Remove starting modal when there is no time limit on quiz #3366

### DIFF
--- a/src/pages/quiz-attempts/QuizAttempts.tsx
+++ b/src/pages/quiz-attempts/QuizAttempts.tsx
@@ -47,7 +47,7 @@ const QuizAttemptsPage: React.FC = () => {
     items
   } = quiz ?? defaultQuizResponse
 
-  const isTimeLimitNeeded = timeLimit != 'No limit'
+  const isTimeLimitNeeded = timeLimit as string != 'No limit'
 
   const getFinishedQuizzes = useCallback(() => {
     return ResourceService.getFinishedQuizzesByQuizId(cooperationId, quizId)

--- a/src/pages/quiz-attempts/QuizAttempts.tsx
+++ b/src/pages/quiz-attempts/QuizAttempts.tsx
@@ -47,6 +47,8 @@ const QuizAttemptsPage: React.FC = () => {
     items
   } = quiz ?? defaultQuizResponse
 
+  const isTimeLimitNeeded = timeLimit != 'No limit'
+
   const getFinishedQuizzes = useCallback(() => {
     return ResourceService.getFinishedQuizzesByQuizId(cooperationId, quizId)
   }, [cooperationId, quizId])
@@ -121,19 +123,21 @@ const QuizAttemptsPage: React.FC = () => {
       />
       <StartViewQuizInfo
         attempts={attemptLimit}
-        onStart={openModal}
+        onStart={isTimeLimitNeeded ? openModal : handleStart}
         questionsAmount={items.length}
         timeLimit={timeLimit}
         usedAttempts={finishedQuizzes.length}
       />
       <Divider sx={styles.divider} />
       {attemptsList}
-      <TimeLimitReminder
-        onClose={handleClose}
-        onStart={handleStart}
-        open={isOpen}
-        timeLimit={timeLimit}
-      />
+      {isTimeLimitNeeded && (
+        <TimeLimitReminder
+          onClose={handleClose}
+          onStart={handleStart}
+          open={isOpen}
+          timeLimit={timeLimit}
+        />
+      )}
     </PageWrapper>
   )
 }

--- a/src/pages/quiz-attempts/QuizAttempts.tsx
+++ b/src/pages/quiz-attempts/QuizAttempts.tsx
@@ -47,7 +47,7 @@ const QuizAttemptsPage: React.FC = () => {
     items
   } = quiz ?? defaultQuizResponse
 
-  const isTimeLimitNeeded = timeLimit as string != 'No limit'
+  const isTimeLimitNeeded = (timeLimit as string) != 'No limit'
 
   const getFinishedQuizzes = useCallback(() => {
     return ResourceService.getFinishedQuizzesByQuizId(cooperationId, quizId)


### PR DESCRIPTION
Removed starting modal for time limit for starting a quiz with no limit in time.

Video for both unlimited and limited quizzes

https://github.com/user-attachments/assets/152ffa5f-2b6d-44c7-8798-9f23dfd79d80

