### PR TITLE
Added tests to check translations into edit profile - professional info page

### DIFF
--- a/tests/unit/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.spec.jsx
+++ b/tests/unit/containers/edit-profile/professional-info-tab/ProfessionalInfoTab.spec.jsx
@@ -119,6 +119,25 @@ describe('ProfessionalInfoTab', () => {
 
     expect(mockOpenModal).toHaveBeenCalled()
   })
+  it('should properly render Ukrainian translation keys for student', () => {
+    const categoriesTitle = screen.getByText(
+      'editProfilePage.profile.professionalTab.categoriesTitle'
+    )
+    expect(categoriesTitle).toBeInTheDocument()
+
+    const studentAboutTitle = screen.getByText(
+      'editProfilePage.profile.professionalTab.studentAboutTitle'
+    )
+    expect(studentAboutTitle).toBeInTheDocument()
+
+    const addCategoryButton = screen.getByText(
+      'editProfilePage.profile.professionalTab.addCategoryBtn'
+    )
+    expect(addCategoryButton).toBeInTheDocument()
+
+    fireEvent.click(addCategoryButton)
+    expect(mockOpenModal).toHaveBeenCalled()
+  })
 })
 
 describe('ProfessionalInfoTab for tutor', () => {
@@ -151,6 +170,30 @@ describe('ProfessionalInfoTab for tutor', () => {
 
     fireEvent.click(editButton)
 
+    expect(mockOpenModal).toHaveBeenCalled()
+  })
+  it('should properly render Ukrainian translation keys for tutor', () => {
+    const categoriesTitle = screen.getByText(
+      'editProfilePage.profile.professionalTab.categoriesTitle'
+    )
+    expect(categoriesTitle).toBeInTheDocument()
+
+    const tutorAboutTitle = screen.getByText(
+      'editProfilePage.profile.professionalTab.tutorAboutTitle'
+    )
+    expect(tutorAboutTitle).toBeInTheDocument()
+
+    const tutorAboutDescription = screen.getByText(
+      'editProfilePage.profile.professionalTab.tutorAboutDescription'
+    )
+    expect(tutorAboutDescription).toBeInTheDocument()
+
+    const addCategoryButton = screen.getByText(
+      'editProfilePage.profile.professionalTab.addCategoryBtn'
+    )
+    expect(addCategoryButton).toBeInTheDocument()
+
+    fireEvent.click(addCategoryButton)
     expect(mockOpenModal).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
**Description:**
Added tests to verify that the Ukrainian translation keys are rendered correctly in the `ProfessionalInfoTab `component for both student and tutor roles. The tests ensure that the relevant translation keys, such as category titles, descriptions, and button labels, are displayed as expected. Additionally, it is verified that the modal opens when the "Add category" button is clicked.

**Changes:**

- Added test for rendering Ukrainian translation keys for both student and tutor roles.

- Verified that the correct titles and descriptions are rendered based on the role (student/tutor).

- Simulated a click on the "Add category" button and ensured the openModal function is called.

- Mocked components to simulate user interactions and validate modal opening.
![image](https://github.com/user-attachments/assets/3f082fc3-ee5f-4cdf-860c-f126c7a0e8ed)
