### PR TITLE
(SP: 0.5) Fixed login popup width for invalid password

### DIFF
--- a/src/containers/guest-home-page/login-form/LoginForm.styles.js
+++ b/src/containers/guest-home-page/login-form/LoginForm.styles.js
@@ -2,6 +2,7 @@ export const styles = {
   form: {
     display: 'flex',
     flexDirection: 'column',
+    rowGap: '26px',
     minWidth: { sm: '340px' }
   },
   loginOptionsContainer: {
@@ -13,8 +14,7 @@ export const styles = {
     mb: '10px'
   },
   input: {
-    maxWidth: '343px',
-    mb: '5px'
+    maxWidth: '343px'
   },
   loginButton: {
     width: '100%',

--- a/src/containers/guest-home-page/login-form/LoginForm.tsx
+++ b/src/containers/guest-home-page/login-form/LoginForm.tsx
@@ -84,6 +84,7 @@ const LoginForm: React.FC<LoginFormProps> = ({
         onBlur={handleBlur('password')}
         onChange={handleChange('password')}
         required
+        sx={styles.input}
         type={showPassword ? 'text' : 'password'}
         value={data.password}
       />


### PR DESCRIPTION
Fixed login popup width for invalid password and added rowGap between inputs according to figma design.

**How it looks now:**
![image](https://github.com/user-attachments/assets/e2f221f3-38bf-4a32-9f2f-df4acead051f)

**In Figma:**
![image](https://github.com/user-attachments/assets/bfe30c39-5bc1-483f-a8fd-8311c8ad8f9b)
