### PR TITLE
Fix photo field handling #3400

### DIFF
--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -199,11 +199,11 @@ const EditProfile = () => {
       dataToUpdate.mainSubjects = categories
     }
 
-    if (typeof photo === 'object' || photo === '') {
-      dataToUpdate.photo = photo
-    }
-
     const dataWithoutEmptyStrings = replaceEmptyStringsWithNull(dataToUpdate)
+
+    if (typeof photo === 'object' || photo === '') {
+      dataWithoutEmptyStrings.photo = photo
+    }
 
     await dispatch(
       updateUser({


### PR DESCRIPTION
Moved the replaceEmptyStringsWithNull call before the photo handling logic, so now the photo send as empry string istead of null

![image](https://github.com/user-attachments/assets/97f21cc6-00e0-43e9-90fa-04c9e5ff1a53)
