### PR TITLE
Made mainSubjects field optional in user stepper

### DIFF
--- a/src/hooks/use-steps.tsx
+++ b/src/hooks/use-steps.tsx
@@ -85,7 +85,7 @@ const useSteps = ({ steps }: UseSteps) => {
       professionalSummary: professionalSummary?.length
         ? professionalSummary
         : undefined,
-      mainSubjects: stepData.subjects,
+      mainSubjects: stepData.subjects.length ? stepData.subjects : undefined,
       nativeLanguage: stepData.language ?? undefined
     }
 


### PR DESCRIPTION
Made mainSubjects field optional in user stepper. Now user can skip all the steps without needing to add main subject.

**How it works now:**

https://github.com/user-attachments/assets/58a45f27-289f-4a50-83b9-88e5c226eecf



**No mainSubjects field is sent when it's empty:**
![image](https://github.com/user-attachments/assets/44638f0a-48c4-4bea-837c-85500d36f2b9)
