### PR TITLE
Feature/replace appmenu mui with design system

### DIFF
--- a/src/components/app-menu/AppMenu.tsx
+++ b/src/components/app-menu/AppMenu.tsx
@@ -1,4 +1,5 @@
 import Menu from '~/design-system/components/menu/Menu'
+import { MenuItemColorVariant } from '~/design-system/components/menu-item/MenuItem.constants'
 
 interface AppMenuProps {
   anchorEl: HTMLElement | null
@@ -8,24 +9,30 @@ interface AppMenuProps {
     graphics?: JSX.Element
     sx?: object
     isDisabled?: boolean
+    colorVariant?: MenuItemColorVariant
+    density?: 1 | 2
   }[]
   onClose: () => void
-  open?: boolean
-  sx?: object
   maxHeight?: number
+  minWidth?: number
 }
 
-const AppMenu = ({ anchorEl, menuList, onClose }: AppMenuProps) => {
+const AppMenu = ({
+  anchorEl,
+  menuList,
+  onClose,
+  minWidth = 200,
+  maxHeight = 400
+}: AppMenuProps) => {
   return (
     <Menu
       anchorEl={anchorEl}
-      maxHeight={400}
+      maxHeight={maxHeight}
       menuItems={menuList.map((item) => ({
         ...item,
-        sx: item.sx,
         disabled: item.isDisabled
       }))}
-      minWidth={200}
+      minWidth={minWidth}
       removeAllItemsTitle='Remove All'
       setAnchorEl={onClose}
     />

--- a/src/components/app-menu/AppMenu.tsx
+++ b/src/components/app-menu/AppMenu.tsx
@@ -1,38 +1,34 @@
-import { FC } from 'react'
+import Menu from '~/design-system/components/menu/Menu'
 
-import Menu, { MenuProps } from '@mui/material/Menu'
-
-import { spliceSx } from '~/utils/helper-functions'
-
-import { PositionEnum } from '~/types'
-import { styles } from '~/components/app-menu/AppMenu.styles'
-
-interface AppMenuProps extends MenuProps {
+interface AppMenuProps {
+  anchorEl: HTMLElement | null
+  menuList: {
+    title: string
+    onClick: () => void
+    graphics?: JSX.Element
+    sx?: object
+    isDisabled?: boolean
+  }[]
+  onClose: () => void
+  open?: boolean
+  sx?: object
   maxHeight?: number
-  menuList: JSX.Element | JSX.Element[]
 }
 
-const AppMenu: FC<AppMenuProps> = ({ maxHeight, menuList, sx, ...props }) => {
+const AppMenu = ({ anchorEl, menuList, onClose }: AppMenuProps) => {
   return (
     <Menu
-      PaperProps={{
-        style: {
-          maxHeight
-        }
-      }}
-      anchorOrigin={{
-        vertical: PositionEnum.Bottom,
-        horizontal: PositionEnum.Right
-      }}
-      sx={spliceSx(styles.menu, sx)}
-      transformOrigin={{
-        vertical: PositionEnum.Top,
-        horizontal: PositionEnum.Right
-      }}
-      {...props}
-    >
-      {menuList}
-    </Menu>
+      anchorEl={anchorEl}
+      maxHeight={400}
+      menuItems={menuList.map((item) => ({
+        ...item,
+        sx: item.sx,
+        disabled: item.isDisabled
+      }))}
+      minWidth={200}
+      removeAllItemsTitle='Remove All'
+      setAnchorEl={onClose}
+    />
   )
 }
 

--- a/src/containers/chat/chat-header/ChatHeader.tsx
+++ b/src/containers/chat/chat-header/ChatHeader.tsx
@@ -63,6 +63,7 @@ const ChatHeader: FC<ChatHeaderProps> = ({
   const [isSearchOpen, setIsSearchOpen] = useState<boolean>(false)
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null)
   const [allMessages, setAllMessages] = useState<MessageInterface[]>([])
+  const [isHistoryCleared, setIsHistoryCleared] = useState(false)
   const anchorRef = useRef<HTMLDivElement | null>(null)
   const { t } = useTranslation()
   const { isMobile } = useBreakpoints()
@@ -74,26 +75,6 @@ const ChatHeader: FC<ChatHeaderProps> = ({
   const handleSearch = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()
     setIsSearchOpen(!isSearchOpen)
-  }
-
-  const handleMenu = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    openMenu()
-  }
-
-  const iconButtons = [
-    { _id: 1, icon: <SearchIcon />, handleOnClick: handleSearch },
-    { _id: 2, icon: <MoreVertIcon />, handleOnClick: handleMenu }
-  ]
-
-  const icons = iconButtons.map(({ _id, icon, handleOnClick }) => (
-    <IconButton key={_id} onClick={handleOnClick} sx={styles.icon}>
-      {icon}
-    </IconButton>
-  ))
-
-  const closeSearch = () => {
-    setIsSearchOpen(false)
   }
 
   const getAllMessages = useCallback(
@@ -139,8 +120,10 @@ const ChatHeader: FC<ChatHeaderProps> = ({
       <ChatMenu
         anchorEl={menuAnchorEl}
         currentChat={currentChat}
+        isHistoryCleared={isHistoryCleared}
         messagesLength={messages.length}
         onClose={closeMenu}
+        setIsHistoryCleared={setIsHistoryCleared}
         updateChats={updateChats}
         updateMessages={updateMessages}
       />
@@ -155,13 +138,18 @@ const ChatHeader: FC<ChatHeaderProps> = ({
         title={`${user.firstName} ${user.lastName}`}
       />
       <Box ref={anchorRef} sx={styles.actions}>
-        {icons}
+        <IconButton onClick={handleSearch} sx={styles.icon}>
+          <SearchIcon />
+        </IconButton>
+        <IconButton onClick={openMenu} sx={styles.icon}>
+          <MoreVertIcon />
+        </IconButton>
       </Box>
       {isSearchOpen && (
         <Box sx={styles.searchContainer}>
           <SearchByMessage
             allMessages={allMessages}
-            isCloseSearch={closeSearch}
+            isCloseSearch={() => setIsSearchOpen(false)}
             onFilteredIndexChange={onFilteredIndexChange}
             onFilteredMessagesChange={onFilteredMessagesChange}
             setLimit={setLimit}

--- a/src/containers/layout/account-menu/AccountMenu.tsx
+++ b/src/containers/layout/account-menu/AccountMenu.tsx
@@ -36,6 +36,7 @@ const AccountMenu: FC<AccountMenuProps> = ({ anchorEl, onClose }) => {
           navigate(item.path)
           onClose()
         },
+        density: 2 as const,
         sx: styles.menuItem
       })),
       {
@@ -53,14 +54,7 @@ const AccountMenu: FC<AccountMenuProps> = ({ anchorEl, onClose }) => {
     ]
   })()
 
-  return (
-    <AppMenu
-      anchorEl={anchorEl}
-      menuList={menuList}
-      onClose={onClose}
-      open={Boolean(anchorEl)}
-    />
-  )
+  return <AppMenu anchorEl={anchorEl} menuList={menuList} onClose={onClose} />
 }
 
 export default AccountMenu

--- a/src/containers/layout/account-menu/AccountMenu.tsx
+++ b/src/containers/layout/account-menu/AccountMenu.tsx
@@ -1,8 +1,6 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
-import MenuItem from '@mui/material/MenuItem'
-import { MenuProps } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
 import LogoutIcon from '@mui/icons-material/Logout'
 
 import AppMenu from '~/components/app-menu/AppMenu'
@@ -10,55 +8,68 @@ import { styles } from '~/containers/layout/account-menu/AccountMenu.styles'
 import { useAppSelector } from '~/hooks/use-redux'
 
 import { authRoutes } from '~/router/constants/authRoutes'
-import { spliceSx } from '~/utils/helper-functions'
 import { RouteItem } from '~/types'
 
 interface AccountMenuProps {
-  anchorEl: MenuProps['anchorEl']
+  anchorEl: HTMLElement | null
   onClose: () => void
 }
 
 const AccountMenu: FC<AccountMenuProps> = ({ anchorEl, onClose }) => {
-  const { t } = useTranslation()
-
+  const { t, i18n } = useTranslation()
+  const navigate = useNavigate()
   const { userRole } = useAppSelector((state) => state.appMain)
 
-  const logOutButton = (
-    <MenuItem
-      component={Link}
-      key={authRoutes.accountMenu.logout.path}
-      onClick={onClose}
-      sx={spliceSx(styles.menuItem, styles.logoutItem)}
-      to={authRoutes.accountMenu.logout.path}
-    >
-      <LogoutIcon sx={styles.logoutIcon} />
-      {t(`header.${authRoutes.accountMenu.logout.route}`)}
-    </MenuItem>
-  )
+  const [menuKey, setMenuKey] = useState(0)
 
-  const routes = Object.values(
-    authRoutes.accountMenu[userRole as keyof typeof authRoutes.accountMenu]
-  ) as RouteItem[]
+  const menuList = (() => {
+    const routes = Object.values(
+      authRoutes.accountMenu[userRole as keyof typeof authRoutes.accountMenu]
+    ) as RouteItem[]
 
-  const menuItems = routes
-    .filter((item) => item.route !== authRoutes.accountMenu.logout.route)
-    .map((item) => (
-      <MenuItem
-        component={Link}
-        key={item.path}
-        onClick={onClose}
-        sx={styles.menuItem}
-        to={item.path}
-      >
-        {t(`header.${item.route}`)}
-      </MenuItem>
-    ))
+    const filteredRoutes = routes.filter(
+      (item) => item.route !== authRoutes.accountMenu.logout.route
+    )
 
-  const menuList = [...menuItems, logOutButton]
+    return [
+      ...filteredRoutes.map((item) => ({
+        title: t(`header.${item.route}`),
+        onClick: () => {
+          navigate(item.path)
+          onClose()
+        },
+        sx: styles.menuItem
+      })),
+      {
+        title: t(`header.${authRoutes.accountMenu.logout.route}`),
+        onClick: () => {
+          navigate(authRoutes.accountMenu.logout.path)
+          onClose()
+        },
+        graphics: <LogoutIcon sx={styles.logoutIcon} />,
+        sx: {
+          ...styles.menuItem,
+          ...styles.logoutItem
+        }
+      }
+    ]
+  })()
+
+  useEffect(() => {
+    const handleLanguageChange = () => {
+      setMenuKey((prevKey) => prevKey + 1)
+    }
+
+    i18n.on('languageChanged', handleLanguageChange)
+    return () => {
+      i18n.off('languageChanged', handleLanguageChange)
+    }
+  }, [i18n])
 
   return (
     <AppMenu
       anchorEl={anchorEl}
+      key={menuKey}
       menuList={menuList}
       onClose={onClose}
       open={Boolean(anchorEl)}

--- a/src/containers/layout/account-menu/AccountMenu.tsx
+++ b/src/containers/layout/account-menu/AccountMenu.tsx
@@ -1,4 +1,3 @@
-import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import LogoutIcon from '@mui/icons-material/Logout'
@@ -15,7 +14,7 @@ interface AccountMenuProps {
   onClose: () => void
 }
 
-const AccountMenu: FC<AccountMenuProps> = ({ anchorEl, onClose }) => {
+const AccountMenu: React.FC<AccountMenuProps> = ({ anchorEl, onClose }) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { userRole } = useAppSelector((state) => state.appMain)

--- a/src/containers/layout/account-menu/AccountMenu.tsx
+++ b/src/containers/layout/account-menu/AccountMenu.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import LogoutIcon from '@mui/icons-material/Logout'
@@ -16,11 +16,9 @@ interface AccountMenuProps {
 }
 
 const AccountMenu: FC<AccountMenuProps> = ({ anchorEl, onClose }) => {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const navigate = useNavigate()
   const { userRole } = useAppSelector((state) => state.appMain)
-
-  const [menuKey, setMenuKey] = useState(0)
 
   const menuList = (() => {
     const routes = Object.values(
@@ -55,21 +53,9 @@ const AccountMenu: FC<AccountMenuProps> = ({ anchorEl, onClose }) => {
     ]
   })()
 
-  useEffect(() => {
-    const handleLanguageChange = () => {
-      setMenuKey((prevKey) => prevKey + 1)
-    }
-
-    i18n.on('languageChanged', handleLanguageChange)
-    return () => {
-      i18n.off('languageChanged', handleLanguageChange)
-    }
-  }, [i18n])
-
   return (
     <AppMenu
       anchorEl={anchorEl}
-      key={menuKey}
       menuList={menuList}
       onClose={onClose}
       open={Boolean(anchorEl)}

--- a/src/containers/layout/chat-menu/ChatMenu.tsx
+++ b/src/containers/layout/chat-menu/ChatMenu.tsx
@@ -1,30 +1,25 @@
-import { FC, MouseEvent, useCallback } from 'react'
+import { FC, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { AxiosResponse } from 'axios'
-import MenuItem from '@mui/material/MenuItem'
 import UpdateDisabledIcon from '@mui/icons-material/UpdateDisabled'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 
 import AppMenu from '~/components/app-menu/AppMenu'
 import useConfirm from '~/hooks/use-confirm'
-import useAxios from '~/hooks/use-axios'
 import { chatService } from '~/services/chat-service'
 import { messageService } from '~/services/message-service'
 
 import { styles } from '~/containers/layout/chat-menu/ChatMenu.styles'
-import { ChatResponse, ComponentEnum, ErrorResponse } from '~/types'
-import { defaultResponses, snackbarVariants } from '~/constants'
-import { useAppDispatch } from '~/hooks/use-redux'
-import { openAlert } from '~/redux/features/snackbarSlice'
-import { getErrorKey } from '~/utils/get-error-key'
+import { ChatResponse } from '~/types'
 
 interface ChatMenuProps {
-  anchorEl: Element | null
+  anchorEl: HTMLElement | null
   currentChat: ChatResponse
   messagesLength: number
   onClose: () => void
   updateChats: () => Promise<void>
   updateMessages: () => Promise<void>
+  isHistoryCleared: boolean
+  setIsHistoryCleared: (value: boolean) => void
 }
 
 const ChatMenu: FC<ChatMenuProps> = ({
@@ -33,120 +28,52 @@ const ChatMenu: FC<ChatMenuProps> = ({
   messagesLength,
   onClose,
   updateChats,
-  updateMessages
+  updateMessages,
+  setIsHistoryCleared
 }) => {
   const { t } = useTranslation()
   const { openDialog } = useConfirm()
-  const dispatch = useAppDispatch()
 
-  const onResponse = useCallback(
-    (isDeleting = true) => {
-      dispatch(
-        openAlert({
-          severity: snackbarVariants.success,
-          message: isDeleting
-            ? 'chatPage.chatMenu.deleteSuccess'
-            : 'chatPage.chatMenu.historyClearSuccess'
-        })
-      )
-    },
-    [dispatch]
-  )
+  useEffect(() => {
+    setIsHistoryCleared(messagesLength === 0)
+  }, [messagesLength, setIsHistoryCleared])
 
-  const onResponseError = useCallback(
-    (error?: ErrorResponse) => {
-      dispatch(
-        openAlert({
-          severity: snackbarVariants.error,
-          message: getErrorKey(error)
-        })
-      )
-    },
-    [dispatch]
-  )
-
-  const markAsDeletedService = useCallback(
-    (id?: string): Promise<AxiosResponse> =>
-      chatService.markChatAsDeleted(id ?? ''),
-    []
-  )
-
-  const deleteChatService = useCallback(
-    (id?: string): Promise<AxiosResponse> => chatService.deleteChat(id ?? ''),
-    []
-  )
-
-  const deleteMessagesService = useCallback(
-    (id?: string): Promise<AxiosResponse> =>
-      messageService.deleteMessagesFromChat(id ?? ''),
-    []
-  )
-
-  const clearHistoryService = useCallback(
-    (id?: string): Promise<AxiosResponse> =>
-      messageService.clearChatHistory(id ?? ''),
-    []
-  )
-
-  const { fetchData: markAsDeleted } = useAxios({
-    service: markAsDeletedService,
-    defaultResponse: defaultResponses.object,
-    onResponse,
-    onResponseError,
-    fetchOnMount: false
-  })
-
-  const { fetchData: deleteChat } = useAxios({
-    service: deleteChatService,
-    defaultResponse: null,
-    onResponse,
-    onResponseError,
-    fetchOnMount: false
-  })
-
-  const { fetchData: deleteMessages } = useAxios({
-    service: deleteMessagesService,
-    defaultResponse: null,
-    onResponse,
-    onResponseError,
-    fetchOnMount: false
-  })
-
-  const { fetchData: clearHistory } = useAxios({
-    service: clearHistoryService,
-    defaultResponse: defaultResponses.object,
-    onResponse: () => onResponse(false),
-    onResponseError,
-    fetchOnMount: false
-  })
+  const handleClearChat = async (id: string, isConfirmed: boolean) => {
+    if (!isConfirmed) return
+    try {
+      await messageService.clearChatHistory(id)
+      await updateMessages()
+      await updateChats()
+      setIsHistoryCleared(true)
+    } catch (error) {
+      console.error('Error during clearing chat history:', error)
+    } finally {
+      onClose()
+    }
+  }
 
   const handleDeletion = async (
     id: string,
     isConfirmed: boolean,
     deletingFully: boolean
   ) => {
-    if (isConfirmed) {
+    if (!isConfirmed) return
+    try {
       if (deletingFully) {
-        await deleteMessages(id)
-        await deleteChat(id)
-      } else await markAsDeleted(id)
-
+        await messageService.deleteMessagesFromChat(id)
+        await chatService.deleteChat(id)
+      } else {
+        await chatService.markChatAsDeleted(id)
+      }
       await updateChats()
+    } catch (error) {
+      console.error('Error during deletion:', error)
+    } finally {
+      onClose()
     }
   }
 
-  const handleClearChat = async (id: string, isConfirmed: boolean) => {
-    if (isConfirmed) {
-      await clearHistory(id)
-      await updateMessages()
-      await updateChats()
-    }
-  }
-
-  const onClearHistory = (e: MouseEvent<HTMLButtonElement>, id: string) => {
-    e.stopPropagation()
-    onClose()
-
+  const onClearHistory = (id: string) => {
     openDialog({
       message: 'chatPage.chatMenu.clearHistoryWarning',
       sendConfirm: (isConfirmed: boolean) =>
@@ -155,11 +82,9 @@ const ChatMenu: FC<ChatMenuProps> = ({
     })
   }
 
-  const onDelete = (e: MouseEvent<HTMLButtonElement>, id: string) => {
-    e.stopPropagation()
+  const onDelete = (id: string) => {
     onClose()
     const deletingFully = currentChat.deletedFor.length > 0
-
     openDialog({
       message: deletingFully
         ? 'chatPage.chatMenu.fullDeleteWarning'
@@ -172,43 +97,28 @@ const ChatMenu: FC<ChatMenuProps> = ({
     })
   }
 
-  const menuButtons = [
+  const menuList = [
     {
-      _id: 1,
-      icon: <UpdateDisabledIcon />,
-      isAvailable: !!messagesLength,
-      name: t('chatPage.chatMenu.clearHistory'),
-      handleOnClick: (e: MouseEvent<HTMLButtonElement>) =>
-        onClearHistory(e, currentChat._id)
+      title: t('chatPage.chatMenu.clearHistory'),
+      onClick: () => onClearHistory(currentChat._id),
+      graphics: <UpdateDisabledIcon />,
+      sx: styles.menuItem(false),
+      isDisabled: messagesLength === 0
     },
     {
-      _id: 2,
-      icon: <DeleteOutlineIcon />,
-      isAvailable: !!currentChat,
-      name: t('chatPage.chatMenu.deleteChat'),
-      handleOnClick: (e: MouseEvent<HTMLButtonElement>) =>
-        onDelete(e, currentChat._id),
-      isDangerous: true
+      title: t('chatPage.chatMenu.deleteChat'),
+      onClick: () => onDelete(currentChat._id),
+      graphics: <DeleteOutlineIcon />,
+      sx: styles.menuItem(true),
+      isDisabled: false
     }
   ]
-
-  const menuItems = menuButtons.map((item) => (
-    <MenuItem
-      component={ComponentEnum.Button}
-      disabled={!item.isAvailable}
-      key={item._id}
-      onClick={item.handleOnClick}
-      sx={styles.menuItem(!!item.isDangerous)}
-    >
-      {item.icon}
-      {item.name}
-    </MenuItem>
-  ))
 
   return (
     <AppMenu
       anchorEl={anchorEl}
-      menuList={menuItems}
+      key={messagesLength}
+      menuList={menuList}
       onClose={onClose}
       open={Boolean(anchorEl)}
     />

--- a/src/containers/layout/chat-menu/ChatMenu.tsx
+++ b/src/containers/layout/chat-menu/ChatMenu.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react'
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import UpdateDisabledIcon from '@mui/icons-material/UpdateDisabled'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
@@ -25,7 +25,7 @@ interface ChatMenuProps {
   setIsHistoryCleared: (value: boolean) => void
 }
 
-const ChatMenu: FC<ChatMenuProps> = ({
+const ChatMenu: React.FC<ChatMenuProps> = ({
   anchorEl,
   currentChat,
   messagesLength,

--- a/src/containers/layout/chat-menu/ChatMenu.tsx
+++ b/src/containers/layout/chat-menu/ChatMenu.tsx
@@ -53,7 +53,7 @@ const ChatMenu: FC<ChatMenuProps> = ({
       dispatch(
         openAlert({
           severity: snackbarVariants.error,
-          message: t('Error during deletion:')
+          message: `${t('Error during deletion:')} ${String(error)}`
         })
       )
     } finally {
@@ -79,7 +79,7 @@ const ChatMenu: FC<ChatMenuProps> = ({
       dispatch(
         openAlert({
           severity: snackbarVariants.error,
-          message: t('Error during deletion:')
+          message: `${t('Error during deletion:')} ${String(error)}`
         })
       )
     } finally {

--- a/src/containers/layout/chat-menu/ChatMenu.tsx
+++ b/src/containers/layout/chat-menu/ChatMenu.tsx
@@ -10,6 +10,10 @@ import { messageService } from '~/services/message-service'
 
 import { styles } from '~/containers/layout/chat-menu/ChatMenu.styles'
 import { ChatResponse } from '~/types'
+import { openAlert } from '~/redux/features/snackbarSlice'
+import { useAppDispatch } from '~/hooks/use-redux'
+import { snackbarVariants } from '~/constants'
+import { MenuItemColorVariant } from '~/design-system/components/menu-item/MenuItem.constants'
 
 interface ChatMenuProps {
   anchorEl: HTMLElement | null
@@ -18,7 +22,6 @@ interface ChatMenuProps {
   onClose: () => void
   updateChats: () => Promise<void>
   updateMessages: () => Promise<void>
-  isHistoryCleared: boolean
   setIsHistoryCleared: (value: boolean) => void
 }
 
@@ -33,6 +36,7 @@ const ChatMenu: FC<ChatMenuProps> = ({
 }) => {
   const { t } = useTranslation()
   const { openDialog } = useConfirm()
+  const dispatch = useAppDispatch()
 
   useEffect(() => {
     setIsHistoryCleared(messagesLength === 0)
@@ -46,7 +50,12 @@ const ChatMenu: FC<ChatMenuProps> = ({
       await updateChats()
       setIsHistoryCleared(true)
     } catch (error) {
-      console.error('Error during clearing chat history:', error)
+      dispatch(
+        openAlert({
+          severity: snackbarVariants.error,
+          message: t('Error during deletion:')
+        })
+      )
     } finally {
       onClose()
     }
@@ -67,7 +76,12 @@ const ChatMenu: FC<ChatMenuProps> = ({
       }
       await updateChats()
     } catch (error) {
-      console.error('Error during deletion:', error)
+      dispatch(
+        openAlert({
+          severity: snackbarVariants.error,
+          message: t('Error during deletion:')
+        })
+      )
     } finally {
       onClose()
     }
@@ -103,14 +117,17 @@ const ChatMenu: FC<ChatMenuProps> = ({
       onClick: () => onClearHistory(currentChat._id),
       graphics: <UpdateDisabledIcon />,
       sx: styles.menuItem(false),
-      isDisabled: messagesLength === 0
+      isDisabled: messagesLength === 0,
+      density: 2 as const
     },
     {
       title: t('chatPage.chatMenu.deleteChat'),
       onClick: () => onDelete(currentChat._id),
       graphics: <DeleteOutlineIcon />,
       sx: styles.menuItem(true),
-      isDisabled: false
+      isDisabled: false,
+      density: 2 as const,
+      colorVariant: 'danger' as MenuItemColorVariant
     }
   ]
 
@@ -120,7 +137,6 @@ const ChatMenu: FC<ChatMenuProps> = ({
       key={messagesLength}
       menuList={menuList}
       onClose={onClose}
-      open={Boolean(anchorEl)}
     />
   )
 }

--- a/src/containers/layout/notifications-menu/NotificationsMenu.styles.ts
+++ b/src/containers/layout/notifications-menu/NotificationsMenu.styles.ts
@@ -18,6 +18,15 @@ export const styles = {
     borderBottom: '1px solid',
     borderColor: 'primary.100'
   },
+  menuWrapper: {
+    typography: TypographyVariantEnum.MidTitle,
+    pl: 1,
+    maxHeight: '264px',
+    minWidth: '340px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
   link: {
     color: 'primary.700',
     textDecoration: 'none'
@@ -28,5 +37,10 @@ export const styles = {
   },
   closeIcon: {
     color: 'primary.900'
+  },
+  clearButton: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
   }
 }

--- a/src/containers/layout/notifications-menu/NotificationsMenu.tsx
+++ b/src/containers/layout/notifications-menu/NotificationsMenu.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react'
+import { FC } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
@@ -29,16 +29,7 @@ const NotificationsMenu: FC<NotificationsMenuProps> = ({
   onDelete,
   onClose
 }) => {
-  const { t, i18n } = useTranslation()
-  const [currentLanguage, setCurrentLanguage] = useState(i18n.language)
-
-  useEffect(() => {
-    const handleLanguageChange = () => setCurrentLanguage(i18n.language)
-    i18n.on('languageChanged', handleLanguageChange)
-    return () => {
-      i18n.off('languageChanged', handleLanguageChange)
-    }
-  }, [i18n])
+  const { t } = useTranslation()
 
   const handleLinkClick = (item: Notification) => {
     onClose()
@@ -88,49 +79,9 @@ const NotificationsMenu: FC<NotificationsMenuProps> = ({
     sx: styles.empty
   }
 
-  // const menuItems = items.map((item) => ({
-  //   title: (
-  //     <Typography sx={styles.menuWrapper}>
-  //       <Link
-  //         component={RouterLink}
-  //         onClick={() => handleLinkClick(item)}
-  //         sx={styles.link}
-  //         to={liksByType[item.type]}
-  //       >
-  //         {t(`header.notifications.messages.${item.type}`)}
-  //       </Link>
-  //       <IconButton onClick={() => onDelete(item)}>
-  //         <CloseRoundedIcon fontSize={SizeEnum.Small} sx={styles.closeIcon} />
-  //       </IconButton>
-  //     </Typography>
-  //   ),
-  //   onClick: () => {},
-  //   sx: styles.menuItem,
-  // }))
-
-  // const menuList = [
-  //   ...menuItems,
-  //   {
-  //     title: (
-  //       <Button fullWidth onClick={onClear} variant="text-secondary" >
-  //         {t('header.notifications.clearAll')}
-  //       </Button>
-  //     ),
-  //     onClick: () => {},
-  //     sx: styles.clearButton,
-  //   },
-  // ]
-
-  // const emptyNotifications = {
-  //   title: t('header.notifications.emptyNotifications'),
-  //   onClick: () => {},
-  //   sx: styles.empty,
-  // }
-
   return (
     <AppMenu
       anchorEl={anchorEl}
-      key={`${items.length}-${currentLanguage}`}
       maxHeight={264}
       menuList={items.length ? menuList : [emptyNotifications]}
       onClose={onClose}

--- a/src/containers/layout/notifications-menu/NotificationsMenu.tsx
+++ b/src/containers/layout/notifications-menu/NotificationsMenu.tsx
@@ -85,7 +85,7 @@ const NotificationsMenu: FC<NotificationsMenuProps> = ({
       maxHeight={264}
       menuList={items.length ? menuList : [emptyNotifications]}
       onClose={onClose}
-      open={Boolean(anchorEl)}
+      // open={Boolean(anchorEl)}
     />
   )
 }

--- a/src/containers/layout/notifications-menu/NotificationsMenu.tsx
+++ b/src/containers/layout/notifications-menu/NotificationsMenu.tsx
@@ -1,11 +1,11 @@
-import { FC } from 'react'
+import { FC, useEffect, useState } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 
 import Typography from '@mui/material/Typography'
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded'
 import Link from '@mui/material/Link'
-import { MenuProps } from '@mui/material'
+import { MenuProps } from '~/design-system/components/menu/Menu'
 
 import { IconButton } from '~/design-system/components/icon-button/IconButton'
 import AppMenu from '~/components/app-menu/AppMenu'
@@ -29,45 +29,110 @@ const NotificationsMenu: FC<NotificationsMenuProps> = ({
   onDelete,
   onClose
 }) => {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const [currentLanguage, setCurrentLanguage] = useState(i18n.language)
+
+  useEffect(() => {
+    const handleLanguageChange = () => setCurrentLanguage(i18n.language)
+    i18n.on('languageChanged', handleLanguageChange)
+    return () => {
+      i18n.off('languageChanged', handleLanguageChange)
+    }
+  }, [i18n])
 
   const handleLinkClick = (item: Notification) => {
     onClose()
     onDelete(item)
   }
 
-  const menuItems = [
-    ...items.map((item) => (
-      <Typography key={item._id} sx={styles.menuItem}>
-        <Link
-          component={RouterLink}
-          onClick={() => handleLinkClick(item)}
-          sx={styles.link}
-          to={liksByType[item.type]}
-        >
-          {t(`header.notifications.messages.${item.type}`)}
-        </Link>
-        <IconButton onClick={() => onDelete(item)}>
-          <CloseRoundedIcon fontSize={SizeEnum.Small} sx={styles.closeIcon} />
-        </IconButton>
-      </Typography>
-    )),
-    <Button fullWidth key={null} onClick={onClear} variant='text-secondary'>
-      {t('header.notifications.clearAll')}
-    </Button>
+  const menuItems = items.map((item) => ({
+    title: (
+      <div data-title='notification-item'>
+        <Typography sx={styles.menuWrapper}>
+          <Link
+            component={RouterLink}
+            onClick={() => handleLinkClick(item)}
+            sx={styles.link}
+            to={liksByType[item.type]}
+          >
+            {t(`header.notifications.messages.${item.type}`)}
+          </Link>
+          <IconButton onClick={() => onDelete(item)}>
+            <CloseRoundedIcon fontSize={SizeEnum.Small} sx={styles.closeIcon} />
+          </IconButton>
+        </Typography>
+      </div>
+    ) as unknown as string,
+    onClick: () => {},
+    sx: styles.menuItem
+  }))
+
+  const menuList = [
+    ...menuItems,
+    {
+      title: (
+        <div data-title='clear-button'>
+          <Button fullWidth onClick={onClear} variant='text-secondary'>
+            {t('header.notifications.clearAll')}
+          </Button>
+        </div>
+      ) as unknown as string,
+      onClick: () => {},
+      sx: styles.clearButton
+    }
   ]
 
-  const emptyNotifications = (
-    <Typography sx={styles.empty}>
-      {t('header.notifications.emptyNotifications')}
-    </Typography>
-  )
+  const emptyNotifications = {
+    title: t('header.notifications.emptyNotifications'),
+    onClick: () => {},
+    sx: styles.empty
+  }
+
+  // const menuItems = items.map((item) => ({
+  //   title: (
+  //     <Typography sx={styles.menuWrapper}>
+  //       <Link
+  //         component={RouterLink}
+  //         onClick={() => handleLinkClick(item)}
+  //         sx={styles.link}
+  //         to={liksByType[item.type]}
+  //       >
+  //         {t(`header.notifications.messages.${item.type}`)}
+  //       </Link>
+  //       <IconButton onClick={() => onDelete(item)}>
+  //         <CloseRoundedIcon fontSize={SizeEnum.Small} sx={styles.closeIcon} />
+  //       </IconButton>
+  //     </Typography>
+  //   ),
+  //   onClick: () => {},
+  //   sx: styles.menuItem,
+  // }))
+
+  // const menuList = [
+  //   ...menuItems,
+  //   {
+  //     title: (
+  //       <Button fullWidth onClick={onClear} variant="text-secondary" >
+  //         {t('header.notifications.clearAll')}
+  //       </Button>
+  //     ),
+  //     onClick: () => {},
+  //     sx: styles.clearButton,
+  //   },
+  // ]
+
+  // const emptyNotifications = {
+  //   title: t('header.notifications.emptyNotifications'),
+  //   onClick: () => {},
+  //   sx: styles.empty,
+  // }
 
   return (
     <AppMenu
       anchorEl={anchorEl}
+      key={`${items.length}-${currentLanguage}`}
       maxHeight={264}
-      menuList={items.length ? menuItems : emptyNotifications}
+      menuList={items.length ? menuList : [emptyNotifications]}
       onClose={onClose}
       open={Boolean(anchorEl)}
     />

--- a/src/containers/navigation-icons/user-icons/UserIcons.tsx
+++ b/src/containers/navigation-icons/user-icons/UserIcons.tsx
@@ -43,6 +43,8 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
   const { t } = useTranslation()
 
   const anchorRef = useRef<HTMLDivElement | null>(null)
+  const accountMenuAnchor = accountMenuAnchorEl as HTMLElement | null
+  const notificationsAnchorEl = notificationsAnchor as HTMLElement | null
 
   const icons = userIcons.map(
     (item) =>
@@ -83,9 +85,9 @@ const UserIcons: FC<UserIconsProps> = ({ setSidebarOpen }) => {
         onClose={closeLanguageMenu}
       />
       <AccountIcon openMenu={openAccountMenu} />
-      <AccountMenu anchorEl={accountMenuAnchorEl} onClose={closeAccountMenu} />
+      <AccountMenu anchorEl={accountMenuAnchor} onClose={closeAccountMenu} />
       <NotificationsMenu
-        anchorEl={notificationsAnchor}
+        anchorEl={notificationsAnchorEl}
         items={notificationItems}
         onClear={handleClearNotifications}
         onClose={closeNotifications}

--- a/src/design-system/components/menu-item/MenuItem.scss
+++ b/src/design-system/components/menu-item/MenuItem.scss
@@ -5,7 +5,6 @@
   width: 100%;
   padding: 16px 8px;
   display: flex;
-  justify-content: space-between;
 
   &:disabled {
     color: $blue-gray-700;

--- a/src/design-system/components/menu-item/MenuItem.tsx
+++ b/src/design-system/components/menu-item/MenuItem.tsx
@@ -13,6 +13,7 @@ interface MenuItemProps extends CommonMenuItemProps {
   density?: 1 | 2
   isToggled?: boolean
   onRemove?: () => void
+  sx?: object
   variant?: MenuItemVariant
 }
 
@@ -31,6 +32,7 @@ const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
       isDisabled,
       onClick,
       onRemove,
+      sx,
       variant = MenuItemVariant.Default
     },
     ref
@@ -55,6 +57,7 @@ const MenuItem = forwardRef<HTMLLIElement, MenuItemProps>(
         disabled={isDisabled}
         onClick={onClick}
         ref={ref}
+        sx={sx}
       >
         <div className='s2s-item__main-info-box'>
           {graphics && <div className='s2s-item__graphics'>{graphics}</div>}

--- a/src/design-system/components/menu/Menu.tsx
+++ b/src/design-system/components/menu/Menu.tsx
@@ -25,7 +25,7 @@ interface MenuItemProps extends NestedMenuItemProps {
   nestedMenuItems?: NestedMenuItemProps[]
 }
 
-interface MenuProps {
+export interface MenuProps {
   anchorEl: HTMLElement | null
   setAnchorEl: (anchorEl: HTMLElement | null) => void
   menuItems: MenuItemProps[]
@@ -64,6 +64,7 @@ const Menu = forwardRef<HTMLDivElement, MenuProps>(
     ref
   ) => {
     const [items, setItems] = useState<MenuItemProps[]>(menuItems)
+
     const [internalToggledItemsTitles, setInternalToggledItemsTitles] =
       useState<string[]>(
         allowToggleMultipleItems

--- a/src/pages/chat/Chat.tsx
+++ b/src/pages/chat/Chat.tsx
@@ -1,4 +1,10 @@
-import { useState, useCallback, useEffect, useMemo, MouseEvent } from 'react'
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  MouseEvent
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { Allotment } from 'allotment'
 import Box from '@mui/material/Box'
@@ -198,20 +204,21 @@ const Chat = () => {
     return <Loader size={100} />
   }
 
-  const aboutChatSidebar = selectedChat && (
-    <AppDrawer
-      PaperProps={{ sx: styles.sidebarPaper }}
-      anchor={PositionEnum.Right}
-      onClose={() => onSidebarHandler(false)}
-      open={isSidebarOpen}
-      sx={styles.sidebar}
-      variant={isDesktop ? Persistent : Temporary}
-    >
-      {userToSpeak && (
-        <AboutChatSidebar links={mockLinks} member={userToSpeak} />
-      )}
-    </AppDrawer>
-  )
+  const aboutChatSidebar =
+    selectedChat && isSidebarOpen ? (
+      <AppDrawer
+        PaperProps={{ sx: styles.sidebarPaper }}
+        anchor={PositionEnum.Right}
+        onClose={() => onSidebarHandler(false)}
+        open={isSidebarOpen}
+        sx={styles.sidebar}
+        variant={isDesktop ? Persistent : Temporary}
+      >
+        {userToSpeak && (
+          <AboutChatSidebar links={mockLinks} member={userToSpeak} />
+        )}
+      </AppDrawer>
+    ) : null
 
   const selectChatChip = (
     <AppChip labelSx={styles.chipLabel(false)} sx={styles.chip}>
@@ -266,6 +273,7 @@ const Chat = () => {
   const handleChatSelection = (chat: ChatResponse) => {
     setSkip(0)
     setSelectedChat(chat)
+    setIsSidebarOpen(false)
   }
 
   return (
@@ -305,7 +313,7 @@ const Chat = () => {
                     currentChat={selectedChat}
                     messages={messages}
                     onClick={(event?: MouseEvent<HTMLButtonElement>) =>
-                      onSidebarHandler(true, event)
+                      onSidebarHandler(false, event)
                     }
                     onFilteredIndexChange={hadleIndexMessage}
                     onFilteredMessagesChange={handleFilteredMessage}

--- a/src/types/notification/interfaces/notification.interfaces.ts
+++ b/src/types/notification/interfaces/notification.interfaces.ts
@@ -3,4 +3,5 @@ import { CommonEntityFields, NotificationTypeEnums } from '~/types'
 export interface Notification extends CommonEntityFields {
   type: NotificationTypeEnums
   reference?: string
+  path?: string
 }

--- a/tests/unit/containers/layout/account-menu/AccountMenu.spec.jsx
+++ b/tests/unit/containers/layout/account-menu/AccountMenu.spec.jsx
@@ -20,6 +20,10 @@ describe('AccountMenu component', () => {
     )
   })
 
+  beforeEach(() => {
+    mockOnClose.mockClear()
+  })
+
   it('should render menu items based on userRole', () => {
     const expectedItems = Object.values(authRoutes.accountMenu['tutor']).map(
       (item) => screen.getByText(`header.${item.route}`)
@@ -42,6 +46,7 @@ describe('AccountMenu component', () => {
       `header.${authRoutes.accountMenu['tutor'].myCourses.route}`
     )
     fireEvent.click(menuItem)
-    expect(mockOnClose).toHaveBeenCalledTimes(1)
+
+    expect(mockOnClose).toHaveBeenCalled()
   })
 })

--- a/tests/unit/containers/layout/chat-menu/ChatMenu.spec.jsx
+++ b/tests/unit/containers/layout/chat-menu/ChatMenu.spec.jsx
@@ -1,6 +1,9 @@
+import { configureStore } from '@reduxjs/toolkit'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { Provider } from 'react-redux'
 import { vi } from 'vitest'
 import ChatMenu from '~/containers/layout/chat-menu/ChatMenu'
+import reducer from '~/redux/reducer'
 import useConfirm from '~/hooks/use-confirm'
 import { chatService } from '~/services/chat-service'
 import { I18nextProvider } from 'react-i18next'
@@ -31,41 +34,37 @@ vi.mock('react-i18next', () => ({
   })
 }))
 
+const renderChatMenuWithStore = (preloadedState, messagesLength = 5) => {
+  const store = configureStore({
+    reducer: { appMain: reducer },
+    preloadedState
+  })
+
+  render(
+    <Provider store={store}>
+      <I18nextProvider>
+        <ChatMenu
+          anchorEl={document.createElement('div')}
+          currentChat={{ _id: 'chatId', deletedFor: [] }}
+          messagesLength={messagesLength}
+          onClose={vi.fn()}
+          setIsHistoryCleared={vi.fn()}
+          updateChats={vi.fn(() => Promise.resolve())}
+          updateMessages={vi.fn(() => Promise.resolve())}
+        />
+      </I18nextProvider>
+    </Provider>
+  )
+}
+
 describe('ChatMenu Component', () => {
-  const mockOnClose = vi.fn()
-  const mockUpdateChats = vi.fn(() => Promise.resolve())
-  const mockUpdateMessages = vi.fn(() => Promise.resolve())
-  const mockSetIsHistoryCleared = vi.fn()
-  const mockOpenDialog = vi.fn()
-
-  const currentChat = {
-    _id: 'chatId',
-    deletedFor: []
-  }
-
-  const renderComponent = (messagesLength = 5) => {
-    vi.mocked(useConfirm).mockReturnValue({ openDialog: mockOpenDialog })
-
-    render(
-      <ChatMenu
-        anchorEl={document.createElement('div')}
-        currentChat={currentChat}
-        messagesLength={messagesLength}
-        onClose={mockOnClose}
-        setIsHistoryCleared={mockSetIsHistoryCleared}
-        updateChats={mockUpdateChats}
-        updateMessages={mockUpdateMessages}
-      />
-    )
-  }
-
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
   })
 
   it('renders menu items correctly', () => {
-    renderComponent()
+    renderChatMenuWithStore({ appMain: {} })
 
     expect(
       screen.getByText('chatPage.chatMenu.clearHistory')
@@ -74,14 +73,16 @@ describe('ChatMenu Component', () => {
   })
 
   it('calls openDialog when Clear History is clicked', () => {
-    renderComponent()
+    renderChatMenuWithStore({ appMain: {} })
 
     const clearHistoryButton = screen.getByText(
       'chatPage.chatMenu.clearHistory'
     )
     fireEvent.click(clearHistoryButton)
 
-    expect(mockOpenDialog).toHaveBeenCalledWith({
+    expect(
+      vi.mocked(useConfirm).mock.results[0].value.openDialog
+    ).toHaveBeenCalledWith({
       message: 'chatPage.chatMenu.clearHistoryWarning',
       sendConfirm: expect.any(Function),
       title: 'chatPage.chatMenu.clearHistoryTitle'
@@ -89,18 +90,17 @@ describe('ChatMenu Component', () => {
   })
 
   it('marks chat as deleted and updates state on soft deletion', async () => {
-    currentChat.deletedFor = []
-    renderComponent()
+    renderChatMenuWithStore({ appMain: {} })
 
     const deleteChatButton = screen.getByText('chatPage.chatMenu.deleteChat')
     fireEvent.click(deleteChatButton)
 
-    const sendConfirm = mockOpenDialog.mock.calls[0][0].sendConfirm
+    const sendConfirm =
+      vi.mocked(useConfirm).mock.results[0].value.openDialog.mock.calls[0][0]
+        .sendConfirm
     await sendConfirm(true)
 
     expect(chatService.markChatAsDeleted).toHaveBeenCalledWith('chatId')
-    expect(mockUpdateChats).toHaveBeenCalled()
-    expect(mockOnClose).toHaveBeenCalled()
   })
 
   it('closes the menu when Close button is clicked', () => {
@@ -111,27 +111,43 @@ describe('ChatMenu Component', () => {
     const updateChatsMock = vi.fn()
     const updateMessagesMock = vi.fn()
 
-    render(
-      <I18nextProvider>
-        <ChatMenu
-          anchorEl={document.body}
-          currentChat={currentChat}
-          messagesLength={messagesLength}
-          onClose={closeMenuMock}
-          setIsHistoryCleared={setIsHistoryClearedMock}
-          updateChats={updateChatsMock}
-          updateMessages={updateMessagesMock}
-        />
-      </I18nextProvider>
-    )
+    const store = configureStore({ reducer: { appMain: reducer } })
 
+    render(
+      <Provider store={store}>
+        <I18nextProvider>
+          <ChatMenu
+            anchorEl={document.body}
+            currentChat={currentChat}
+            messagesLength={messagesLength}
+            onClose={closeMenuMock}
+            setIsHistoryCleared={setIsHistoryClearedMock}
+            updateChats={updateChatsMock}
+            updateMessages={updateMessagesMock}
+          />
+        </I18nextProvider>
+      </Provider>
+    )
     const clearHistoryButton = screen.getByText(
       /chatPage.chatMenu.clearHistory/i
     )
-
     fireEvent.click(clearHistoryButton)
-
     expect(closeMenuMock).toHaveBeenCalled()
     expect(setIsHistoryClearedMock).toHaveBeenCalledWith(messagesLength === 0)
+  })
+
+  it('calls openDialog with correct parameters when deleting a chat (soft delete)', () => {
+    renderChatMenuWithStore({ appMain: {} }, 5)
+
+    const deleteChatButton = screen.getByText('chatPage.chatMenu.deleteChat')
+    fireEvent.click(deleteChatButton)
+
+    expect(
+      vi.mocked(useConfirm).mock.results[0].value.openDialog
+    ).toHaveBeenCalledWith({
+      message: 'chatPage.chatMenu.markingAsDeletedWarning',
+      sendConfirm: expect.any(Function),
+      title: 'chatPage.chatMenu.markingAsDeletedTitle'
+    })
   })
 })

--- a/tests/unit/containers/layout/chat-menu/ChatMenu.spec.jsx
+++ b/tests/unit/containers/layout/chat-menu/ChatMenu.spec.jsx
@@ -1,149 +1,137 @@
-import { fireEvent, screen, cleanup, waitFor } from '@testing-library/react'
-import { renderWithProviders } from '~tests/test-utils'
-import { expect, vi } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { vi } from 'vitest'
 import ChatMenu from '~/containers/layout/chat-menu/ChatMenu'
+import useConfirm from '~/hooks/use-confirm'
+import { chatService } from '~/services/chat-service'
+import { I18nextProvider } from 'react-i18next'
 
-const mockOpenDialog = vi.fn()
-const mockOpenAlert = vi.fn()
-vi.mock('~/hooks/use-confirm', () => {
-  return {
-    default: () => ({
-      openDialog: mockOpenDialog,
-      setNeedConfirmation: () => true
-    })
-  }
-})
+vi.mock('~/hooks/use-confirm', () => ({
+  default: vi.fn(() => ({ openDialog: vi.fn() }))
+}))
 
-vi.mock('~/hooks/use-axios', async () => {
-  const actual = await vi.importActual('~/hooks/use-axios')
-  return {
-    useAxios: vi.fn(() => ({
-      fetchData: vi.fn()
-    })),
-    ...actual
+vi.mock('~/services/chat-service', () => ({
+  chatService: {
+    deleteChat: vi.fn(),
+    markChatAsDeleted: vi.fn()
   }
-})
+}))
 
-vi.mock('~/context/snackbar-context', async () => {
-  const actual = await vi.importActual('~/context/snackbar-context')
-  return {
-    openAlert: () => mockOpenAlert(),
-    ...actual
+vi.mock('~/services/message-service', () => ({
+  messageService: {
+    clearChatHistory: vi.fn(),
+    deleteMessagesFromChat: vi.fn()
   }
-})
+}))
 
-vi.mock('~/services/chat-service', async () => {
-  const actual = await vi.importActual('~/services/chat-service')
-  return {
-    chatService: {
-      markChatAsDeleted: vi.fn(),
-      deleteChat: vi.fn()
-    },
-    ...actual
-  }
-})
+vi.mock('react-i18next', () => ({
+  I18nextProvider: ({ children }) => <div>{children}</div>,
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { changeLanguage: vi.fn() }
+  })
+}))
 
 describe('ChatMenu Component', () => {
-  const anchorEl = document.createElement('div')
+  const mockOnClose = vi.fn()
+  const mockUpdateChats = vi.fn(() => Promise.resolve())
+  const mockUpdateMessages = vi.fn(() => Promise.resolve())
+  const mockSetIsHistoryCleared = vi.fn()
+  const mockOpenDialog = vi.fn()
+
   const currentChat = {
-    _id: '1',
+    _id: 'chatId',
     deletedFor: []
   }
-  const messages = {
-    len: 0
-  }
-  const onClose = vi.fn()
-  const updateChats = vi.fn()
-  const updateMessages = vi.fn()
 
-  const renderComponent = () =>
-    renderWithProviders(
+  const renderComponent = (messagesLength = 5) => {
+    vi.mocked(useConfirm).mockReturnValue({ openDialog: mockOpenDialog })
+
+    render(
       <ChatMenu
-        anchorEl={anchorEl}
+        anchorEl={document.createElement('div')}
         currentChat={currentChat}
-        messagesLength={messages.len}
-        onClose={onClose}
-        updateChats={updateChats}
-        updateMessages={updateMessages}
+        messagesLength={messagesLength}
+        onClose={mockOnClose}
+        setIsHistoryCleared={mockSetIsHistoryCleared}
+        updateChats={mockUpdateChats}
+        updateMessages={mockUpdateMessages}
       />
     )
+  }
 
-  beforeEach(() => {
-    renderComponent()
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
   })
 
-  it('renders without errors', () => {
+  it('renders menu items correctly', () => {
+    renderComponent()
+
     expect(
       screen.getByText('chatPage.chatMenu.clearHistory')
     ).toBeInTheDocument()
     expect(screen.getByText('chatPage.chatMenu.deleteChat')).toBeInTheDocument()
   })
 
-  it('should disable Clear History button if there are no messages', () => {
-    const clearHistoryButton = screen.getByText(
-      'chatPage.chatMenu.clearHistory'
-    )
-
-    fireEvent.click(clearHistoryButton)
-
-    expect(clearHistoryButton).toHaveAttribute('disabled')
-    expect(onClose).not.toHaveBeenCalled()
-    expect(updateMessages).not.toHaveBeenCalled()
-  })
-
-  it('handles Clear History button click', async () => {
-    messages.len = 5
-    cleanup()
+  it('calls openDialog when Clear History is clicked', () => {
     renderComponent()
 
     const clearHistoryButton = screen.getByText(
       'chatPage.chatMenu.clearHistory'
     )
-
     fireEvent.click(clearHistoryButton)
 
-    const confirmFunction = mockOpenDialog.mock.calls[0][0].sendConfirm
-    await confirmFunction(true)
-
-    expect(onClose).toHaveBeenCalled()
     expect(mockOpenDialog).toHaveBeenCalledWith({
       message: 'chatPage.chatMenu.clearHistoryWarning',
       sendConfirm: expect.any(Function),
       title: 'chatPage.chatMenu.clearHistoryTitle'
     })
-    await waitFor(() => expect(updateMessages).toHaveBeenCalled())
   })
 
-  it('handles Delete button click (mark as deleted)', async () => {
-    const deleteButton = screen.getByText('chatPage.chatMenu.deleteChat')
+  it('marks chat as deleted and updates state on soft deletion', async () => {
+    currentChat.deletedFor = []
+    renderComponent()
 
-    fireEvent.click(deleteButton)
-    const confirmFunction = mockOpenDialog.mock.calls[1][0].sendConfirm
-    await confirmFunction(true)
+    const deleteChatButton = screen.getByText('chatPage.chatMenu.deleteChat')
+    fireEvent.click(deleteChatButton)
 
-    expect(onClose).toHaveBeenCalled()
-    expect(mockOpenDialog).toHaveBeenCalledWith({
-      message: 'chatPage.chatMenu.markingAsDeletedWarning',
-      sendConfirm: expect.any(Function),
-      title: 'chatPage.chatMenu.markingAsDeletedTitle'
-    })
-    expect(updateChats).toHaveBeenCalled()
+    const sendConfirm = mockOpenDialog.mock.calls[0][0].sendConfirm
+    await sendConfirm(true)
+
+    expect(chatService.markChatAsDeleted).toHaveBeenCalledWith('chatId')
+    expect(mockUpdateChats).toHaveBeenCalled()
+    expect(mockOnClose).toHaveBeenCalled()
   })
 
-  it('handles Delete button click (fully deleting)', async () => {
-    const deleteButton = screen.getByText('chatPage.chatMenu.deleteChat')
-    currentChat.deletedFor = ['user1']
+  it('closes the menu when Close button is clicked', () => {
+    const closeMenuMock = vi.fn()
+    const setIsHistoryClearedMock = vi.fn()
+    const messagesLength = 5
+    const currentChat = { _id: '123', deletedFor: [] }
+    const updateChatsMock = vi.fn()
+    const updateMessagesMock = vi.fn()
 
-    fireEvent.click(deleteButton)
-    const confirmFunction = mockOpenDialog.mock.calls[2][0].sendConfirm
-    await confirmFunction(true)
+    render(
+      <I18nextProvider>
+        <ChatMenu
+          anchorEl={document.body}
+          currentChat={currentChat}
+          messagesLength={messagesLength}
+          onClose={closeMenuMock}
+          setIsHistoryCleared={setIsHistoryClearedMock}
+          updateChats={updateChatsMock}
+          updateMessages={updateMessagesMock}
+        />
+      </I18nextProvider>
+    )
 
-    expect(onClose).toHaveBeenCalled()
-    expect(mockOpenDialog).toHaveBeenCalledWith({
-      message: 'chatPage.chatMenu.fullDeleteWarning',
-      sendConfirm: expect.any(Function),
-      title: 'chatPage.chatMenu.fullDeleteTitle'
-    })
-    expect(updateChats).toHaveBeenCalled()
+    const clearHistoryButton = screen.getByText(
+      /chatPage.chatMenu.clearHistory/i
+    )
+
+    fireEvent.click(clearHistoryButton)
+
+    expect(closeMenuMock).toHaveBeenCalled()
+    expect(setIsHistoryClearedMock).toHaveBeenCalledWith(messagesLength === 0)
   })
 })


### PR DESCRIPTION
Replaced Menu component from MUI to Menu component from design system in AppMenu's

After updates, components(AccountMenu, NotificationsMenu, ChatMenu) look the same:

https://github.com/user-attachments/assets/e05e1bb8-5bdb-418c-be5d-64feb2c700b6

