### PR TITLE
(SP:) Fix error when getting by resource ID #3392

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -47,7 +47,7 @@ export const URLs = {
     patch: '/courses/:id'
   },
   coursesAndCooperations: {
-    getByResourceId: '/courses-cooperations/resource/'
+    getByResourceId: '/courses-cooperations/resource/:resourceId'
   },
   categories: {
     get: '/categories',

--- a/src/services/course-cooperation-service.ts
+++ b/src/services/course-cooperation-service.ts
@@ -7,7 +7,7 @@ export const CoursesAndCooperationsService = {
   getByResourceId: (resourceId: string) => {
     const url = getFullUrl({
       pathname: URLs.coursesAndCooperations.getByResourceId,
-      searchParameters: { resourceId }
+      parameters: { resourceId }
     })
 
     return baseService.request<CourseCooperationResponse>({


### PR DESCRIPTION
Fix the 404 error on Lessons, Quizzes, and Attachments pages when trying to fetch a resource by ID.

Before:

https://github.com/user-attachments/assets/4fb19f4c-e5f1-4987-8d2d-ac4609b49af2

After:

https://github.com/user-attachments/assets/85b21331-96ea-44f8-86c3-2e1fb6d2f9b2