### PR TITLE
chore(gitignore): use wildcard for dotenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,8 @@ test-report.xml
 /.idea
 .idea
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+!.env.example
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
**Description:**
This PR simplifies the .gitignore rules for dotenv files by replacing multiple specific entries:

**Was:**
```text
.env.local  
.env.development.local  
.env.test.local  
.env.production.local 
```

**Now:**
```text
.env*  
!.env.example
```

**Why:**

- Reduces duplication
- Ensures all environment-specific .env files are excluded
- Keeps .env.example for documentation and onboarding purposes

No functional changes to the application — only cleanup for maintainability.