### PR TITLE
(SP:) [Edit profile. Profile]Verify that tutor/student can search for native language in 'Your native language' field. #2729

### DIFF
--- a/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
+++ b/tests/unit/containers/edit-profile/profile-tab/profile-tab-form/ProfileTabForm.spec.jsx
@@ -65,6 +65,27 @@ describe('ProfileTabForm', () => {
     expect(input).toHaveValue('a'.repeat(200))
   })
 
+  it("should allow searching for native language in the 'Your native language' field", () => {
+    const partialInput = 'Ukra'
+    const expectedLanguage = 'Ukrainian'
+
+    const languageField = screen.getByLabelText(
+      'becomeTutor.languages.autocompleteLabel'
+    )
+
+    fireEvent.click(languageField)
+    fireEvent.change(languageField, { target: { value: partialInput } })
+
+    const filteredOption = screen.getByText(expectedLanguage)
+    expect(filteredOption).toBeInTheDocument()
+
+    fireEvent.click(filteredOption)
+    expect(handleNonInputValueChange).toHaveBeenCalledWith(
+      'nativeLanguage',
+      expectedLanguage
+    )
+  })
+
   it('should handle photo deletion', () => {
     const removePhotoBtn = screen.getByRole('button', { name: 'common.remove' })
     fireEvent.click(removePhotoBtn)


### PR DESCRIPTION
This PR adds a test case to verify that **tutor/student users can search for their native language** in the **"Your native language"** dropdown field.

### Changes

- Implemented automated test to check the search functionality within the language selection field.