### PR TITLE
(SP:) [Edit profile. Profile]Verify that tutor/student can add only one language to 'Your native language' field #2726

### DIFF
--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -54,6 +54,32 @@ describe('ProfileTabForm', () => {
     expect(languageField.value).toBe(newLanguageValue)
   })
 
+  it('should add only one language to "Your native language" field', () => {
+    const languages = [
+      'English',
+      'Ukrainian',
+      'Polish',
+      'German',
+      'French',
+      'Spanish',
+      'Arabic'
+    ]
+    const languageField = screen.getByLabelText(
+      'becomeTutor.languages.autocompleteLabel'
+    )
+    expect(languageField).toBeInTheDocument()
+
+    fireEvent.click(languageField)
+
+    for (const lang of languages) {
+      fireEvent.change(languageField, { target: { value: lang } })
+      const option = screen.getByText(lang)
+      fireEvent.click(option, { ctrlKey: true })
+    }
+
+    expect(languageField).toHaveValue('Arabic')
+  })
+
   it('should not allow typing more than 200 characters in "Professional headline"', async () => {
     const longText = 'a'.repeat(250)
     const input = screen


### PR DESCRIPTION
Added test for the validation of the "Your native language" field in the "ProfileTabForm" component.

Although these test did not increase coverage, they clearly target important edge cases in form validation, improving confidence in the component's behavior.

![Screenshot 2025-04-30 162617](https://github.com/user-attachments/assets/a737b272-b8c5-4e63-8c39-b5feebe0c502)
