### PR TITLE
add test for account activation success

### DIFF
--- a/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/password-security-tab/PasswordSecurityTab.spec.jsx
@@ -171,4 +171,40 @@ describe('PasswordSecurityTab', () => {
       })
     })
   })
+  it('should appear success message after clicking the Activate button', async () => {
+    mockAxiosClient
+      .onPatch(`${URLs.users.activate}/${userDataMock._id}`)
+      .reply(200)
+
+    renderWithProviders(
+      <TestSnackbar>
+        <PasswordSecurityTab />
+      </TestSnackbar>,
+      {
+        preloadedState: {
+          appMain: {
+            userId: userDataMock._id,
+            userStatus: 'inactive'
+          }
+        }
+      }
+    )
+
+    const activateAccountButton = screen.getByText(
+      'editProfilePage.profile.passwordSecurityTab.activateAccount'
+    )
+    fireEvent.click(activateAccountButton)
+
+    const activateButton = screen.getByText(
+      'editProfilePage.profile.passwordSecurityTab.activateBtn'
+    )
+    fireEvent.click(activateButton)
+
+    await waitFor(() => {
+      expect(openAlert).toHaveBeenCalledWith({
+        severity: snackbarVariants.success,
+        message: 'editProfilePage.profile.successMessage'
+      })
+    })
+  })
 })


### PR DESCRIPTION


### Description

Added a test for the **account activation** flow in the `PasswordSecurityTab` component. It ensures that after clicking the **"Activate Account"** button, a success message is displayed in the snackbar.

### Changes

* Added test for account activation success message
* Mocked API call for activation
* Verified success snackbar message is shown

![image](https://github.com/user-attachments/assets/82a9b273-4ed3-40c3-ba3f-e1d131c00efc)

