### PR TITLE
Add resource for updating course availability in `CreateCourse` page

### DIFF
--- a/src/pages/create-course/CreateCourse.handlers.ts
+++ b/src/pages/create-course/CreateCourse.handlers.ts
@@ -10,7 +10,9 @@ import {
   AddSectionResourcesEvent,
   ResourceUpdatedEvent,
   ResourceRemovedEvent,
-  ResourcesOrderChangeEvent
+  ResourcesOrderChangeEvent,
+  ResourceUpdateAvailabilityEvent,
+  ResourceAvailability
 } from '~/types'
 
 const getSectionById = (
@@ -82,7 +84,17 @@ export const resourceHandlers = {
   [CourseResourceEventType.ResourcesOrderChange]: (
     ctx: CreateCourseContext,
     event: ResourcesOrderChangeEvent
-  ) => updateResourcesOrder(ctx, event.sectionId, event.resources)
+  ) => updateResourcesOrder(ctx, event.sectionId, event.resources),
+  [CourseResourceEventType.ResourceUpdateAvailability]: (
+    ctx: CreateCourseContext,
+    event: ResourceUpdateAvailabilityEvent
+  ) =>
+    updateResourceAvailability(
+      ctx,
+      event.sectionId,
+      event.resourceId,
+      event.availability
+    )
 }
 
 export const addSectionResources = (
@@ -164,4 +176,28 @@ export const updateResourcesOrder = (
     resourceType: resource.resourceType
   }))
   handleSectionChange(sectionId, 'resources', newSectionResources)
+}
+
+export const updateResourceAvailability = (
+  { sections, handleSectionChange }: CreateCourseContext,
+  sectionId: CourseSection['id'],
+  resourceId: CourseResource['id'],
+  availability: ResourceAvailability
+): void => {
+  const section = getSectionById(sections, sectionId)
+  if (!section) return
+
+  const updatedResources = section.resources.map((item) =>
+    item.resource.id === resourceId
+      ? {
+          ...item,
+          resource: {
+            ...item.resource,
+            availability
+          }
+        }
+      : item
+  )
+
+  handleSectionChange(sectionId, 'resources', updatedResources)
 }

--- a/tests/unit/pages/create-course/CreateCourse.handlers.spec.jsx
+++ b/tests/unit/pages/create-course/CreateCourse.handlers.spec.jsx
@@ -6,8 +6,10 @@ import {
   updateResource,
   deleteResource,
   updateResourcesOrder,
-  updateResourceAvailability
+  updateResourceAvailability,
+  resourceHandlers
 } from '~/pages/create-course/CreateCourse.handlers'
+import { CourseResourceEventType } from '~/types'
 import { sectionInitialData } from '~/pages/create-course/CreateCourse.constants'
 import { isValidUUID } from '~tests/test-utils'
 import { vi } from 'vitest'
@@ -154,6 +156,61 @@ describe('Test CreateCourse handlers:', () => {
         resource: {
           id: 'resource-1',
           availability: newAvailability
+        },
+        resourceType: 'type'
+      }
+    ])
+  })
+
+  it('updateResourceAvailability: should return nothing if section is not found', () => {
+    const sections = []
+    const handleSectionChange = vi.fn()
+    const ctx = { sections, handleSectionChange }
+
+    updateResourceAvailability(
+      ctx,
+      'non-existent-section',
+      'resource-1',
+      'Unavailable'
+    )
+
+    expect(handleSectionChange).not.toHaveBeenCalled()
+  })
+
+  it('resourceHandlers.ResourceUpdateAvailability: should update availability through handler', () => {
+    const handleSectionChange = vi.fn()
+    const ctx = {
+      sections: [
+        {
+          id: 'section-1',
+          resources: [
+            {
+              resource: { id: 'resource-1', availability: 'Available' },
+              resourceType: 'type'
+            }
+          ]
+        }
+      ],
+      handleSectionChange
+    }
+
+    const event = {
+      type: CourseResourceEventType.ResourceUpdateAvailability,
+      sectionId: 'section-1',
+      resourceId: 'resource-1',
+      availability: 'Unavailable'
+    }
+
+    resourceHandlers[CourseResourceEventType.ResourceUpdateAvailability](
+      ctx,
+      event
+    )
+
+    expect(handleSectionChange).toHaveBeenCalledWith('section-1', 'resources', [
+      {
+        resource: {
+          id: 'resource-1',
+          availability: 'Unavailable'
         },
         resourceType: 'type'
       }

--- a/tests/unit/pages/create-course/CreateCourse.handlers.spec.jsx
+++ b/tests/unit/pages/create-course/CreateCourse.handlers.spec.jsx
@@ -5,7 +5,8 @@ import {
   addSectionResources,
   updateResource,
   deleteResource,
-  updateResourcesOrder
+  updateResourcesOrder,
+  updateResourceAvailability
 } from '~/pages/create-course/CreateCourse.handlers'
 import { sectionInitialData } from '~/pages/create-course/CreateCourse.constants'
 import { isValidUUID } from '~tests/test-utils'
@@ -125,6 +126,35 @@ describe('Test CreateCourse handlers:', () => {
     expect(handleSectionChange).toHaveBeenCalledWith('section-1', 'resources', [
       {
         resource: { id: 'resource-1', resourceType: 'type' },
+        resourceType: 'type'
+      }
+    ])
+  })
+
+  it('updateResourceAvailability: should update availability of a resource in a section', () => {
+    const sections = [
+      {
+        id: 'section-1',
+        resources: [
+          {
+            resource: { id: 'resource-1', availability: 'Available' },
+            resourceType: 'type'
+          }
+        ]
+      }
+    ]
+    const handleSectionChange = vi.fn()
+    const ctx = { sections, handleSectionChange }
+    const newAvailability = 'Unavailable'
+
+    updateResourceAvailability(ctx, 'section-1', 'resource-1', newAvailability)
+
+    expect(handleSectionChange).toHaveBeenCalledWith('section-1', 'resources', [
+      {
+        resource: {
+          id: 'resource-1',
+          availability: newAvailability
+        },
         resourceType: 'type'
       }
     ])


### PR DESCRIPTION
- Added `updateResourceAvailability` to fix the problem with missing handler in `resourceHandlers` (CreateCourse.handlers.ts);
- Added the relevant tests.

Fixed an error in `CreateCourse` page:
![image](https://github.com/user-attachments/assets/93b0b88c-2185-4e95-ab98-914232b4e9dd)

Successfully adding an available lesson and using the updateAvailability() method:
![image](https://github.com/user-attachments/assets/6549af86-de2d-4ed9-9bfd-86aa4d7f3f39)

After that, the used lesson becomes unavailable:
![image](https://github.com/user-attachments/assets/067b3679-88f6-4ee8-9872-3e621f094404)

Issue: #3427 