### PR TITLE
Fix profile update to reflect changes without page reload 

### DIFF
--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -13,6 +13,8 @@ import Box from '@mui/material/Box'
 import Divider from '@mui/material/Divider'
 
 import useConfirm from '~/hooks/use-confirm'
+import useMutation from '~/hooks/use-mutation'
+import useSnackbarAlert from '~/hooks/use-snackbar-alert'
 import { useAppDispatch, useAppSelector } from '~/hooks/use-redux'
 import Loader from '~/components/loader/Loader'
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
@@ -27,13 +29,12 @@ import {
 import { tabsData } from '~/pages/edit-profile/EditProfile.constants'
 import {
   fetchUserById,
-  updateUser,
   EditProfileState
 } from '~/redux/features/editProfileSlice'
 import { LoadingStatusEnum } from '~/redux/redux.constants'
-import { openAlert } from '~/redux/features/snackbarSlice'
 import { snackbarVariants } from '~/constants'
 import { authRoutes } from '~/router/constants/authRoutes'
+import { userService } from '~/services/user-service'
 
 import { styles } from '~/pages/edit-profile/EditProfile.styles'
 import { getChangedFields } from '~/utils/get-changed-fields'
@@ -53,6 +54,8 @@ const EditProfile = () => {
   const activeTab = searchParams.get('tab') as UserProfileTabsEnum
 
   const { t } = useTranslation()
+
+  const { handleAlert, handleErrorAlert } = useSnackbarAlert()
 
   const dispatch = useAppDispatch()
 
@@ -160,8 +163,27 @@ const EditProfile = () => {
     }
   }
 
-  const { hash, search, pathname } = useLocation()
+  const { search, pathname } = useLocation()
   const navigate = useNavigate()
+
+  const updateUserProfile = useCallback(
+    (params: UpdateUserParams) => userService.updateUser(userId, params),
+    [userId]
+  )
+
+  const onUpdateUserSuccess = () => {
+    handleAlert({
+      severity: snackbarVariants.success,
+      message: 'editProfilePage.profile.successMessage'
+    })
+  }
+
+  const { mutateAsync: updateUser } = useMutation({
+    mutationFn: updateUserProfile,
+    queryKey: ['user', userId, userRole],
+    onSuccess: onUpdateUserSuccess,
+    onError: handleErrorAlert
+  })
 
   const handleUpdateUser = useCallback(async (): Promise<void> => {
     const { country, city } = profileState
@@ -205,25 +227,14 @@ const EditProfile = () => {
       dataWithoutEmptyStrings.photo = photo
     }
 
-    await dispatch(
-      updateUser({
-        userId,
-        params: dataWithoutEmptyStrings
-      })
-    )
-
-    dispatch(
-      openAlert({
-        severity: snackbarVariants.success,
-        message: 'editProfilePage.profile.successMessage'
-      })
-    )
+    await updateUser(dataWithoutEmptyStrings)
+    setIsModalConfirmed(true)
     setInitialEditProfileState(structuredClone(profileState))
 
-    if (hash) {
-      navigate(`${authRoutes.myProfile.path}#complete`)
-    }
-  }, [profileState, changedFields, dispatch, userId, hash, userRole, navigate])
+    navigate(`${authRoutes.myProfile.path}#complete`, {
+      state: { refresh: true }
+    })
+  }, [profileState, changedFields, userRole, navigate, updateUser])
 
   const blocker = useBlocker(getProfileTabChangedFields)
   const { openDialog } = useConfirm()
@@ -268,6 +279,8 @@ const EditProfile = () => {
       }
 
       openAffirmativeModal(hasPathnameChanged)
+    } else if (isModalConfirmed && blocker) {
+      blocker.proceed?.()
     }
   }, [
     blocker,

--- a/src/pages/edit-profile/EditProfile.tsx
+++ b/src/pages/edit-profile/EditProfile.tsx
@@ -163,7 +163,7 @@ const EditProfile = () => {
     }
   }
 
-  const { search, pathname } = useLocation()
+  const { hash, search, pathname } = useLocation()
   const navigate = useNavigate()
 
   const updateUserProfile = useCallback(
@@ -231,10 +231,10 @@ const EditProfile = () => {
     setIsModalConfirmed(true)
     setInitialEditProfileState(structuredClone(profileState))
 
-    navigate(`${authRoutes.myProfile.path}#complete`, {
-      state: { refresh: true }
-    })
-  }, [profileState, changedFields, userRole, navigate, updateUser])
+    if (hash) {
+      navigate(`${authRoutes.myProfile.path}#complete`)
+    }
+  }, [profileState, changedFields, userRole, hash, navigate, updateUser])
 
   const blocker = useBlocker(getProfileTabChangedFields)
   const { openDialog } = useConfirm()

--- a/tests/unit/pages/edit-profile/EditProfile.spec.jsx
+++ b/tests/unit/pages/edit-profile/EditProfile.spec.jsx
@@ -114,10 +114,27 @@ vi.mock('~/redux/features/editProfileSlice', async () => {
   const actual = await vi.importActual('~/redux/features/editProfileSlice')
   return {
     ...actual,
-    updateUser: vi.fn(),
     fetchUserById: vi.fn()
   }
 })
+
+const mockMutateAsync = vi.fn()
+
+vi.mock('~/hooks/use-mutation', () => ({
+  __esModule: true,
+  default: ({ onSuccess, onError }) => {
+    return {
+      mutateAsync: async (params) => {
+        try {
+          await mockMutateAsync(params)
+          onSuccess?.()
+        } catch (error) {
+          onError?.(error)
+        }
+      }
+    }
+  }
+}))
 
 vi.mock('~/redux/features/snackbarSlice', async () => {
   const actual = await vi.importActual('~/redux/features/snackbarSlice')


### PR DESCRIPTION
Before: 

https://github.com/user-attachments/assets/ca113a8a-4e4e-42c3-a36d-261e44f101a0

- Rewrote user profile update logic using `useMutation` instead of  `dispatch`
- Fixed navigation after update
- Fixed modal confirmation logic: after clicking the Update button, the confirmation dialog is no longer triggered unnecessarily  
- Fixed tests 

After: 

https://github.com/user-attachments/assets/d42b8482-3b19-497b-ada6-05869e41cd9d



