### PR TITLE
Chore/3422/deps update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/icons-material": "^5.14.16",
         "@mui/material": "^5.14.16",
         "@mui/x-date-pickers": "^5.0.20",
-        "@reduxjs/toolkit": "^2.2.7",
+        "@reduxjs/toolkit": "^2.7.0",
         "@tanstack/react-query": "^5.62.7",
         "@tinymce/tinymce-react": "^5.1.1",
         "allotment": "^1.19.3",
@@ -3369,17 +3369,20 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.7.tgz",
-      "integrity": "sha512-faI3cZbSdFb8yv9dhDTmGwclW0vk0z5o1cia+kf7gCbaCwHI5e+7tP57mJUv22pNcNbeA62GSrPpfrUfdXcQ6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.7.0.tgz",
+      "integrity": "sha512-XVwolG6eTqwV0N8z/oDlN93ITCIGIop6leXlGJI/4EKy+0POYkR+ABHRSdGXY+0MQvJBP8yAzh+EYFxTuvmBiQ==",
+      "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
         "immer": "^10.0.3",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
         "reselect": "^5.1.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
         "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -3642,6 +3645,18 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@storybook/addon-actions": {
       "version": "8.2.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@tinymce/tinymce-react": "^5.1.1",
         "allotment": "^1.19.3",
         "axios": "^1.8.3",
-        "chart.js": "^4.4.4",
+        "chart.js": "^4.4.9",
         "date-fns": "^2.30.0",
         "dompurify": "^3.2.4",
         "emoji-mart": "^5.5.2",
@@ -6992,9 +6992,10 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.4.tgz",
-      "integrity": "sha512-emICKGBABnxhMjUjlYRR12PmOXhJ2eJjEHL2/dZlWjxRAZT1D8xplLFq5M0tMQK8ja+wBS/tuVEJB5C6r7VxJA==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mui/icons-material": "^5.14.16",
     "@mui/material": "^5.14.16",
     "@mui/x-date-pickers": "^5.0.20",
-    "@reduxjs/toolkit": "^2.2.7",
+    "@reduxjs/toolkit": "^2.7.0",
     "@tanstack/react-query": "^5.62.7",
     "@tinymce/tinymce-react": "^5.1.1",
     "allotment": "^1.19.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@tinymce/tinymce-react": "^5.1.1",
     "allotment": "^1.19.3",
     "axios": "^1.8.3",
-    "chart.js": "^4.4.4",
+    "chart.js": "^4.4.9",
     "date-fns": "^2.30.0",
     "dompurify": "^3.2.4",
     "emoji-mart": "^5.5.2",


### PR DESCRIPTION
Combines updates from:

- #3419 (`chart.js` from 4.4.4 to 4.4.9)
- #3421 (`@reduxjs/toolkit` from 2.2.7 to 2.7.0)

Both updates were cherry-picked into this branch.