### PR TITLE
test to ensure that edit category modal opens on button click

### DIFF
--- a/tests/unit/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.spec.jsx
@@ -23,7 +23,13 @@ vi.mock('~/context/modal-context', async () => {
 vi.mock(
   '~/containers/edit-profile/professional-info-tab/professional-category-list/ProfessionalCategoryList',
   () => ({
-    default: () => <div>Professional Category List</div>
+    default: ({ openProfessionalCategoryModal }) => (
+      <div>
+        <button onClick={() => openProfessionalCategoryModal({}, true)}>
+          Edit category
+        </button>
+      </div>
+    )
   })
 )
 
@@ -137,5 +143,14 @@ describe('ProfessionalInfoTab for tutor', () => {
     )
 
     expect(aboutTutorTitle).toBeInTheDocument()
+  })
+  it('should open edit category modal when an edit button is clicked for a category', () => {
+    const editButton = screen.getByRole('button', {
+      name: /edit category/i
+    })
+
+    fireEvent.click(editButton)
+
+    expect(mockOpenModal).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### Description

Added a test to verify that the edit category modal opens correctly when the "Edit" button is clicked in the `ProfessionalInfoTab` component. The test ensures that the modal opens with the correct parameters.

### Changes

* Added test for opening edit category modal on button click
* Mocked `ProfessionalCategoryList` component to simulate edit button click
* Verified that `openModal` is called when the edit button is clicked
![image](https://github.com/user-attachments/assets/048436f1-4378-4d47-97e1-6aadf06f4781)

