### PR TITLE
Added possibility to add hex colors

### DIFF
--- a/src/components/subject-level-chips/SubjectLevelChips.tsx
+++ b/src/components/subject-level-chips/SubjectLevelChips.tsx
@@ -19,7 +19,8 @@ interface SubjectLevelChipsProps {
 const SubjectLevelChips: FC<SubjectLevelChipsProps> = ({
   proficiencyLevel,
   subject,
-  sx
+  sx,
+  color
 }) => {
   const proficiencyLevelText = useMemo(() => {
     if (!Array.isArray(proficiencyLevel)) return proficiencyLevel
@@ -32,6 +33,7 @@ const SubjectLevelChips: FC<SubjectLevelChipsProps> = ({
   return (
     <Box sx={spliceSx(styles.chips, sx)}>
       <Chip
+        color={color}
         detail={proficiencyLevelText}
         label={subject ?? ''}
         size='sm'

--- a/src/components/subject-level-chips/SubjectLevelChips.tsx
+++ b/src/components/subject-level-chips/SubjectLevelChips.tsx
@@ -3,7 +3,7 @@ import { FC, useMemo } from 'react'
 import Box from '@mui/material/Box'
 import { SxProps } from '@mui/material'
 
-import Chip from '~scss-components/chip/Chip'
+import Chip, { ChipColor } from '~scss-components/chip/Chip'
 import { spliceSx } from '~/utils/helper-functions'
 
 import { ProficiencyLevelEnum } from '~/types'
@@ -33,7 +33,7 @@ const SubjectLevelChips: FC<SubjectLevelChipsProps> = ({
   return (
     <Box sx={spliceSx(styles.chips, sx)}>
       <Chip
-        color={color}
+        color={color as ChipColor | `#${string}`}
         detail={proficiencyLevelText}
         label={subject ?? ''}
         size='sm'

--- a/src/design-system/components/chip/ChipInternalComponents.tsx
+++ b/src/design-system/components/chip/ChipInternalComponents.tsx
@@ -204,14 +204,16 @@ const CategoryChip = forwardRef<HTMLDivElement, CategoryChipProps>(
     { color = 'blue-gray', detail, disabled, label, size = 'md', type },
     reference
   ) => {
+    const isHexColor = color.includes('#')
+
     const labelStyle = {
-      '--chip-bg-color': `var(--s2s-${color}-300)`,
-      '--chip-text-color': `var(--s2s-${color}-900)`
+      '--chip-bg-color': isHexColor ? color : `var(--s2s-${color}-300)`,
+      '--chip-text-color': isHexColor ? 'blue-gray' : `var(--s2s-${color}-900)`
     } as CSSProperties
 
     const detailStyle = {
-      '--chip-bg-color': `var(--s2s-${color}-100)`,
-      '--chip-text-color': `var(--s2s-${color}-900)`
+      '--chip-bg-color': isHexColor ? color : `var(--s2s-${color}-100)`,
+      '--chip-text-color': isHexColor ? 'blue-gray' : `var(--s2s-${color}-900)`
     } as CSSProperties
 
     return (
@@ -251,10 +253,12 @@ const StateChip = forwardRef<HTMLDivElement, StateChipProps>(
     },
     reference
   ) => {
+    const isHexColor = color.includes('#')
+
     const style = {
-      '--chip-bg-color': `var(--s2s-${color}-100)`,
-      '--chip-border-color': `var(--s2s-${color}-700)`,
-      '--chip-text-color': `var(--s2s-${color}-700)`
+      '--chip-bg-color': isHexColor ? color : `var(--s2s-${color}-100)`,
+      '--chip-border-color': isHexColor ? color : `var(--s2s-${color}-700)`,
+      '--chip-text-color': isHexColor ? 'blue-gray' : `var(--s2s-${color}-700)`
     } as CSSProperties
 
     return (

--- a/src/design-system/components/chip/types.ts
+++ b/src/design-system/components/chip/types.ts
@@ -47,9 +47,11 @@ type InputChipProps = CommonChipProps<'input'> &
     variant?: 'filled' | 'outlined' | 'filled-outlined'
   }
 
+type HexColor = `#${string}`
+
 type CategoryChipProps = CommonChipProps<'category'> &
   ChipWithLabel & {
-    color?: ChipColor
+    color?: ChipColor | HexColor
     detail: string
   }
 


### PR DESCRIPTION
Currently, chips only accept predefined named colors (like "blue", "green", etc.).
It now allows hex color codes (e.g., #FF5733) as well.

![image](https://github.com/user-attachments/assets/5a8d4d64-811c-4ddc-a310-20278173a76a)
