### PR TITLE
 (SP: ) Remove study materials access from student's offer #3372

### DIFF
--- a/src/containers/offer-details/offer-general-info/OfferGeneralInfo.tsx
+++ b/src/containers/offer-details/offer-general-info/OfferGeneralInfo.tsx
@@ -11,7 +11,6 @@ import DoneIcon from '@mui/icons-material/Done'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import IconTitleDescription from '~/components/icon-title-description/IconTitleDescription'
 import AppCard from '~/components/app-card/AppCard'
-import StudyMaterials from '~/containers/my-cooperations/cooperation-completion/StudyMaterials'
 
 import { styles } from '~/containers/offer-details/offer-general-info/OfferGeneralInfo.styles'
 import { Offer, SizeEnum } from '~/types'
@@ -75,10 +74,7 @@ const OfferGeneralInfo: FC<OfferGeneralInfo> = ({ offer }) => {
         {t('offerDetailsPage.generalInfo.title')}
       </Typography>
 
-      <Box sx={styles.cardsContainer}>
-        {generalInfoCards}
-        <StudyMaterials />
-      </Box>
+      <Box sx={styles.cardsContainer}>{generalInfoCards}</Box>
     </Box>
   )
 }

--- a/src/containers/offer-page/teaching-block/TeachingBlock.tsx
+++ b/src/containers/offer-page/teaching-block/TeachingBlock.tsx
@@ -53,7 +53,7 @@ const TeachingBlock = <T extends CreateOrUpdateOfferData>({
     }
   }
 
-  const studyMaterials = userRole === UserRoleEnum.Student && <StudyMaterials />
+  const studyMaterials = userRole === UserRoleEnum.Tutor && <StudyMaterials />
 
   return (
     <OrderedListItem


### PR DESCRIPTION
- Removed the study materials block in the general info 

![image](https://github.com/user-attachments/assets/b2344a09-78bf-42c4-a9be-c5c67f07d41d)

- Changed student role for tutors, so now when you create or edit the offer, only tutors can see the study materials access block

![image](https://github.com/user-attachments/assets/47abc2e7-16d1-4605-b105-806edeff6fc7)

In the student account
![image](https://github.com/user-attachments/assets/dfa46872-b695-4a50-ac97-20acf769704e)
