### PR TITLE
(SP: ) Fix page not found error when trying to edit lesson #3365

### DIFF
--- a/src/router/constants/authRoutes.ts
+++ b/src/router/constants/authRoutes.ts
@@ -24,7 +24,7 @@ export const authRoutes = {
       path: '/my-resources/new-lesson'
     },
     editLesson: {
-      route: 'my-resources/edit-lesson/:id',
+      route: '/my-resources/edit-lesson/:id',
       path: '/my-resources/edit-lesson'
     },
     newQuiz: {


### PR DESCRIPTION
Fix a bug where editing a lesson from My Resources → Lessons resulted in a 404 "Page not found" error.

Before:

![435489978-57b87181-10f0-4d0b-81c9-00edd5801e68](https://github.com/user-attachments/assets/6dbaec8d-1c46-44cb-abb2-b389e8c823a4)

After:

https://github.com/user-attachments/assets/9de0925f-e019-46ee-b5dd-15c58d5291e9